### PR TITLE
SetSolvent should infer molecular weight and density from the species properties

### DIFF
--- a/include/miam/constraints/henry_law_equilibrium_constraint_builder.hpp
+++ b/include/miam/constraints/henry_law_equilibrium_constraint_builder.hpp
@@ -64,22 +64,6 @@ namespace miam
       return *this;
     }
 
-    /// @brief Sets the molecular weight of the solvent species [kg mol⁻¹]
-    HenryLawEquilibriumConstraintBuilder& SetSolventMolecularWeight(double solvent_molecular_weight)
-    {
-      solvent_molecular_weight_ = solvent_molecular_weight;
-      solvent_molecular_weight_is_set_ = true;
-      return *this;
-    }
-
-    /// @brief Sets the density of the solvent species [kg m⁻³]
-    HenryLawEquilibriumConstraintBuilder& SetSolventDensity(double solvent_density)
-    {
-      solvent_density_ = solvent_density;
-      solvent_density_is_set_ = true;
-      return *this;
-    }
-
     HenryLawEquilibriumConstraint Build() const
     {
       if (!gas_species_is_set_)
@@ -92,10 +76,9 @@ namespace miam
         throw std::runtime_error("HenryLawEquilibriumConstraintBuilder requires the condensed phase to be set.");
       if (!henry_law_constant_)
         throw std::runtime_error("HenryLawEquilibriumConstraintBuilder requires the Henry's Law constant to be set.");
-      if (!solvent_molecular_weight_is_set_)
-        throw std::runtime_error("HenryLawEquilibriumConstraintBuilder requires the solvent molecular weight to be set.");
-      if (!solvent_density_is_set_)
-        throw std::runtime_error("HenryLawEquilibriumConstraintBuilder requires the solvent density to be set.");
+
+      double solvent_molecular_weight = solvent_.GetProperty<double>("molecular weight [kg mol-1]");
+      double solvent_density = solvent_.GetProperty<double>("density [kg m-3]");
 
       return HenryLawEquilibriumConstraint(
           henry_law_constant_,
@@ -103,8 +86,8 @@ namespace miam
           condensed_species_,
           solvent_,
           condensed_phase_,
-          solvent_molecular_weight_,
-          solvent_density_);
+          solvent_molecular_weight,
+          solvent_density);
     }
 
    private:
@@ -117,9 +100,5 @@ namespace miam
     micm::Phase condensed_phase_;
     bool condensed_phase_is_set_ = false;
     std::function<double(const micm::Conditions& conditions)> henry_law_constant_;
-    double solvent_molecular_weight_ = 0.0;  ///< [kg mol⁻¹]
-    bool solvent_molecular_weight_is_set_ = false;
-    double solvent_density_ = 0.0;  ///< [kg m⁻³]
-    bool solvent_density_is_set_ = false;
   };
 }  // namespace miam

--- a/test/integration/test_cam_cloud_chemistry.cpp
+++ b/test/integration/test_cam_cloud_chemistry.cpp
@@ -247,8 +247,6 @@ TEST(CamCloudChemistry, Step1_SingleHLC)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant({
           .HLC_ref_ = HLC_ref, .C_ = C_hlc }))
-      .SetSolventMolecularWeight(0.018)
-      .SetSolventDensity(1000.0)
       .Build();
 
   // Mass conservation: [SO2_g] + [SO2_aq] = total  (SO2_g algebraic)
@@ -550,8 +548,6 @@ TEST(CamCloudChemistry, Step2_HLC_Plus_Dissociation)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant({
           .HLC_ref_ = HLC_ref, .C_ = C_hlc }))
-      .SetSolventMolecularWeight(0.018)
-      .SetSolventDensity(1000.0)
       .Build();
 
   // Kw: H2O ⇌ H+ + OH-
@@ -772,21 +768,21 @@ TEST(CamCloudChemistry, Step3_FullEquilibrium)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant({
           .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
-      .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+      .Build();
 
   auto hl_h2o2 = HenryLawEquilibriumConstraintBuilder()
       .SetGasSpecies(h2o2_g).SetCondensedSpecies(h2o2_aq).SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant({
           .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
-      .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+      .Build();
 
   auto hl_o3 = HenryLawEquilibriumConstraintBuilder()
       .SetGasSpecies(o3_g).SetCondensedSpecies(o3_aq).SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant({
           .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
-      .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+      .Build();
 
   // --- Dissociation equilibria ---
   auto eq_kw = DissolvedEquilibriumConstraintBuilder()
@@ -1017,21 +1013,21 @@ TEST(CamCloudChemistry, Step3b_NaiveInitialConditions)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant({
           .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
-      .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+      .Build();
 
   auto hl_h2o2 = HenryLawEquilibriumConstraintBuilder()
       .SetGasSpecies(h2o2_g).SetCondensedSpecies(h2o2_aq).SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant({
           .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
-      .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+      .Build();
 
   auto hl_o3 = HenryLawEquilibriumConstraintBuilder()
       .SetGasSpecies(o3_g).SetCondensedSpecies(o3_aq).SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant({
           .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
-      .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+      .Build();
 
   auto eq_kw = DissolvedEquilibriumConstraintBuilder()
       .SetPhase(aqueous_phase).SetReactants({ h2o }).SetProducts({ hp, ohm })
@@ -1224,21 +1220,21 @@ TEST(CamCloudChemistry, Step4_FullSystemWithKinetics)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant({
           .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
-      .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+      .Build();
 
   auto hl_h2o2 = HenryLawEquilibriumConstraintBuilder()
       .SetGasSpecies(h2o2_g).SetCondensedSpecies(h2o2_aq).SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant({
           .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
-      .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+      .Build();
 
   auto hl_o3 = HenryLawEquilibriumConstraintBuilder()
       .SetGasSpecies(o3_g).SetCondensedSpecies(o3_aq).SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant({
           .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
-      .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+      .Build();
 
   // --- Dissociation equilibria ---
   auto eq_kw = DissolvedEquilibriumConstraintBuilder()
@@ -1556,21 +1552,21 @@ TEST(CamCloudChemistry, Step4b_NaiveInitialConditions)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant({
           .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
-      .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+      .Build();
 
   auto hl_h2o2 = HenryLawEquilibriumConstraintBuilder()
       .SetGasSpecies(h2o2_g).SetCondensedSpecies(h2o2_aq).SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant({
           .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
-      .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+      .Build();
 
   auto hl_o3 = HenryLawEquilibriumConstraintBuilder()
       .SetGasSpecies(o3_g).SetCondensedSpecies(o3_aq).SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant({
           .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
-      .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+      .Build();
 
   auto eq_kw = DissolvedEquilibriumConstraintBuilder()
       .SetPhase(aqueous_phase).SetReactants({ h2o }).SetProducts({ hp, ohm })
@@ -1829,21 +1825,21 @@ TEST(CamCloudChemistry, Step5_JacobianVerification)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant({
           .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
-      .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+      .Build();
 
   auto hl_h2o2 = HenryLawEquilibriumConstraintBuilder()
       .SetGasSpecies(h2o2_g).SetCondensedSpecies(h2o2_aq).SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant({
           .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
-      .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+      .Build();
 
   auto hl_o3 = HenryLawEquilibriumConstraintBuilder()
       .SetGasSpecies(o3_g).SetCondensedSpecies(o3_aq).SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant({
           .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
-      .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+      .Build();
 
   auto eq_kw = DissolvedEquilibriumConstraintBuilder()
       .SetPhase(aqueous_phase).SetReactants({ h2o }).SetProducts({ hp, ohm })

--- a/test/integration/test_henry_law_equilibrium_constraint.cpp
+++ b/test/integration/test_henry_law_equilibrium_constraint.cpp
@@ -79,8 +79,6 @@ TEST(HenryLawEquilibriumConstraintIntegration, GasPhaseDriverSingleInstance)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant(
           HenrysLawConstantParameters{ .HLC_ref_ = HLC }))
-      .SetSolventMolecularWeight(solvent_molecular_weight)
-      .SetSolventDensity(solvent_density)
       .Build();
 
   // Mass conservation: [Precursor] + [A_g] + [A_aq] = total, A_g algebraic (global)
@@ -235,8 +233,6 @@ TEST(HenryLawEquilibriumConstraintIntegration, MultipleInstances)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant(
           HenrysLawConstantParameters{ .HLC_ref_ = HLC }))
-      .SetSolventMolecularWeight(solvent_molecular_weight)
-      .SetSolventDensity(solvent_density)
       .Build();
 
   double P0 = 1.0;

--- a/test/integration/test_jacobian_verification.cpp
+++ b/test/integration/test_jacobian_verification.cpp
@@ -542,8 +542,6 @@ TEST(JacobianVerification, HenryLawEquilibriumConstraint)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant(
           HenrysLawConstantParameters{ .HLC_ref_ = HLC }))
-      .SetSolventMolecularWeight(solvent_molecular_weight)
-      .SetSolventDensity(solvent_density)
       .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
@@ -665,8 +663,6 @@ TEST(JacobianVerification, HenryLawEquilibriumWithConservation)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(HenrysLawConstant(
           HenrysLawConstantParameters{ .HLC_ref_ = HLC }))
-      .SetSolventMolecularWeight(solvent_molecular_weight)
-      .SetSolventDensity(solvent_density)
       .Build();
 
   double total = 1.0;

--- a/test/integration/test_kinetic_vs_constrained.cpp
+++ b/test/integration/test_kinetic_vs_constrained.cpp
@@ -419,8 +419,6 @@ TEST(KineticVsConstrained, HenryLawPhaseTransferVsEquilibriumConstraint)
         .SetCondensedPhase(aqueous_phase)
         .SetHenryLawConstant(HenrysLawConstant(
             HenrysLawConstantParameters{ .HLC_ref_ = HLC }))
-        .SetSolventMolecularWeight(solvent_molecular_weight)
-        .SetSolventDensity(solvent_density)
         .Build();
 
     auto mass_cons = LinearConstraintBuilder()

--- a/test/integration/test_solvent_robustness.cpp
+++ b/test/integration/test_solvent_robustness.cpp
@@ -188,21 +188,21 @@ namespace
         .SetCondensedPhase(sp.aqueous_phase)
         .SetHenryLawConstant(HenrysLawConstant({
             .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
-        .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+        .Build();
 
     auto hl_h2o2 = HenryLawEquilibriumConstraintBuilder()
         .SetGasSpecies(sp.h2o2_g).SetCondensedSpecies(sp.h2o2_aq).SetSolvent(sp.h2o)
         .SetCondensedPhase(sp.aqueous_phase)
         .SetHenryLawConstant(HenrysLawConstant({
             .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
-        .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+        .Build();
 
     auto hl_o3 = HenryLawEquilibriumConstraintBuilder()
         .SetGasSpecies(sp.o3_g).SetCondensedSpecies(sp.o3_aq).SetSolvent(sp.h2o)
         .SetCondensedPhase(sp.aqueous_phase)
         .SetHenryLawConstant(HenrysLawConstant({
             .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
-        .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+        .Build();
 
     auto eq_kw = DissolvedEquilibriumConstraintBuilder()
         .SetPhase(sp.aqueous_phase).SetReactants({ sp.h2o }).SetProducts({ sp.hp, sp.ohm })
@@ -589,7 +589,7 @@ TEST(SolventRobustness, A4_HenryLawConstraint_SolventSweep)
         .SetCondensedPhase(aqueous_phase)
         .SetHenryLawConstant(HenrysLawConstant({
             .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
-        .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+        .Build();
 
     auto mass = LinearConstraintBuilder()
         .SetAlgebraicSpecies(gas_phase, so2_g)
@@ -671,7 +671,7 @@ TEST(SolventRobustness, A5_HLC_Plus_Dissociation_SolventSweep)
         .SetCondensedPhase(aqueous_phase)
         .SetHenryLawConstant(HenrysLawConstant({
             .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
-        .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+        .Build();
 
     auto eq_ka1 = DissolvedEquilibriumConstraintBuilder()
         .SetPhase(aqueous_phase).SetReactants({ so2_aq }).SetProducts({ hso3m, hp })
@@ -772,21 +772,21 @@ TEST(SolventRobustness, A6_FullEquilibrium_SolventSweep)
         .SetCondensedPhase(aqueous_phase)
         .SetHenryLawConstant(HenrysLawConstant({
             .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
-        .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+        .Build();
 
     auto hl_h2o2 = HenryLawEquilibriumConstraintBuilder()
         .SetGasSpecies(h2o2_g).SetCondensedSpecies(h2o2_aq).SetSolvent(h2o)
         .SetCondensedPhase(aqueous_phase)
         .SetHenryLawConstant(HenrysLawConstant({
             .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
-        .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+        .Build();
 
     auto hl_o3 = HenryLawEquilibriumConstraintBuilder()
         .SetGasSpecies(o3_g).SetCondensedSpecies(o3_aq).SetSolvent(h2o)
         .SetCondensedPhase(aqueous_phase)
         .SetHenryLawConstant(HenrysLawConstant({
             .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
-        .SetSolventMolecularWeight(0.018).SetSolventDensity(1000.0).Build();
+        .Build();
 
     auto eq_kw = DissolvedEquilibriumConstraintBuilder()
         .SetPhase(aqueous_phase).SetReactants({ h2o }).SetProducts({ hp, ohm })

--- a/test/unit/constraints/henry_law_equilibrium_constraint.cpp
+++ b/test/unit/constraints/henry_law_equilibrium_constraint.cpp
@@ -30,12 +30,14 @@ namespace
 {
   using DMP = micm::Matrix<double>;
 
-  auto h2o = micm::Species{ "H2O" };
+  constexpr double water_molecular_weight = 0.018;
+  constexpr double water_density = 1000.0;
+  auto h2o = micm::Species{ "H2O",
+      { { "molecular weight [kg mol-1]", water_molecular_weight },
+        { "density [kg m-3]", water_density } } };
   auto A_g = micm::Species{ "A_g" };
   auto A_aq = micm::Species{ "A_aq" };
   auto aqueous_phase = micm::Phase{ "AQUEOUS", { { h2o }, { A_aq } } };
-  constexpr double water_molecular_weight = 0.018;
-  constexpr double water_density = 1000.0;
 
   /// @brief Build state parameter index map from a constraint's ConstraintStateParameterNames
   template<typename ConstraintT>
@@ -62,8 +64,6 @@ TEST(HenryLawEquilibriumConstraint, AlgebraicVariableNamesSinglePrefix)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -83,8 +83,6 @@ TEST(HenryLawEquilibriumConstraint, AlgebraicVariableNamesMultiplePrefixes)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -108,8 +106,6 @@ TEST(HenryLawEquilibriumConstraint, SpeciesDependencies)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -132,8 +128,6 @@ TEST(HenryLawEquilibriumConstraint, SpeciesDependenciesMultipleInstances)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -161,8 +155,6 @@ TEST(HenryLawEquilibriumConstraint, NonZeroJacobianElements)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -196,8 +188,6 @@ TEST(HenryLawEquilibriumConstraint, ResidualSingleInstance)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -250,8 +240,6 @@ TEST(HenryLawEquilibriumConstraint, ResidualMultipleInstances)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -310,8 +298,6 @@ TEST(HenryLawEquilibriumConstraint, JacobianSingleInstance)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -380,8 +366,6 @@ TEST(HenryLawEquilibriumConstraint, UpdateConstraintParametersTemperatureDep)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -422,8 +406,6 @@ TEST(HenryLawEquilibriumConstraint, BuilderValidation)
           .SetSolvent(h2o)
           .SetCondensedPhase(aqueous_phase)
           .SetHenryLawConstant(FakeHLC{})
-          .SetSolventMolecularWeight(water_molecular_weight)
-          .SetSolventDensity(water_density)
           .Build(),
       std::runtime_error);
 
@@ -434,8 +416,6 @@ TEST(HenryLawEquilibriumConstraint, BuilderValidation)
                         .SetSolvent(h2o)
                         .SetCondensedPhase(aqueous_phase)
                         .SetHenryLawConstant(FakeHLC{})
-                        .SetSolventMolecularWeight(water_molecular_weight)
-                        .SetSolventDensity(water_density)
                         .Build();
   EXPECT_EQ(constraint.gas_species_.name_, "A_g");
   EXPECT_EQ(constraint.condensed_species_.name_, "A_aq");
@@ -552,8 +532,6 @@ TEST(HenryLawEquilibriumConstraint, JacobianFDSingleInstance)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -588,8 +566,6 @@ TEST(HenryLawEquilibriumConstraint, JacobianFDMultipleInstances)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -629,8 +605,6 @@ TEST(HenryLawEquilibriumConstraint, ResidualMultipleCells)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -680,8 +654,6 @@ TEST(HenryLawEquilibriumConstraint, MultiInstanceMultiCellFD)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -721,8 +693,6 @@ TEST(HenryLawEquilibriumConstraint, ThreeInstancesFD)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -766,8 +736,6 @@ TEST(HenryLawEquilibriumConstraint, JacobianAccumulates)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -813,8 +781,6 @@ TEST(HenryLawEquilibriumConstraint, ResidualSetsNotAccumulates)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -854,8 +820,6 @@ TEST(HenryLawEquilibriumConstraint, TemperatureDependentHlcMultiCell)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -911,8 +875,6 @@ TEST(HenryLawEquilibriumConstraint, CrossInstanceJacobianIsolation)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -964,8 +926,6 @@ TEST(HenryLawEquilibriumConstraint, JacobianMultipleInstancesAnalytical)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -1029,8 +989,6 @@ TEST(HenryLawEquilibriumConstraint, LargeHLC)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -1074,8 +1032,6 @@ TEST(HenryLawEquilibriumConstraint, CopiedConstraintProducesSameResults)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   auto copy = original.CopyWithNewUuid();
@@ -1121,8 +1077,6 @@ TEST(HenryLawEquilibriumConstraint, ResidualZeroAtEquilibrium)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -1166,8 +1120,6 @@ TEST(HenryLawEquilibriumConstraint, KitchenSinkFD)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -1230,8 +1182,6 @@ namespace
         .SetSolvent(h2o)
         .SetCondensedPhase(aqueous_phase)
         .SetHenryLawConstant(hlc_fn)
-        .SetSolventMolecularWeight(water_molecular_weight)
-        .SetSolventDensity(water_density)
         .Build();
 
     std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -1385,8 +1335,6 @@ TEST(HenryLawEquilibriumConstraint, ResidualZeroGasConcentration)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -1423,8 +1371,6 @@ TEST(HenryLawEquilibriumConstraint, ResidualZeroAqueousConcentration)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -1464,8 +1410,6 @@ TEST(HenryLawEquilibriumConstraint, JacobianFDZeroConcentrations)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -1502,8 +1446,6 @@ TEST(HenryLawEquilibriumConstraint, JacobianFDTemperatureExtremes)
       .SetSolvent(h2o)
       .SetCondensedPhase(aqueous_phase)
       .SetHenryLawConstant(hlc)
-      .SetSolventMolecularWeight(water_molecular_weight)
-      .SetSolventDensity(water_density)
       .Build();
 
   std::map<std::string, std::set<std::string>> phase_prefixes;


### PR DESCRIPTION
This PR:

- Removes `SetSolventMolecularWeight` and `SetSolventDensity` functions. `Build()` now infers both via `GetProperty` (`henry_law_equilibrium_constraint_builder.hpp`)
- Updates the test files to remove all call sites.
- Closes #29