### PR TITLE
Sync the MIAM API test with the current version of MICM

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -24,7 +24,7 @@ endif()
 
 FetchContent_Declare(micm
     GIT_REPOSITORY https://github.com/NCAR/micm.git
-    GIT_TAG 1d4fa141ae2c9000ad8888401d614382adc2e486
+    GIT_TAG 17a9afdd873c79368c1ed64ca8778228fff7849d
     GIT_PROGRESS NOT ${FETCHCONTENT_QUIET}
     FIND_PACKAGE_ARGS NAMES micm
 )

--- a/test/integration/test_miam_api.cpp
+++ b/test/integration/test_miam_api.cpp
@@ -124,19 +124,24 @@ int main()
                                     .temperature_ref_ = 298.15 }})
                                .Build();
 
+  // First reversible acid-dissociation reaction `H2CO3(aq) <-> HCO3-(aq) + H+(aq)`
+  // auto h2co3_hco3m_hp = DissolvedReversibleProcessBuilder()
+  Process h2co3_hco3m_hp = ChemicalReactionBuilder()
+                            .SetPhase(aqueous_phase)
+                            .SetReactants({ h2co3 })
+                            .SetProducts({ { hco3m, 1.0 }, { hp, 1.0 } })
+                            .SetRateConstant(ArrheniusRateConstant({ .A_ = 1.0e-3 }))
+                            .Build();
 
-  // // Condensed phase reversible reaction
-  // // K_eq = A * exp(C / T) = Equilibrium constant
-  // // k_r = reverse rate constant
-  // // (k_f = K_eq * k_r = forward rate constant)
-  Process h2o_dissociation = ChemicalReactionBuilder()
-                             .SetAerosolScope(accumulation.GetScope(), aqueous_phase)
-                             .SetReactants({ h2o })
-                             .SetProducts({ { ohm }, { hp } })
-                             .SetRateConstant(ReversibleRateConstant({ .A_ = 1.14e-2, .C_ = 2300.0, .k_r_ = 0.32 }))
-                             .Build();
+  // Second reversible acid-dissociation reaction `HCO3-(aq) <-> CO3--(aq) + H+(aq)`
+  Process hco3m_co32m_hp = ChemicalReactionBuilder()
+                            .SetPhase(aqueous_phase)
+                            .SetReactants({ hco3m })
+                            .SetProducts({ { co32m, 1.0 }, {  hp, 1.0 } })
+                            .SetRateConstant(ArrheniusRateConstant({ .A_ = 1.0e-3 }))
+                            .Build();
 
-  std::vector<Process> reactions{ co2_photo, co2_phase_transfer, h2o_dissociation };
+  std::vector<Process> reactions{ co2_photo, co2_phase_transfer, h2co3_hco3m_hp, hco3m_co32m_hp };
 
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                   .SetSystem(chemical_system)

--- a/test/integration/test_miam_api.cpp
+++ b/test/integration/test_miam_api.cpp
@@ -76,31 +76,35 @@ int main()
   System chemical_system = ConfigureSystem(gas_phase, { small_drop, large_drop, aitken, accumulation }, { dust });
 
   // State array should contain
-  //  1) (GAS.) CO2
-  //  2) (CLOUD.) SMALL_DROP.AQUEOUS.CO2
-  //  3) (CLOUD.) SMALL_DROP.AQUEOUS.H2O
-  //  4) (CLOUD.) SMALL_DROP.AQUEOUS.OH-
-  //  5) (CLOUD.) SMALL_DROP.AQUEOUS.H+
-  //  6) (CLOUD.) SMALL_DROP.AQUEOUS.HCO3-
-  //  7) (CLOUD.) SMALL_DROP.AQUEOUS.CO32-
-  //  8) (CLOUD.) LARGE_DROP.AQUEOUS.CO2
-  //  9) (CLOUD.) LARGE_DROP.AQUEOUS.H2O
-  // 10) (CLOUD.) LARGE_DROP.AQUEOUS.OH-
-  // 11) (CLOUD.) LARGE_DROP.AQUEOUS.H+
-  // 12) (CLOUD.) LARGE_DROP.AQUEOUS.HCO3-
-  // 13) (CLOUD.) LARGE_DROP.AQUEOUS.CO32-
-  // 14) (AEROSOL.) AITKEN.AQUEOUS.CO2           ( Mode )
-  // 15) (AEROSOL.) AITKEN.AQUEOUS.HEXANE        ( Mode )
-  // 16) (AEROSOL.) ACCUMULATION.AQUEOUS.CO2     ( Mode )
-  // 17) (AEROSOL.) ACCUMULATION.AQUEOUS.H2O     ( Mode )
-  // 18) (AEROSOL.) ACCUMULATION.AQUEOUS.OH-     ( Mode )
-  // 19) (AEROSOL.) ACCUMULATION.AQUEOUS.H+      ( Mode )
-  // 20) (AEROSOL.) ACCUMULATION.AQUEOUS.HCO3-   ( Mode )
-  // 21) (AEROSOL.) ACCUMULATION.AQUEOUS.CO32-   ( Mode )
-  // 22) (AEROSOL.) ACCUMULATION.ORGANIC.CO2     ( Mode )
-  // 23) (AEROSOL.) ACCUMULATION.ORGANIC.HEXANE  ( Mode )
-  // 24) (AEROSOL.) DUST.ORGANIC.CO2             ( Section )
-  // 25) (AEROSOL.) DUST.ORGANIC.HEXANE          ( Section )
+  // (GAS.) CO2
+  // (CLOUD.) SMALL_DROP.AQUEOUS.CO2
+  // (CLOUD.) SMALL_DROP.AQUEOUS.H2O
+  // (CLOUD.) SMALL_DROP.AQUEOUS.OH-
+  // (CLOUD.) SMALL_DROP.AQUEOUS.H+
+  // (CLOUD.) SMALL_DROP.AQUEOUS.HCO3-
+  // (CLOUD.) SMALL_DROP.AQUEOUS.CO32-
+  // (CLOUD.) SMALL_DROP.AQUEOUS.H2CO3
+  // (CLOUD.) LARGE_DROP.AQUEOUS.CO2
+  // (CLOUD.) LARGE_DROP.AQUEOUS.H2O
+  // (CLOUD.) LARGE_DROP.AQUEOUS.OH-
+  // (CLOUD.) LARGE_DROP.AQUEOUS.H+
+  // (CLOUD.) LARGE_DROP.AQUEOUS.HCO3-
+  // (CLOUD.) LARGE_DROP.AQUEOUS.CO32-
+  // (CLOUD.) LARGE_DROP.AQUEOUS.H2CO3
+  // (AEROSOL.) AITKEN.AQUEOUS.CO2           ( Mode )
+  // (AEROSOL.) AITKEN.AQUEOUS.HEXANE        ( Mode )
+  // (AEROSOL.) AITKEN.AQUEOUS.H2CO3         ( Mode )
+  // (AEROSOL.) ACCUMULATION.AQUEOUS.CO2     ( Mode )
+  // (AEROSOL.) ACCUMULATION.AQUEOUS.H2O     ( Mode )
+  // (AEROSOL.) ACCUMULATION.AQUEOUS.OH-     ( Mode )
+  // (AEROSOL.) ACCUMULATION.AQUEOUS.H+      ( Mode )
+  // (AEROSOL.) ACCUMULATION.AQUEOUS.HCO3-   ( Mode )
+  // (AEROSOL.) ACCUMULATION.AQUEOUS.CO32-   ( Mode )
+  // (AEROSOL.) ACCUMULATION.AQUEOUS.H2CO3   ( Mode )
+  // (AEROSOL.) ACCUMULATION.ORGANIC.CO2     ( Mode )
+  // (AEROSOL.) ACCUMULATION.ORGANIC.HEXANE  ( Mode )
+  // (AEROSOL.) DUST.ORGANIC.CO2             ( Section )
+  // (AEROSOL.) DUST.ORGANIC.HEXANE          ( Section )
 
   Process co2_photo = ChemicalReactionBuilder()
                       .SetReactants({ co2 })
@@ -127,7 +131,7 @@ int main()
   // First reversible acid-dissociation reaction `H2CO3(aq) <-> HCO3-(aq) + H+(aq)`
   // auto h2co3_hco3m_hp = DissolvedReversibleProcessBuilder()
   Process h2co3_hco3m_hp = ChemicalReactionBuilder()
-                            .SetPhase(aqueous_phase)
+                            .SetAerosolScope(accumulation.GetScope(), aqueous_phase)
                             .SetReactants({ h2co3 })
                             .SetProducts({ { hco3m, 1.0 }, { hp, 1.0 } })
                             .SetRateConstant(ArrheniusRateConstant({ .A_ = 1.0e-3 }))
@@ -135,7 +139,7 @@ int main()
 
   // Second reversible acid-dissociation reaction `HCO3-(aq) <-> CO3--(aq) + H+(aq)`
   Process hco3m_co32m_hp = ChemicalReactionBuilder()
-                            .SetPhase(aqueous_phase)
+                            .SetAerosolScope(accumulation.GetScope(), aqueous_phase)
                             .SetReactants({ hco3m })
                             .SetProducts({ { co32m, 1.0 }, {  hp, 1.0 } })
                             .SetRateConstant(ArrheniusRateConstant({ .A_ = 1.0e-3 }))

--- a/test/integration/test_miam_api.cpp
+++ b/test/integration/test_miam_api.cpp
@@ -92,7 +92,11 @@ int main()
   // (CLOUD.) LARGE_DROP.AQUEOUS.CO32-
   // (CLOUD.) LARGE_DROP.AQUEOUS.H2CO3
   // (AEROSOL.) AITKEN.AQUEOUS.CO2           ( Mode )
-  // (AEROSOL.) AITKEN.AQUEOUS.HEXANE        ( Mode )
+  // (AEROSOL.) AITKEN.AQUEOUS.H2O           ( Mode )
+  // (AEROSOL.) AITKEN.AQUEOUS.OH-           ( Mode )
+  // (AEROSOL.) AITKEN.AQUEOUS.H+            ( Mode )
+  // (AEROSOL.) AITKEN.AQUEOUS.HCO3-         ( Mode )
+  // (AEROSOL.) AITKEN.AQUEOUS.CO32-         ( Mode )
   // (AEROSOL.) AITKEN.AQUEOUS.H2CO3         ( Mode )
   // (AEROSOL.) ACCUMULATION.AQUEOUS.CO2     ( Mode )
   // (AEROSOL.) ACCUMULATION.AQUEOUS.H2O     ( Mode )


### PR DESCRIPTION
- Updates the MICM tag to use the latest verison.
- This is what Matt suggested but `DissolvedReversibleProcessBuilder()` is not implemented yet, so `ChemicalReactionBuilder`is being used as a placeholder.

```C++                   
  // First reversible acid-dissociation reaction `H2CO3(aq) <-> HCO3-(aq) + H+(aq)`
  auto h2co3_hco3m_hp = DissolvedReversibleProcessBuilder()
                                .SetPhase(aqueous_phase)
                                .SetReactants({ h2co3 })
                                .SetProducts({ Yield(hco3m, 1.0), Yield( hp, 1.0) })
                                .SetSolvent(h2o)
                                .SetForwardRateConstant(ArrheniusRateConstant({ .A_ = 123.4, .B_ = 123.4 , <etc>})
                                .SetEquilibriumConstant(<might need a new algorithm, or it could be handled by Arrhenius equation>)
                                .Build()

  // Second reversible acid-dissociation reaction `HCO3-(aq) <-> CO3--(aq) + H+(aq)`
  auto hco3m_co32m_hp = DissolvedReversibleProcessBuilder()
                                .SetPhase(aqueous_phase)
                                .SetReactants({ hco3m })
                                .SetProducts({ Yield(co32m, 1.0), Yield( hp, 1.0) })
                                .SetSolvent(h2o)
                                .SetForwardRateConstant(ArrheniusRateConstant({ .A_ = 123.4, .B_ = 123.4 , <etc>})
                                .SetEquilibriumConstant(<might need a new algorithm, or it could be handled by Arrhenius equation>)
                                .Build()
```