### PR TITLE
Avoid passing ExternalModel object twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ int main()
   cloud_model.AddProcesses({ co2_transfer });
 
   // Build solver (MICM Rosenbrock)
-  auto system = System(gas_phase, cloud_model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                     .SetSystem(system)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -24,7 +24,7 @@ endif()
 
 FetchContent_Declare(micm
     GIT_REPOSITORY https://github.com/NCAR/micm.git
-    GIT_TAG a35813e9f4f80f8f4810799df2efd0d939ef9ffd
+    GIT_TAG 983-investigate-system-passed-twice
     GIT_PROGRESS NOT ${FETCHCONTENT_QUIET}
     FIND_PACKAGE_ARGS NAMES micm
 )

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -24,7 +24,7 @@ endif()
 
 FetchContent_Declare(micm
     GIT_REPOSITORY https://github.com/NCAR/micm.git
-    GIT_TAG 983-investigate-system-passed-twice
+    GIT_TAG fa3e8c5d86db9f148ce75a44a14343554ccfa4bc
     GIT_PROGRESS NOT ${FETCHCONTENT_QUIET}
     FIND_PACKAGE_ARGS NAMES micm
 )

--- a/test/integration/test_cam_cloud_chemistry.cpp
+++ b/test/integration/test_cam_cloud_chemistry.cpp
@@ -255,7 +255,7 @@ TEST(CamCloudChemistry, Step1_SingleHLC)
   auto model = Model{ .name_ = "CLOUD", .representations_ = { cloud } };
   model.AddConstraints(hl_so2, mass_so2);
 
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                     .SetSystem(system)
@@ -347,7 +347,7 @@ TEST(CamCloudChemistry, Step1b_KwOnly)
   auto model = Model{ .name_ = "CLOUD", .representations_ = { cloud } };
   model.AddConstraints(eq_kw, charge);
 
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                     .SetSystem(system)
@@ -450,7 +450,7 @@ TEST(CamCloudChemistry, Step1c_KwNaiveIC)
   params.constraint_init_tolerance_ = 1e-20;
   params.max_number_of_steps_ = 1500;
 
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(params)
                     .SetSystem(system)
                     .AddExternalModel(model)
@@ -588,7 +588,7 @@ TEST(CamCloudChemistry, Step2_HLC_Plus_Dissociation)
   auto model = Model{ .name_ = "CLOUD", .representations_ = { cloud } };
   model.AddConstraints(hl_so2, eq_kw, eq_ka1, mass_S, charge);
 
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                     .SetSystem(system)
@@ -843,7 +843,7 @@ TEST(CamCloudChemistry, Step3_FullEquilibrium)
                        eq_kw, eq_ka1, eq_ka2,
                        mass_S, mass_H2O2, mass_O3, charge);
 
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                     .SetSystem(system)
@@ -1084,7 +1084,7 @@ TEST(CamCloudChemistry, Step3b_NaiveInitialConditions)
                        eq_kw, eq_ka1, eq_ka2,
                        mass_S, mass_H2O2, mass_O3, charge);
 
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                     .SetSystem(system)
@@ -1353,7 +1353,7 @@ TEST(CamCloudChemistry, Step4_FullSystemWithKinetics)
                        eq_kw, eq_ka1, eq_ka2,
                        mass_S, mass_H2O2, mass_O3, charge);
 
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                     .SetSystem(system)
@@ -1674,7 +1674,7 @@ TEST(CamCloudChemistry, Step4b_NaiveInitialConditions)
                        eq_kw, eq_ka1, eq_ka2,
                        mass_S, mass_H2O2, mass_O3, charge);
 
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                     .SetSystem(system)

--- a/test/integration/test_dissolved_reaction.cpp
+++ b/test/integration/test_dissolved_reaction.cpp
@@ -50,7 +50,7 @@ TEST(DissolvedReactionIntegration, SimpleFirstOrderDecay)
   Phase gas_phase{ "GAS", {} };
   double A0 = 1.0;  // mol/m^3
 
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                   .SetSystem(system)
                   .AddExternalModel(model)
@@ -159,7 +159,7 @@ TEST(DissolvedReactionIntegration, SolventAsReactant)
   double A0 = 1.0e-5;
   double C0 = 1.0e-4;
 
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                   .SetSystem(system)
                   .AddExternalModel(model)
@@ -267,7 +267,7 @@ TEST(DissolvedReactionIntegration, SolventAsProduct)
   double B0 = 0.0;
   double C0 = 1.0e-4;
 
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                   .SetSystem(system)
                   .AddExternalModel(model)
@@ -390,7 +390,7 @@ TEST(DissolvedReactionIntegration, MultiPhaseInstances)
   double A0_small = 1.0;
   double A0_large = 0.5;
 
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                   .SetSystem(system)
                   .AddExternalModel(model)
@@ -522,7 +522,7 @@ TEST(DissolvedReactionIntegration, SecondOrderTwoReactants)
   double S0 = 50.0;    // mol/m^3 (solvent, large and approximately constant)
   double k_eff = k / S0;  // effective second-order rate constant
 
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                   .SetSystem(system)
                   .AddExternalModel(model)
@@ -641,7 +641,7 @@ TEST(DissolvedReactionIntegration, MinHalflifeZeroReactant)
 
   Phase gas_phase{ "GAS", {} };
 
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                   .SetSystem(system)
                   .AddExternalModel(model)

--- a/test/integration/test_dissolved_reversible_reaction.cpp
+++ b/test/integration/test_dissolved_reversible_reaction.cpp
@@ -86,7 +86,7 @@ TEST(DissolvedReversibleReactionIntegration, SimpleAtoB)
   double B_eq = A0 * K_eq / (1.0 + K_eq);
   
   // Build solver
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                   .SetSystem(system)
                   .AddExternalModel(model)
@@ -223,7 +223,7 @@ TEST(DissolvedReversibleReactionIntegration, SolventAsReactant)
   double C_eq = C0 - B_eq;
   
   // Build solver
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                   .SetSystem(system)
                   .AddExternalModel(model)
@@ -373,7 +373,7 @@ TEST(DissolvedReversibleReactionIntegration, SolventAsProduct) {
   double B_eq = k_forward / (k_forward + k_reverse) * A0;  // ≈ 0
   
   // Build solver
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                   .SetSystem(system)
                   .AddExternalModel(model)
@@ -539,7 +539,7 @@ TEST(DissolvedReversibleReactionIntegration, MultiPhaseInstances) {
   double tau_large = 1.0 / k_total_large;  // 3.33 s
   
   // Build solver
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                   .SetSystem(system)
                   .AddExternalModel(model)

--- a/test/integration/test_equilibrium_constraints.cpp
+++ b/test/integration/test_equilibrium_constraints.cpp
@@ -95,7 +95,7 @@ TEST(EquilibriumConstraintsIntegration, DissolvedEquilibriumWithKineticDriver)
 
   // Build DAE solver
   Phase gas_phase{ "GAS", {} };
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                     .SetSystem(system)
@@ -246,7 +246,7 @@ TEST(EquilibriumConstraintsIntegration, PerInstanceEquilibrium)
   model.AddConstraints(equil);
 
   Phase gas_phase{ "GAS", {} };
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                     .SetSystem(system)
@@ -381,7 +381,7 @@ TEST(EquilibriumConstraintsIntegration, InconsistentInitialConditions)
   model.AddConstraints(equil, mass_cons);
 
   Phase gas_phase{ "GAS", {} };
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                     .SetSystem(system)

--- a/test/integration/test_henry_law_equilibrium_constraint.cpp
+++ b/test/integration/test_henry_law_equilibrium_constraint.cpp
@@ -101,7 +101,7 @@ TEST(HenryLawEquilibriumConstraintIntegration, GasPhaseDriverSingleInstance)
   model.AddConstraints(hl_constraint, mass_cons);
 
   // Build DAE solver with MICM gas-phase reaction + MIAM constraints
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                     .SetSystem(system)
@@ -249,7 +249,7 @@ TEST(HenryLawEquilibriumConstraintIntegration, MultipleInstances)
   };
   model.AddConstraints(hl_constraint, mass_cons);
 
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                     .SetSystem(system)

--- a/test/integration/test_henry_law_phase_transfer.cpp
+++ b/test/integration/test_henry_law_phase_transfer.cpp
@@ -98,7 +98,7 @@ TEST(HenryLawPhaseTransferIntegration, SimpleOneInstance)
   };
   model.AddProcesses({ transfer });
 
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                     .SetSystem(system)
@@ -260,7 +260,7 @@ TEST(HenryLawPhaseTransferIntegration, MultiInstanceMassConservation)
   model.AddProcesses({ transfer_small });
   model.AddProcesses({ transfer_large });
 
-  auto system = System(gas_phase, model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                     .SetSystem(system)
@@ -388,7 +388,7 @@ TEST(HenryLawPhaseTransferIntegration, TemperatureDependentHLC)
     };
     model.AddProcesses({ transfer });
 
-    auto system = System(gas_phase, model);
+    auto system = System(gas_phase);
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                       RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                       .SetSystem(system)
@@ -501,7 +501,7 @@ TEST(HenryLawPhaseTransferIntegration, SmallVsLargeParticleRate)
     };
     model.AddProcesses({ transfer });
 
-    auto system = System(gas_phase, model);
+    auto system = System(gas_phase);
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                       RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                       .SetSystem(system)

--- a/test/integration/test_kinetic_vs_constrained.cpp
+++ b/test/integration/test_kinetic_vs_constrained.cpp
@@ -52,7 +52,7 @@ namespace
     model.AddProcesses({ reversible });
 
     Phase gas_phase{ "GAS", {} };
-    auto system = System(gas_phase, model);
+    auto system = System(gas_phase);
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                       RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                       .SetSystem(system)
@@ -146,7 +146,7 @@ TEST(KineticVsConstrained, DissolvedReversibleVsEquilibriumConstraint)
     model.AddProcesses({ reversible });
 
     Phase gas_phase{ "GAS", {} };
-    auto system = System(gas_phase, model);
+    auto system = System(gas_phase);
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                       RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                       .SetSystem(system)
@@ -226,7 +226,7 @@ TEST(KineticVsConstrained, DissolvedReversibleVsEquilibriumConstraint)
     model.AddConstraints(equil, mass_cons);
 
     Phase gas_phase{ "GAS", {} };
-    auto system = System(gas_phase, model);
+    auto system = System(gas_phase);
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                       RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                       .SetSystem(system)
@@ -360,7 +360,7 @@ TEST(KineticVsConstrained, HenryLawPhaseTransferVsEquilibriumConstraint)
     };
     model.AddProcesses({ transfer });
 
-    auto system = System(gas_phase, model);
+    auto system = System(gas_phase);
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                       RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                       .SetSystem(system)
@@ -423,7 +423,7 @@ TEST(KineticVsConstrained, HenryLawPhaseTransferVsEquilibriumConstraint)
     };
     model.AddConstraints(hl_constraint, mass_cons);
 
-    auto system = System(gas_phase, model);
+    auto system = System(gas_phase);
 
     // Need at least one differential variable — A_g and A_aq are both algebraic.
     // Create a dummy inert species to have a differential equation.
@@ -432,7 +432,7 @@ TEST(KineticVsConstrained, HenryLawPhaseTransferVsEquilibriumConstraint)
     // not converge well. Let's add a dummy inert gas species that doesn't participate.
     auto Inert = Species{ "Inert" };
     Phase gas_phase_with_inert{ "GAS", { { A_g }, { Inert } } };
-    auto system_with_inert = System(gas_phase_with_inert, model);
+    auto system_with_inert = System(gas_phase_with_inert);
 
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                       RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())

--- a/test/integration/test_miam_api.cpp
+++ b/test/integration/test_miam_api.cpp
@@ -193,7 +193,7 @@ TEST(MIAM, ApiExample)
   aerosol_model.AddProcesses(reactions);
   cloud_model.AddProcesses(reactions);
 
-  auto system = System(gas_phase, aerosol_model, cloud_model);
+  auto system = System(gas_phase);
 
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                   .SetSystem(system)

--- a/test/integration/test_readme_example.cpp
+++ b/test/integration/test_readme_example.cpp
@@ -57,7 +57,7 @@ TEST(ReadmeExample, HenryLawPhaseTransfer)
   cloud_model.AddProcesses({ co2_transfer });
 
   // Build solver (MICM Rosenbrock)
-  auto system = System(gas_phase, cloud_model);
+  auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                     .SetSystem(system)

--- a/test/integration/test_solvent_robustness.cpp
+++ b/test/integration/test_solvent_robustness.cpp
@@ -363,7 +363,7 @@ TEST(SolventRobustness, A1_DissolvedReaction_SolventSweep)
     model.AddConstraints(mass_S, charge);
 
     Phase dummy_gas{ "GAS", {} };
-    auto system = System(dummy_gas, model);
+    auto system = System(dummy_gas);
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                       RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                       .SetSystem(system)
@@ -444,7 +444,7 @@ TEST(SolventRobustness, A2_DissolvedReversibleReaction_SolventSweep)
     model.AddConstraints(mass);
 
     Phase dummy_gas{ "GAS", {} };
-    auto system = System(dummy_gas, model);
+    auto system = System(dummy_gas);
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                       RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                       .SetSystem(system)
@@ -518,7 +518,7 @@ TEST(SolventRobustness, A3_DissolvedEquilibriumConstraint_SolventSweep)
     model.AddConstraints(eq_ka1, charge);
 
     Phase dummy_gas{ "GAS", {} };
-    auto system = System(dummy_gas, model);
+    auto system = System(dummy_gas);
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                       RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                       .SetSystem(system)
@@ -592,7 +592,7 @@ TEST(SolventRobustness, A4_HenryLawConstraint_SolventSweep)
     auto model = Model{ .name_ = "CLOUD", .representations_ = { cloud } };
     model.AddConstraints(hl_so2, mass);
 
-    auto system = System(gas_phase, model);
+    auto system = System(gas_phase);
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                       RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                       .SetSystem(system)
@@ -689,7 +689,7 @@ TEST(SolventRobustness, A5_HLC_Plus_Dissociation_SolventSweep)
     auto model = Model{ .name_ = "CLOUD", .representations_ = { cloud } };
     model.AddConstraints(hl_so2, eq_ka1, mass_S, charge);
 
-    auto system = System(gas_phase, model);
+    auto system = System(gas_phase);
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                       RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                       .SetSystem(system)
@@ -837,7 +837,7 @@ TEST(SolventRobustness, A6_FullEquilibrium_SolventSweep)
                          eq_kw, eq_ka1, eq_ka2,
                          mass_S, mass_H2O2, mass_O3, charge);
 
-    auto system = System(gas_phase, model);
+    auto system = System(gas_phase);
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                       RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                       .SetSystem(system)
@@ -915,7 +915,7 @@ TEST(SolventRobustness, B1_FullMechanism_StaticSweep)
     CamCloudSpecies sp;
     auto [model, cloud] = BuildCamCloudModel(sp);
 
-    auto system = System(sp.gas_phase, model);
+    auto system = System(sp.gas_phase);
     auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                       RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                       .SetSystem(system)
@@ -997,7 +997,7 @@ TEST(SolventRobustness, B2_DynamicEvaporation)
   CamCloudSpecies sp;
   auto [model, cloud] = BuildCamCloudModel(sp);
 
-  auto system = System(sp.gas_phase, model);
+  auto system = System(sp.gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                     .SetSystem(system)
@@ -1097,7 +1097,7 @@ TEST(SolventRobustness, B3_CloudFormation)
   CamCloudSpecies sp;
   auto [model, cloud] = BuildCamCloudModel(sp);
 
-  auto system = System(sp.gas_phase, model);
+  auto system = System(sp.gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                     .SetSystem(system)
@@ -1178,7 +1178,7 @@ TEST(SolventRobustness, C1_MixedColumn)
   CamCloudSpecies sp;
   auto [model, cloud] = BuildCamCloudModel(sp);
 
-  auto system = System(sp.gas_phase, model);
+  auto system = System(sp.gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                     .SetSystem(system)
@@ -1289,7 +1289,7 @@ TEST(SolventRobustness, C2_UniformColumn)
   CamCloudSpecies sp;
   auto [model, cloud] = BuildCamCloudModel(sp);
 
-  auto system = System(sp.gas_phase, model);
+  auto system = System(sp.gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                     .SetSystem(system)
@@ -1371,7 +1371,7 @@ TEST(SolventRobustness, C3_ExtremeContrast)
   CamCloudSpecies sp;
   auto [model, cloud] = BuildCamCloudModel(sp);
 
-  auto system = System(sp.gas_phase, model);
+  auto system = System(sp.gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                     RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                     .SetSystem(system)


### PR DESCRIPTION
MICM (https://github.com/NCAR/micm/pull/1004) refactored `SolverBuilder` API to avoid passing ExternalModel object  twice. 
This PR updates the MICM tag and the relevant tests.

```C++
// Current
auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                    RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                    .SetSystem(System(gas_phase, model));
                    .AddExternalModel(model)
                    .Build();

// This PR
auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
                    RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters())
                    .SetSystem(System(gas_phase));
                    .AddExternalModel(model)
                    .Build();
```
