### PR TITLE
moving condensation rate provider

### DIFF
--- a/include/miam/constraints/henry_law_equilibrium_constraint.hpp
+++ b/include/miam/constraints/henry_law_equilibrium_constraint.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <miam/util/condensation_rate.hpp>
+#include <miam/math/condensation_rate.hpp>
 #include <miam/util/uuid.hpp>
 
 #include <micm/system/conditions.hpp>
@@ -190,7 +190,7 @@ namespace miam
               for (const auto& hlc_rt_idx : hlc_rt_indices)
                 params.ForEachRow(
                     [hlc_fn](const micm::Conditions& cond, double& hlc_rt)
-                    { hlc_rt = hlc_fn(cond) * util::R_gas * cond.temperature_; },
+                    { hlc_rt = hlc_fn(cond) * math::R_gas * cond.temperature_; },
                     conditions,
                     params.GetColumnView(hlc_rt_idx));
             },

--- a/include/miam/constraints/henry_law_equilibrium_constraint.hpp
+++ b/include/miam/constraints/henry_law_equilibrium_constraint.hpp
@@ -190,7 +190,7 @@ namespace miam
               for (const auto& hlc_rt_idx : hlc_rt_indices)
                 params.ForEachRow(
                     [hlc_fn](const micm::Conditions& cond, double& hlc_rt)
-                    { hlc_rt = hlc_fn(cond) * math::R_gas * cond.temperature_; },
+                    { hlc_rt = hlc_fn(cond) * R_gas * cond.temperature_; },
                     conditions,
                     params.GetColumnView(hlc_rt_idx));
             },

--- a/include/miam/math/condensation_rate.hpp
+++ b/include/miam/math/condensation_rate.hpp
@@ -12,7 +12,7 @@
 
 namespace miam
 {
-  namespace util
+  namespace math
   {
     /// @brief Gas constant [J mol⁻¹ K⁻¹]
     constexpr double R_gas = micm::constants::GAS_CONSTANT;
@@ -126,5 +126,5 @@ namespace miam
 
       return provider;
     }
-  }  // namespace util
+  }  // namespace math
 }  // namespace miam

--- a/include/miam/math/condensation_rate.hpp
+++ b/include/miam/math/condensation_rate.hpp
@@ -12,8 +12,6 @@
 
 namespace miam
 {
-  namespace math
-  {
     /// @brief Gas constant [J mol⁻¹ K⁻¹]
     constexpr double R_gas = micm::constants::GAS_CONSTANT;
 
@@ -126,5 +124,4 @@ namespace miam
 
       return provider;
     }
-  }  // namespace math
 }  // namespace miam

--- a/include/miam/processes/henry_law_phase_transfer.hpp
+++ b/include/miam/processes/henry_law_phase_transfer.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <miam/aerosol_property.hpp>
-#include <miam/util/condensation_rate.hpp>
+#include <miam/math/condensation_rate.hpp>
 #include <miam/util/uuid.hpp>
 
 #include <micm/system/conditions.hpp>
@@ -285,7 +285,7 @@ namespace miam
           AerosolPropertyProvider<DenseMatrixPolicy> r_eff_provider;
           AerosolPropertyProvider<DenseMatrixPolicy> N_provider;
           AerosolPropertyProvider<DenseMatrixPolicy> phi_provider;
-          util::CondensationRateProvider cond_rate_provider;
+          math::CondensationRateProvider cond_rate_provider;
         };
 
         std::vector<InstanceData> instances;
@@ -310,7 +310,7 @@ namespace miam
             inst.r_eff_provider = prov_map.at(AerosolProperty::EffectiveRadius);
             inst.N_provider = prov_map.at(AerosolProperty::NumberConcentration);
             inst.phi_provider = prov_map.at(AerosolProperty::PhaseVolumeFraction);
-            inst.cond_rate_provider = util::MakeCondensationRateProvider(
+            inst.cond_rate_provider = math::MakeCondensationRateProvider(
                 diffusion_coefficient_, accommodation_coefficient_, gas_molecular_weight_);
             instances.push_back(std::move(inst));
           }
@@ -358,7 +358,7 @@ namespace miam
                     {
                       double kc = inst.cond_rate_provider.ComputeValue(r_eff, N, T);
                       double kc_eff = phi * kc;
-                      double ke_eff = kc_eff / (hlc * util::R_gas * T);
+                      double ke_eff = kc_eff / (hlc * math::R_gas * T);
                       double fv = solvent * inst.molar_volume;
                       net_val = kc_eff * gas - ke_eff * aq / fv;
                     },
@@ -439,7 +439,7 @@ namespace miam
           AerosolPropertyProvider<DenseMatrixPolicy> r_eff_provider;
           AerosolPropertyProvider<DenseMatrixPolicy> N_provider;
           AerosolPropertyProvider<DenseMatrixPolicy> phi_provider;
-          util::CondensationRateProvider cond_rate_provider;
+          math::CondensationRateProvider cond_rate_provider;
           std::size_t n_r_eff_deps;
           std::size_t n_N_deps;
           std::size_t n_phi_deps;
@@ -470,7 +470,7 @@ namespace miam
             inst.r_eff_provider = prov_map.at(AerosolProperty::EffectiveRadius);
             inst.N_provider = prov_map.at(AerosolProperty::NumberConcentration);
             inst.phi_provider = prov_map.at(AerosolProperty::PhaseVolumeFraction);
-            inst.cond_rate_provider = util::MakeCondensationRateProvider(
+            inst.cond_rate_provider = math::MakeCondensationRateProvider(
                 diffusion_coefficient_, accommodation_coefficient_, gas_molecular_weight_);
             inst.n_r_eff_deps = prov_map.at(AerosolProperty::EffectiveRadius).dependent_variable_indices.size();
             inst.n_N_deps = prov_map.at(AerosolProperty::NumberConcentration).dependent_variable_indices.size();
@@ -576,7 +576,7 @@ namespace miam
                         double& j_as)
                     {
                       double kc = inst.cond_rate_provider.ComputeValue(r_eff, N, T);
-                      double ke = kc / (hlc * util::R_gas * T);
+                      double ke = kc / (hlc * math::R_gas * T);
                       double fv = solvent * inst.molar_volume;
                       // -J[gas, gas] = +φ · k_cond
                       j_gg += phi * kc;
@@ -627,7 +627,7 @@ namespace miam
                       {
                         double kc_dummy, dk_dr, dk_dN_unused;
                         inst.cond_rate_provider.ComputeValueAndDerivatives(r_eff, N, T, kc_dummy, dk_dr, dk_dN_unused);
-                        double dke_dr = dk_dr / (hlc * util::R_gas * T);
+                        double dke_dr = dk_dr / (hlc * math::R_gas * T);
                         double fv = solvent * inst.molar_volume;
                         double eff = phi * (dk_dr * dr_dvar * gas - dke_dr * dr_dvar * aq / fv);
                         j_gas += eff;
@@ -667,7 +667,7 @@ namespace miam
                       {
                         double kc_dummy, dk_dr_unused, dk_dN;
                         inst.cond_rate_provider.ComputeValueAndDerivatives(r_eff, N, T, kc_dummy, dk_dr_unused, dk_dN);
-                        double dke_dN = dk_dN / (hlc * util::R_gas * T);
+                        double dke_dN = dk_dN / (hlc * math::R_gas * T);
                         double fv = solvent * inst.molar_volume;
                         double eff = phi * (dk_dN * dN_dvar * gas - dke_dN * dN_dvar * aq / fv);
                         j_gas += eff;
@@ -706,7 +706,7 @@ namespace miam
                           double& j_aq)
                       {
                         double kc = inst.cond_rate_provider.ComputeValue(r_eff, N, T);
-                        double ke = kc / (hlc * util::R_gas * T);
+                        double ke = kc / (hlc * math::R_gas * T);
                         double fv = solvent * inst.molar_volume;
                         double R = kc * gas - ke * aq / fv;
                         j_gas += R * dphi_dvar;

--- a/include/miam/processes/henry_law_phase_transfer.hpp
+++ b/include/miam/processes/henry_law_phase_transfer.hpp
@@ -285,7 +285,7 @@ namespace miam
           AerosolPropertyProvider<DenseMatrixPolicy> r_eff_provider;
           AerosolPropertyProvider<DenseMatrixPolicy> N_provider;
           AerosolPropertyProvider<DenseMatrixPolicy> phi_provider;
-          math::CondensationRateProvider cond_rate_provider;
+          CondensationRateProvider cond_rate_provider;
         };
 
         std::vector<InstanceData> instances;
@@ -310,7 +310,7 @@ namespace miam
             inst.r_eff_provider = prov_map.at(AerosolProperty::EffectiveRadius);
             inst.N_provider = prov_map.at(AerosolProperty::NumberConcentration);
             inst.phi_provider = prov_map.at(AerosolProperty::PhaseVolumeFraction);
-            inst.cond_rate_provider = math::MakeCondensationRateProvider(
+            inst.cond_rate_provider = MakeCondensationRateProvider(
                 diffusion_coefficient_, accommodation_coefficient_, gas_molecular_weight_);
             instances.push_back(std::move(inst));
           }
@@ -358,7 +358,7 @@ namespace miam
                     {
                       double kc = inst.cond_rate_provider.ComputeValue(r_eff, N, T);
                       double kc_eff = phi * kc;
-                      double ke_eff = kc_eff / (hlc * math::R_gas * T);
+                      double ke_eff = kc_eff / (hlc * R_gas * T);
                       double fv = solvent * inst.molar_volume;
                       net_val = kc_eff * gas - ke_eff * aq / fv;
                     },
@@ -439,7 +439,7 @@ namespace miam
           AerosolPropertyProvider<DenseMatrixPolicy> r_eff_provider;
           AerosolPropertyProvider<DenseMatrixPolicy> N_provider;
           AerosolPropertyProvider<DenseMatrixPolicy> phi_provider;
-          math::CondensationRateProvider cond_rate_provider;
+          CondensationRateProvider cond_rate_provider;
           std::size_t n_r_eff_deps;
           std::size_t n_N_deps;
           std::size_t n_phi_deps;
@@ -470,7 +470,7 @@ namespace miam
             inst.r_eff_provider = prov_map.at(AerosolProperty::EffectiveRadius);
             inst.N_provider = prov_map.at(AerosolProperty::NumberConcentration);
             inst.phi_provider = prov_map.at(AerosolProperty::PhaseVolumeFraction);
-            inst.cond_rate_provider = math::MakeCondensationRateProvider(
+            inst.cond_rate_provider = MakeCondensationRateProvider(
                 diffusion_coefficient_, accommodation_coefficient_, gas_molecular_weight_);
             inst.n_r_eff_deps = prov_map.at(AerosolProperty::EffectiveRadius).dependent_variable_indices.size();
             inst.n_N_deps = prov_map.at(AerosolProperty::NumberConcentration).dependent_variable_indices.size();
@@ -576,7 +576,7 @@ namespace miam
                         double& j_as)
                     {
                       double kc = inst.cond_rate_provider.ComputeValue(r_eff, N, T);
-                      double ke = kc / (hlc * math::R_gas * T);
+                      double ke = kc / (hlc * R_gas * T);
                       double fv = solvent * inst.molar_volume;
                       // -J[gas, gas] = +φ · k_cond
                       j_gg += phi * kc;
@@ -627,7 +627,7 @@ namespace miam
                       {
                         double kc_dummy, dk_dr, dk_dN_unused;
                         inst.cond_rate_provider.ComputeValueAndDerivatives(r_eff, N, T, kc_dummy, dk_dr, dk_dN_unused);
-                        double dke_dr = dk_dr / (hlc * math::R_gas * T);
+                        double dke_dr = dk_dr / (hlc * R_gas * T);
                         double fv = solvent * inst.molar_volume;
                         double eff = phi * (dk_dr * dr_dvar * gas - dke_dr * dr_dvar * aq / fv);
                         j_gas += eff;
@@ -667,7 +667,7 @@ namespace miam
                       {
                         double kc_dummy, dk_dr_unused, dk_dN;
                         inst.cond_rate_provider.ComputeValueAndDerivatives(r_eff, N, T, kc_dummy, dk_dr_unused, dk_dN);
-                        double dke_dN = dk_dN / (hlc * math::R_gas * T);
+                        double dke_dN = dk_dN / (hlc * R_gas * T);
                         double fv = solvent * inst.molar_volume;
                         double eff = phi * (dk_dN * dN_dvar * gas - dke_dN * dN_dvar * aq / fv);
                         j_gas += eff;
@@ -706,7 +706,7 @@ namespace miam
                           double& j_aq)
                       {
                         double kc = inst.cond_rate_provider.ComputeValue(r_eff, N, T);
-                        double ke = kc / (hlc * math::R_gas * T);
+                        double ke = kc / (hlc * R_gas * T);
                         double fv = solvent * inst.molar_volume;
                         double R = kc * gas - ke * aq / fv;
                         j_gas += R * dphi_dvar;

--- a/test/integration/test_cam_cloud_chemistry.cpp
+++ b/test/integration/test_cam_cloud_chemistry.cpp
@@ -36,7 +36,7 @@ using SparseMatrixFD = micm::SparseMatrix<double, micm::SparseMatrixStandardOrde
 
 namespace
 {
-  constexpr double R_gas = miam::util::R_gas;
+  constexpr double R_gas = miam::math::R_gas;
 
   // M/atm → mol m⁻³ Pa⁻¹
   constexpr double M_ATM_TO_MOL_M3_PA = 1000.0 / 101325.0;

--- a/test/integration/test_cam_cloud_chemistry.cpp
+++ b/test/integration/test_cam_cloud_chemistry.cpp
@@ -36,8 +36,6 @@ using SparseMatrixFD = micm::SparseMatrix<double, micm::SparseMatrixStandardOrde
 
 namespace
 {
-  constexpr double R_gas = miam::math::R_gas;
-
   // M/atm → mol m⁻³ Pa⁻¹
   constexpr double M_ATM_TO_MOL_M3_PA = 1000.0 / 101325.0;
 

--- a/test/integration/test_henry_law_equilibrium_constraint.cpp
+++ b/test/integration/test_henry_law_equilibrium_constraint.cpp
@@ -16,7 +16,7 @@ using namespace miam;
 
 namespace
 {
-  constexpr double R_gas = miam::util::R_gas;  // 8.314462618 J mol⁻¹ K⁻¹
+  constexpr double R_gas = miam::math::R_gas;  // 8.314462618 J mol⁻¹ K⁻¹
 }
 
 // ============================================================================

--- a/test/integration/test_henry_law_equilibrium_constraint.cpp
+++ b/test/integration/test_henry_law_equilibrium_constraint.cpp
@@ -14,11 +14,6 @@
 using namespace micm;
 using namespace miam;
 
-namespace
-{
-  constexpr double R_gas = miam::math::R_gas;  // 8.314462618 J mol⁻¹ K⁻¹
-}
-
 // ============================================================================
 // Test 1: Henry's Law equilibrium constraint with gas-phase driver
 //

--- a/test/integration/test_henry_law_phase_transfer.cpp
+++ b/test/integration/test_henry_law_phase_transfer.cpp
@@ -14,8 +14,6 @@ using namespace miam;
 
 namespace
 {
-  constexpr double R_gas = miam::math::R_gas;  // 8.314462618 J mol⁻¹ K⁻¹
-
   // Analytical solution for the HLPT two-species linear system:
   //   d[gas]/dt = -a · [gas] + b · [aq]
   //   d[aq]/dt  =  a · [gas] - b · [aq]
@@ -152,7 +150,7 @@ TEST(HenryLawPhaseTransferIntegration, SimpleOneInstance)
   double phi = 1.0;
 
   // k_cond from condensation rate utility
-  auto cond_provider = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto cond_provider = miam::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
   double k_cond = cond_provider.ComputeValue(r_eff, N, T);
   double k_evap = k_cond / (HLC_val * R_gas * T);
 

--- a/test/integration/test_henry_law_phase_transfer.cpp
+++ b/test/integration/test_henry_law_phase_transfer.cpp
@@ -14,7 +14,7 @@ using namespace miam;
 
 namespace
 {
-  constexpr double R_gas = miam::util::R_gas;  // 8.314462618 J mol⁻¹ K⁻¹
+  constexpr double R_gas = miam::math::R_gas;  // 8.314462618 J mol⁻¹ K⁻¹
 
   // Analytical solution for the HLPT two-species linear system:
   //   d[gas]/dt = -a · [gas] + b · [aq]
@@ -152,7 +152,7 @@ TEST(HenryLawPhaseTransferIntegration, SimpleOneInstance)
   double phi = 1.0;
 
   // k_cond from condensation rate utility
-  auto cond_provider = miam::util::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto cond_provider = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
   double k_cond = cond_provider.ComputeValue(r_eff, N, T);
   double k_evap = k_cond / (HLC_val * R_gas * T);
 

--- a/test/integration/test_kinetic_vs_constrained.cpp
+++ b/test/integration/test_kinetic_vs_constrained.cpp
@@ -19,8 +19,6 @@ using namespace miam;
 
 namespace
 {
-  constexpr double R_gas = miam::math::R_gas;
-
   // Solve a kinetic ODE system to steady state and return final concentrations
   template<typename FindIdx>
   std::tuple<double, double, double> SolveKineticSystem(

--- a/test/integration/test_kinetic_vs_constrained.cpp
+++ b/test/integration/test_kinetic_vs_constrained.cpp
@@ -19,7 +19,7 @@ using namespace miam;
 
 namespace
 {
-  constexpr double R_gas = miam::util::R_gas;
+  constexpr double R_gas = miam::math::R_gas;
 
   // Solve a kinetic ODE system to steady state and return final concentrations
   template<typename FindIdx>

--- a/test/integration/test_solvent_robustness.cpp
+++ b/test/integration/test_solvent_robustness.cpp
@@ -35,7 +35,7 @@ using DenseMatrix = micm::Matrix<double>;
 
 namespace
 {
-  constexpr double R_gas = miam::util::R_gas;
+  constexpr double R_gas = miam::math::R_gas;
   constexpr double M_ATM_TO_MOL_M3_PA = 1000.0 / 101325.0;
   constexpr double c_H2O_M = 55.556;
   constexpr double water_molecular_weight = 0.018;

--- a/test/integration/test_solvent_robustness.cpp
+++ b/test/integration/test_solvent_robustness.cpp
@@ -35,7 +35,7 @@ using DenseMatrix = micm::Matrix<double>;
 
 namespace
 {
-  constexpr double R_gas = miam::math::R_gas;
+  constexpr double R_gas = miam::R_gas;
   constexpr double M_ATM_TO_MOL_M3_PA = 1000.0 / 101325.0;
   constexpr double c_H2O_M = 55.556;
   constexpr double water_molecular_weight = 0.018;

--- a/test/unit/condensation_rate.cpp
+++ b/test/unit/condensation_rate.cpp
@@ -1,11 +1,11 @@
-#include <miam/util/condensation_rate.hpp>
+#include <miam/math/condensation_rate.hpp>
 
 #include <cmath>
 #include <numbers>
 
 #include <gtest/gtest.h>
 
-using namespace miam::util;
+using namespace miam::math;
 
 namespace
 {

--- a/test/unit/condensation_rate.cpp
+++ b/test/unit/condensation_rate.cpp
@@ -5,7 +5,7 @@
 
 #include <gtest/gtest.h>
 
-using namespace miam::math;
+using namespace miam;
 
 namespace
 {

--- a/test/unit/constraints/henry_law_equilibrium_constraint.cpp
+++ b/test/unit/constraints/henry_law_equilibrium_constraint.cpp
@@ -232,7 +232,7 @@ TEST(HenryLawEquilibriumConstraint, ResidualSingleInstance)
   residual_fn(state_variables, state_params, residual);
 
   double f_v = solvent_conc * water_molecular_weight / water_density;
-  double hlc_rt = HLC * miam::math::R_gas * T;
+  double hlc_rt = HLC * miam::R_gas * T;
   double expected = hlc_rt * f_v * gas_conc - aq_conc;
   EXPECT_NEAR(residual[0][1], expected, std::abs(expected) * 1.0e-12);
 }
@@ -285,7 +285,7 @@ TEST(HenryLawEquilibriumConstraint, ResidualMultipleInstances)
   DMP residual{ 1, 5, 0.0 };
   residual_fn(state_variables, state_params, residual);
 
-  double hlc_rt = HLC * miam::math::R_gas * T;
+  double hlc_rt = HLC * miam::R_gas * T;
   double gas_conc = 1.0e-5;
 
   // LARGE: f_v = 400.0 * 0.018 / 1000.0 = 0.0072
@@ -351,7 +351,7 @@ TEST(HenryLawEquilibriumConstraint, JacobianSingleInstance)
     v = 0.0;
   jac_fn(state_variables, state_params, jacobian);
 
-  double hlc_rt = HLC * miam::math::R_gas * T;
+  double hlc_rt = HLC * miam::R_gas * T;
   double f_v = solvent_conc * water_molecular_weight / water_density;
   double Mw_rho = water_molecular_weight / water_density;
 
@@ -400,7 +400,7 @@ TEST(HenryLawEquilibriumConstraint, UpdateConstraintParametersTemperatureDep)
   update_fn(conditions, state_params);
 
   // HLC*R*T = (1000/T) * R * T = 1000 * R (temperature-independent)
-  double expected = 1000.0 * miam::math::R_gas;
+  double expected = 1000.0 * miam::R_gas;
   std::size_t hlc_rt_col = pi.begin()->second;
   EXPECT_NEAR(state_params[0][hlc_rt_col], expected, expected * 1.0e-12);
   EXPECT_NEAR(state_params[1][hlc_rt_col], expected, expected * 1.0e-12);
@@ -645,7 +645,7 @@ TEST(HenryLawEquilibriumConstraint, ResidualMultipleCells)
   auto pi = BuildParamIndices(constraint, phase_prefixes);
   auto sp = InitHlcRt(constraint, phase_prefixes, pi, nc, T);
 
-  double hlc_rt = HLC * miam::math::R_gas * T;
+  double hlc_rt = HLC * miam::R_gas * T;
 
   DMP sv{ nc, 3, 0.0 };
   sv[0][0] = 1.0e-6;  sv[0][1] = 0.5;  sv[0][2] = 300.0;
@@ -888,7 +888,7 @@ TEST(HenryLawEquilibriumConstraint, TemperatureDependentHlcMultiCell)
   {
     double T = conditions[c].temperature_;
     double hlc_val = 5000.0 * std::exp(2400.0 * (1.0 / T - 1.0 / 298.15));
-    double hlc_rt = hlc_val * miam::math::R_gas * T;
+    double hlc_rt = hlc_val * miam::R_gas * T;
     double fv = sv[c][2] * water_molecular_weight / water_density;
     double expected = hlc_rt * fv * sv[c][0] - sv[c][1];
     EXPECT_NEAR(residual[c][1], expected, std::max(std::abs(expected) * 1e-10, 1e-20))
@@ -994,7 +994,7 @@ TEST(HenryLawEquilibriumConstraint, JacobianMultipleInstancesAnalytical)
 
   jac_fn(sv, sp, jacobian);
 
-  double hlc_rt = HLC * miam::math::R_gas * T;
+  double hlc_rt = HLC * miam::R_gas * T;
   double Mw_rho = water_molecular_weight / water_density;
 
   // LARGE instance (row 1):
@@ -1053,7 +1053,7 @@ TEST(HenryLawEquilibriumConstraint, LargeHLC)
   DMP residual{ 1, 3, 0.0 };
   rf(sv, sp, residual);
 
-  double hlc_rt = HLC * miam::math::R_gas * T;
+  double hlc_rt = HLC * miam::R_gas * T;
   double fv = 0.017 * water_molecular_weight / water_density;
   double expected = hlc_rt * fv * 1.0e-9 - 0.1;
   EXPECT_NEAR(residual[0][1], expected, std::abs(expected) * 1e-10);
@@ -1136,7 +1136,7 @@ TEST(HenryLawEquilibriumConstraint, ResidualZeroAtEquilibrium)
   auto pi = BuildParamIndices(constraint, phase_prefixes);
   auto sp = InitHlcRt(constraint, phase_prefixes, pi, 1, T);
 
-  double hlc_rt = HLC * miam::math::R_gas * T;
+  double hlc_rt = HLC * miam::R_gas * T;
   double solvent_conc = 0.017;
   double fv = solvent_conc * water_molecular_weight / water_density;
   double gas_conc = 1.0e-6;
@@ -1264,7 +1264,7 @@ namespace
     for (std::size_t c = 0; c < num_cells; ++c)
     {
       double T = conditions[c].temperature_;
-      double expected = HLC * miam::math::R_gas * T;
+      double expected = HLC * miam::R_gas * T;
       EXPECT_NEAR(state_params[c][hlc_rt_col], expected, expected * 1e-12)
           << "Cell " << c << " T=" << T;
     }
@@ -1448,7 +1448,7 @@ TEST(HenryLawEquilibriumConstraint, ResidualZeroAqueousConcentration)
   rf(sv, sp, residual);
 
   double f_v = H2O_conc * water_molecular_weight / water_density;
-  double hlc_rt = HLC * miam::math::R_gas * T;
+  double hlc_rt = HLC * miam::R_gas * T;
   EXPECT_NEAR(residual[0][1], hlc_rt * f_v * A_g_conc, 1.0e-10);
   EXPECT_GT(residual[0][1], 0.0);  // positive: equilibrium favors aqueous phase
 }

--- a/test/unit/constraints/henry_law_equilibrium_constraint.cpp
+++ b/test/unit/constraints/henry_law_equilibrium_constraint.cpp
@@ -3,7 +3,7 @@
 
 #include <miam/constraints/henry_law_equilibrium_constraint.hpp>
 #include <miam/constraints/henry_law_equilibrium_constraint_builder.hpp>
-#include <miam/util/condensation_rate.hpp>
+#include <miam/math/condensation_rate.hpp>
 #include <micm/util/jacobian_verification.hpp>
 
 #include <micm/system/conditions.hpp>
@@ -232,7 +232,7 @@ TEST(HenryLawEquilibriumConstraint, ResidualSingleInstance)
   residual_fn(state_variables, state_params, residual);
 
   double f_v = solvent_conc * water_molecular_weight / water_density;
-  double hlc_rt = HLC * miam::util::R_gas * T;
+  double hlc_rt = HLC * miam::math::R_gas * T;
   double expected = hlc_rt * f_v * gas_conc - aq_conc;
   EXPECT_NEAR(residual[0][1], expected, std::abs(expected) * 1.0e-12);
 }
@@ -285,7 +285,7 @@ TEST(HenryLawEquilibriumConstraint, ResidualMultipleInstances)
   DMP residual{ 1, 5, 0.0 };
   residual_fn(state_variables, state_params, residual);
 
-  double hlc_rt = HLC * miam::util::R_gas * T;
+  double hlc_rt = HLC * miam::math::R_gas * T;
   double gas_conc = 1.0e-5;
 
   // LARGE: f_v = 400.0 * 0.018 / 1000.0 = 0.0072
@@ -351,7 +351,7 @@ TEST(HenryLawEquilibriumConstraint, JacobianSingleInstance)
     v = 0.0;
   jac_fn(state_variables, state_params, jacobian);
 
-  double hlc_rt = HLC * miam::util::R_gas * T;
+  double hlc_rt = HLC * miam::math::R_gas * T;
   double f_v = solvent_conc * water_molecular_weight / water_density;
   double Mw_rho = water_molecular_weight / water_density;
 
@@ -400,7 +400,7 @@ TEST(HenryLawEquilibriumConstraint, UpdateConstraintParametersTemperatureDep)
   update_fn(conditions, state_params);
 
   // HLC*R*T = (1000/T) * R * T = 1000 * R (temperature-independent)
-  double expected = 1000.0 * miam::util::R_gas;
+  double expected = 1000.0 * miam::math::R_gas;
   std::size_t hlc_rt_col = pi.begin()->second;
   EXPECT_NEAR(state_params[0][hlc_rt_col], expected, expected * 1.0e-12);
   EXPECT_NEAR(state_params[1][hlc_rt_col], expected, expected * 1.0e-12);
@@ -645,7 +645,7 @@ TEST(HenryLawEquilibriumConstraint, ResidualMultipleCells)
   auto pi = BuildParamIndices(constraint, phase_prefixes);
   auto sp = InitHlcRt(constraint, phase_prefixes, pi, nc, T);
 
-  double hlc_rt = HLC * miam::util::R_gas * T;
+  double hlc_rt = HLC * miam::math::R_gas * T;
 
   DMP sv{ nc, 3, 0.0 };
   sv[0][0] = 1.0e-6;  sv[0][1] = 0.5;  sv[0][2] = 300.0;
@@ -888,7 +888,7 @@ TEST(HenryLawEquilibriumConstraint, TemperatureDependentHlcMultiCell)
   {
     double T = conditions[c].temperature_;
     double hlc_val = 5000.0 * std::exp(2400.0 * (1.0 / T - 1.0 / 298.15));
-    double hlc_rt = hlc_val * miam::util::R_gas * T;
+    double hlc_rt = hlc_val * miam::math::R_gas * T;
     double fv = sv[c][2] * water_molecular_weight / water_density;
     double expected = hlc_rt * fv * sv[c][0] - sv[c][1];
     EXPECT_NEAR(residual[c][1], expected, std::max(std::abs(expected) * 1e-10, 1e-20))
@@ -994,7 +994,7 @@ TEST(HenryLawEquilibriumConstraint, JacobianMultipleInstancesAnalytical)
 
   jac_fn(sv, sp, jacobian);
 
-  double hlc_rt = HLC * miam::util::R_gas * T;
+  double hlc_rt = HLC * miam::math::R_gas * T;
   double Mw_rho = water_molecular_weight / water_density;
 
   // LARGE instance (row 1):
@@ -1053,7 +1053,7 @@ TEST(HenryLawEquilibriumConstraint, LargeHLC)
   DMP residual{ 1, 3, 0.0 };
   rf(sv, sp, residual);
 
-  double hlc_rt = HLC * miam::util::R_gas * T;
+  double hlc_rt = HLC * miam::math::R_gas * T;
   double fv = 0.017 * water_molecular_weight / water_density;
   double expected = hlc_rt * fv * 1.0e-9 - 0.1;
   EXPECT_NEAR(residual[0][1], expected, std::abs(expected) * 1e-10);
@@ -1136,7 +1136,7 @@ TEST(HenryLawEquilibriumConstraint, ResidualZeroAtEquilibrium)
   auto pi = BuildParamIndices(constraint, phase_prefixes);
   auto sp = InitHlcRt(constraint, phase_prefixes, pi, 1, T);
 
-  double hlc_rt = HLC * miam::util::R_gas * T;
+  double hlc_rt = HLC * miam::math::R_gas * T;
   double solvent_conc = 0.017;
   double fv = solvent_conc * water_molecular_weight / water_density;
   double gas_conc = 1.0e-6;
@@ -1264,7 +1264,7 @@ namespace
     for (std::size_t c = 0; c < num_cells; ++c)
     {
       double T = conditions[c].temperature_;
-      double expected = HLC * miam::util::R_gas * T;
+      double expected = HLC * miam::math::R_gas * T;
       EXPECT_NEAR(state_params[c][hlc_rt_col], expected, expected * 1e-12)
           << "Cell " << c << " T=" << T;
     }
@@ -1448,7 +1448,7 @@ TEST(HenryLawEquilibriumConstraint, ResidualZeroAqueousConcentration)
   rf(sv, sp, residual);
 
   double f_v = H2O_conc * water_molecular_weight / water_density;
-  double hlc_rt = HLC * miam::util::R_gas * T;
+  double hlc_rt = HLC * miam::math::R_gas * T;
   EXPECT_NEAR(residual[0][1], hlc_rt * f_v * A_g_conc, 1.0e-10);
   EXPECT_GT(residual[0][1], 0.0);  // positive: equilibrium favors aqueous phase
 }

--- a/test/unit/processes/henry_law_phase_transfer.cpp
+++ b/test/unit/processes/henry_law_phase_transfer.cpp
@@ -4,7 +4,7 @@
 #include <miam/processes/henry_law_phase_transfer.hpp>
 #include <miam/processes/henry_law_phase_transfer_builder.hpp>
 #include <miam/processes/constants/henrys_law_constant.hpp>
-#include <miam/util/condensation_rate.hpp>
+#include <miam/math/condensation_rate.hpp>
 
 #include <micm/util/jacobian_verification.hpp>
 
@@ -402,10 +402,10 @@ TEST(HenryLawPhaseTransfer, ForcingFunctionBasicRates)
   forcing_func(state_parameters, state_variables, forcing_terms);
 
   // Compute expected net rate
-  auto cond_rate_provider = miam::util::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto cond_rate_provider = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
   double kc = cond_rate_provider.ComputeValue(r_eff_val, N_val, T);
   double kc_eff = phi_val * kc;
-  double ke_eff = kc_eff / (hlc * miam::util::R_gas * T);
+  double ke_eff = kc_eff / (hlc * miam::math::R_gas * T);
   double f_v = solvent_conc * solvent_molecular_weight / solvent_density;
   double expected_net = kc_eff * gas_conc - ke_eff * aq_conc / f_v;
 
@@ -462,10 +462,10 @@ TEST(HenryLawPhaseTransfer, ForcingFunctionMultipleCells)
 
   forcing_func(state_parameters, state_variables, forcing_terms);
 
-  auto cond_rate_provider = miam::util::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto cond_rate_provider = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
   double kc = cond_rate_provider.ComputeValue(r_eff_val, N_val, T);
   double kc_eff = phi_val * kc;
-  double ke_eff = kc_eff / (hlc * miam::util::R_gas * T);
+  double ke_eff = kc_eff / (hlc * miam::math::R_gas * T);
   double f_v = solvent * solvent_molecular_weight / solvent_density;
 
   for (std::size_t i = 0; i < num_cells; ++i)
@@ -574,9 +574,9 @@ TEST(HenryLawPhaseTransfer, JacobianFunctionDirectEntries)
 
   jac_func(state_parameters, state_variables, jacobian);
 
-  auto cond_rate_provider = miam::util::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto cond_rate_provider = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
   double kc = cond_rate_provider.ComputeValue(r_eff_val, N_val, T);
-  double ke = kc / (hlc * miam::util::R_gas * T);
+  double ke = kc / (hlc * miam::math::R_gas * T);
   double fv = solvent_conc * solvent_molecular_weight / solvent_density;
 
   // Stored as -J (MICM convention). -J[gas,gas] = +φ · k_cond
@@ -793,7 +793,7 @@ TEST(HenryLawPhaseTransfer, JacobianFunctionMultipleCells)
 
   jac_func(state_parameters, state_variables, jacobian);
 
-  auto cond_rate_provider = miam::util::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto cond_rate_provider = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
   double kc = cond_rate_provider.ComputeValue(r_eff_val, N_val, T);
 
   // Both cells should have same -J[gas,gas] = +φ · k_cond (MICM convention)
@@ -854,7 +854,7 @@ namespace
   }
 
   /// @brief Compare analytical Jacobian against central finite-difference approximation
-  ///        using MICM's FiniteDifferenceJacobian / CompareJacobianToFiniteDifference utilities.
+  ///        using MICM's FiniteDifferenceJacobian / CompareJacobianToFiniteDifference mathities.
   void CheckFiniteDifferenceJacobian(
       const HenryLawPhaseTransfer& process,
       const std::map<std::string, std::set<std::string>>& phase_prefixes,
@@ -993,15 +993,15 @@ TEST(HenryLawPhaseTransfer, ForcingMultiplePhaseInstances)
   MatrixPolicy forcing(1, 5, 0.0);
   forcing_func(params, vars, forcing);
 
-  auto crp = miam::util::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto crp = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
 
   double kc1 = crp.ComputeValue(r1, N1, T);
-  double ke1 = kc1 / (hlc * miam::util::R_gas * T);
+  double ke1 = kc1 / (hlc * miam::math::R_gas * T);
   double fv1 = solvent1 * solvent_molecular_weight / solvent_density;
   double net1 = phi1 * kc1 * gas - phi1 * ke1 * aq1 / fv1;
 
   double kc2 = crp.ComputeValue(r2, N2, T);
-  double ke2 = kc2 / (hlc * miam::util::R_gas * T);
+  double ke2 = kc2 / (hlc * miam::math::R_gas * T);
   double fv2 = solvent2 * solvent_molecular_weight / solvent_density;
   double net2 = phi2 * kc2 * gas - phi2 * ke2 * aq2 / fv2;
 
@@ -1070,14 +1070,14 @@ TEST(HenryLawPhaseTransfer, JacobianMultiplePhaseInstances)
 
   jac_func(params, vars, jacobian);
 
-  auto crp = miam::util::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto crp = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
 
   double kc1 = crp.ComputeValue(r1, N1, T);
-  double ke1 = kc1 / (hlc * miam::util::R_gas * T);
+  double ke1 = kc1 / (hlc * miam::math::R_gas * T);
   double fv1 = solvent1 * solvent_molecular_weight / solvent_density;
 
   double kc2 = crp.ComputeValue(r2, N2, T);
-  double ke2 = kc2 / (hlc * miam::util::R_gas * T);
+  double ke2 = kc2 / (hlc * miam::math::R_gas * T);
   double fv2 = solvent2 * solvent_molecular_weight / solvent_density;
 
   // -J[gas,gas] = phi1*kc1 + phi2*kc2  (both instances contribute)
@@ -1254,12 +1254,12 @@ TEST(HenryLawPhaseTransfer, ForcingMultiCellsMultiInstances)
   MatrixPolicy forcing(num_cells, 5, 0.0);
   forcing_func(params, vars, forcing);
 
-  auto crp = miam::util::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto crp = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
   double kc1 = crp.ComputeValue(r1, N1, T);
-  double ke1 = kc1 / (hlc * miam::util::R_gas * T);
+  double ke1 = kc1 / (hlc * miam::math::R_gas * T);
   double fv1 = 55000.0 * solvent_molecular_weight / solvent_density;
   double kc2 = crp.ComputeValue(r2, N2, T);
-  double ke2 = kc2 / (hlc * miam::util::R_gas * T);
+  double ke2 = kc2 / (hlc * miam::math::R_gas * T);
   double fv2 = 45000.0 * solvent_molecular_weight / solvent_density;
 
   for (std::size_t c = 0; c < num_cells; ++c)
@@ -1391,16 +1391,16 @@ TEST(HenryLawPhaseTransfer, ForcingMultipleTransferProcesses)
   ff_CO2(params, vars, forcing);
   ff_SO2(params, vars, forcing);
 
-  auto crp_CO2 = miam::util::MakeCondensationRateProvider(D_CO2, alpha, 0.044);
-  auto crp_SO2 = miam::util::MakeCondensationRateProvider(D_SO2, alpha, 0.064);
+  auto crp_CO2 = miam::math::MakeCondensationRateProvider(D_CO2, alpha, 0.044);
+  auto crp_SO2 = miam::math::MakeCondensationRateProvider(D_SO2, alpha, 0.064);
   double fv = h2o * solvent_molecular_weight / solvent_density;
 
   double kc_co2 = crp_CO2.ComputeValue(r, N, T);
-  double ke_co2 = kc_co2 / (HLC_CO2 * miam::util::R_gas * T);
+  double ke_co2 = kc_co2 / (HLC_CO2 * miam::math::R_gas * T);
   double net_co2 = phi * kc_co2 * co2_g - phi * ke_co2 * co2_aq / fv;
 
   double kc_so2 = crp_SO2.ComputeValue(r, N, T);
-  double ke_so2 = kc_so2 / (HLC_SO2 * miam::util::R_gas * T);
+  double ke_so2 = kc_so2 / (HLC_SO2 * miam::math::R_gas * T);
   double net_so2 = phi * kc_so2 * so2_g - phi * ke_so2 * so2_aq / fv;
 
   EXPECT_NEAR(forcing[0][0], -net_co2, std::abs(net_co2) * 1e-10);
@@ -1967,10 +1967,10 @@ TEST(HenryLawPhaseTransfer, ForcingFunctionZeroGasConcentration)
   MatrixPolicy forcing(1, 3, 0.0);
   ff(params, vars, forcing);
 
-  auto cond_rate_provider = miam::util::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto cond_rate_provider = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
   double kc = cond_rate_provider.ComputeValue(r_eff, N, T);
   double kc_eff = phi * kc;
-  double ke_eff = kc_eff / (HLC_ref * miam::util::R_gas * T);
+  double ke_eff = kc_eff / (HLC_ref * miam::math::R_gas * T);
   double f_v = 55000.0 * solvent_molecular_weight / solvent_density;
   double expected_net = 0.0 - ke_eff * 1.0e-5 / f_v;  // condensation term = 0
 
@@ -2010,7 +2010,7 @@ TEST(HenryLawPhaseTransfer, ForcingFunctionZeroAqueousConcentration)
   MatrixPolicy forcing(1, 3, 0.0);
   ff(params, vars, forcing);
 
-  auto cond_rate_provider = miam::util::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto cond_rate_provider = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
   double kc = cond_rate_provider.ComputeValue(r_eff, N, T);
   double kc_eff = phi * kc;
   double expected_net = kc_eff * 1.0e-3;  // evaporation term = 0

--- a/test/unit/processes/henry_law_phase_transfer.cpp
+++ b/test/unit/processes/henry_law_phase_transfer.cpp
@@ -402,10 +402,10 @@ TEST(HenryLawPhaseTransfer, ForcingFunctionBasicRates)
   forcing_func(state_parameters, state_variables, forcing_terms);
 
   // Compute expected net rate
-  auto cond_rate_provider = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto cond_rate_provider = miam::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
   double kc = cond_rate_provider.ComputeValue(r_eff_val, N_val, T);
   double kc_eff = phi_val * kc;
-  double ke_eff = kc_eff / (hlc * miam::math::R_gas * T);
+  double ke_eff = kc_eff / (hlc * miam::R_gas * T);
   double f_v = solvent_conc * solvent_molecular_weight / solvent_density;
   double expected_net = kc_eff * gas_conc - ke_eff * aq_conc / f_v;
 
@@ -462,10 +462,10 @@ TEST(HenryLawPhaseTransfer, ForcingFunctionMultipleCells)
 
   forcing_func(state_parameters, state_variables, forcing_terms);
 
-  auto cond_rate_provider = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto cond_rate_provider = miam::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
   double kc = cond_rate_provider.ComputeValue(r_eff_val, N_val, T);
   double kc_eff = phi_val * kc;
-  double ke_eff = kc_eff / (hlc * miam::math::R_gas * T);
+  double ke_eff = kc_eff / (hlc * miam::R_gas * T);
   double f_v = solvent * solvent_molecular_weight / solvent_density;
 
   for (std::size_t i = 0; i < num_cells; ++i)
@@ -574,9 +574,9 @@ TEST(HenryLawPhaseTransfer, JacobianFunctionDirectEntries)
 
   jac_func(state_parameters, state_variables, jacobian);
 
-  auto cond_rate_provider = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto cond_rate_provider = miam::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
   double kc = cond_rate_provider.ComputeValue(r_eff_val, N_val, T);
-  double ke = kc / (hlc * miam::math::R_gas * T);
+  double ke = kc / (hlc * miam::R_gas * T);
   double fv = solvent_conc * solvent_molecular_weight / solvent_density;
 
   // Stored as -J (MICM convention). -J[gas,gas] = +φ · k_cond
@@ -793,7 +793,7 @@ TEST(HenryLawPhaseTransfer, JacobianFunctionMultipleCells)
 
   jac_func(state_parameters, state_variables, jacobian);
 
-  auto cond_rate_provider = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto cond_rate_provider = miam::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
   double kc = cond_rate_provider.ComputeValue(r_eff_val, N_val, T);
 
   // Both cells should have same -J[gas,gas] = +φ · k_cond (MICM convention)
@@ -993,15 +993,15 @@ TEST(HenryLawPhaseTransfer, ForcingMultiplePhaseInstances)
   MatrixPolicy forcing(1, 5, 0.0);
   forcing_func(params, vars, forcing);
 
-  auto crp = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto crp = miam::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
 
   double kc1 = crp.ComputeValue(r1, N1, T);
-  double ke1 = kc1 / (hlc * miam::math::R_gas * T);
+  double ke1 = kc1 / (hlc * miam::R_gas * T);
   double fv1 = solvent1 * solvent_molecular_weight / solvent_density;
   double net1 = phi1 * kc1 * gas - phi1 * ke1 * aq1 / fv1;
 
   double kc2 = crp.ComputeValue(r2, N2, T);
-  double ke2 = kc2 / (hlc * miam::math::R_gas * T);
+  double ke2 = kc2 / (hlc * miam::R_gas * T);
   double fv2 = solvent2 * solvent_molecular_weight / solvent_density;
   double net2 = phi2 * kc2 * gas - phi2 * ke2 * aq2 / fv2;
 
@@ -1070,14 +1070,14 @@ TEST(HenryLawPhaseTransfer, JacobianMultiplePhaseInstances)
 
   jac_func(params, vars, jacobian);
 
-  auto crp = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto crp = miam::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
 
   double kc1 = crp.ComputeValue(r1, N1, T);
-  double ke1 = kc1 / (hlc * miam::math::R_gas * T);
+  double ke1 = kc1 / (hlc * miam::R_gas * T);
   double fv1 = solvent1 * solvent_molecular_weight / solvent_density;
 
   double kc2 = crp.ComputeValue(r2, N2, T);
-  double ke2 = kc2 / (hlc * miam::math::R_gas * T);
+  double ke2 = kc2 / (hlc * miam::R_gas * T);
   double fv2 = solvent2 * solvent_molecular_weight / solvent_density;
 
   // -J[gas,gas] = phi1*kc1 + phi2*kc2  (both instances contribute)
@@ -1254,12 +1254,12 @@ TEST(HenryLawPhaseTransfer, ForcingMultiCellsMultiInstances)
   MatrixPolicy forcing(num_cells, 5, 0.0);
   forcing_func(params, vars, forcing);
 
-  auto crp = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto crp = miam::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
   double kc1 = crp.ComputeValue(r1, N1, T);
-  double ke1 = kc1 / (hlc * miam::math::R_gas * T);
+  double ke1 = kc1 / (hlc * miam::R_gas * T);
   double fv1 = 55000.0 * solvent_molecular_weight / solvent_density;
   double kc2 = crp.ComputeValue(r2, N2, T);
-  double ke2 = kc2 / (hlc * miam::math::R_gas * T);
+  double ke2 = kc2 / (hlc * miam::R_gas * T);
   double fv2 = 45000.0 * solvent_molecular_weight / solvent_density;
 
   for (std::size_t c = 0; c < num_cells; ++c)
@@ -1391,16 +1391,16 @@ TEST(HenryLawPhaseTransfer, ForcingMultipleTransferProcesses)
   ff_CO2(params, vars, forcing);
   ff_SO2(params, vars, forcing);
 
-  auto crp_CO2 = miam::math::MakeCondensationRateProvider(D_CO2, alpha, 0.044);
-  auto crp_SO2 = miam::math::MakeCondensationRateProvider(D_SO2, alpha, 0.064);
+  auto crp_CO2 = miam::MakeCondensationRateProvider(D_CO2, alpha, 0.044);
+  auto crp_SO2 = miam::MakeCondensationRateProvider(D_SO2, alpha, 0.064);
   double fv = h2o * solvent_molecular_weight / solvent_density;
 
   double kc_co2 = crp_CO2.ComputeValue(r, N, T);
-  double ke_co2 = kc_co2 / (HLC_CO2 * miam::math::R_gas * T);
+  double ke_co2 = kc_co2 / (HLC_CO2 * miam::R_gas * T);
   double net_co2 = phi * kc_co2 * co2_g - phi * ke_co2 * co2_aq / fv;
 
   double kc_so2 = crp_SO2.ComputeValue(r, N, T);
-  double ke_so2 = kc_so2 / (HLC_SO2 * miam::math::R_gas * T);
+  double ke_so2 = kc_so2 / (HLC_SO2 * miam::R_gas * T);
   double net_so2 = phi * kc_so2 * so2_g - phi * ke_so2 * so2_aq / fv;
 
   EXPECT_NEAR(forcing[0][0], -net_co2, std::abs(net_co2) * 1e-10);
@@ -1967,10 +1967,10 @@ TEST(HenryLawPhaseTransfer, ForcingFunctionZeroGasConcentration)
   MatrixPolicy forcing(1, 3, 0.0);
   ff(params, vars, forcing);
 
-  auto cond_rate_provider = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto cond_rate_provider = miam::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
   double kc = cond_rate_provider.ComputeValue(r_eff, N, T);
   double kc_eff = phi * kc;
-  double ke_eff = kc_eff / (HLC_ref * miam::math::R_gas * T);
+  double ke_eff = kc_eff / (HLC_ref * miam::R_gas * T);
   double f_v = 55000.0 * solvent_molecular_weight / solvent_density;
   double expected_net = 0.0 - ke_eff * 1.0e-5 / f_v;  // condensation term = 0
 
@@ -2010,7 +2010,7 @@ TEST(HenryLawPhaseTransfer, ForcingFunctionZeroAqueousConcentration)
   MatrixPolicy forcing(1, 3, 0.0);
   ff(params, vars, forcing);
 
-  auto cond_rate_provider = miam::math::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
+  auto cond_rate_provider = miam::MakeCondensationRateProvider(D_g, alpha, gas_molecular_weight);
   double kc = cond_rate_provider.ComputeValue(r_eff, N, T);
   double kc_eff = phi * kc;
   double expected_net = kc_eff * 1.0e-3;  // evaporation term = 0


### PR DESCRIPTION
Closes #33 

Moves `CondensationRateProvider` into a `math` folder with the namespace `math`