### PR TITLE
Update the MICM tag

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -24,7 +24,7 @@ endif()
 
 FetchContent_Declare(micm
     GIT_REPOSITORY https://github.com/NCAR/micm.git
-    GIT_TAG fa3e8c5d86db9f148ce75a44a14343554ccfa4bc
+    GIT_TAG b4ad795c7f9b3bb1f1e4f3e5023df3c8066db439
     GIT_PROGRESS NOT ${FETCHCONTENT_QUIET}
     FIND_PACKAGE_ARGS NAMES micm
 )

--- a/docs/src/user_guide/debugging_dae_systems.rst
+++ b/docs/src/user_guide/debugging_dae_systems.rst
@@ -152,7 +152,7 @@ For **kinetic process** Jacobians:
 
    auto result = CompareJacobianToFiniteDifference<DenseMatrix, SparseMatrix>(
        analytical_jac, fd_jac, num_species, /*atol=*/1e-5, /*rtol=*/1e-4);
-   EXPECT_TRUE(result.passed);
+   EXPECT_TRUE(result.passed_);
 
 For **constraint** Jacobians, the pattern is similar but uses
 ``ConstraintResidualFunction`` and ``ConstraintJacobianFunction``.  See
@@ -166,7 +166,7 @@ pattern silently drops that derivative to zero:
 
    auto sparsity = CheckJacobianSparsityCompleteness<DenseMatrix, SparseMatrix>(
        analytical_jac, fd_jac, num_species);
-   EXPECT_TRUE(sparsity.passed);
+   EXPECT_TRUE(sparsity.passed_);
 
 Strategy 2: Test sub-systems in isolation
 ------------------------------------------

--- a/test/integration/test_aqueous_carbonic_acid.cpp
+++ b/test/integration/test_aqueous_carbonic_acid.cpp
@@ -266,7 +266,7 @@ TEST(AqueousCarbonicAcid, KineticODE)
   model.AddProcesses({ sys.rxn1, rxn2, rxn_w });
 
   // -- ODE Solver --
-  auto system = System(sys.gas_phase, model);
+  auto system = System(sys.gas_phase);
   auto ode_params = RosenbrockSolverParameters::ThreeStageRosenbrockParameters();
   ode_params.h_start_ = 1.0e-4;  // small initial step; Rosenbrock will grow it adaptively
   ode_params.h_max_ = 5.0;       // cap step size: k2_r*h_max ~3e13, acceptable for rtol=0.05
@@ -441,7 +441,7 @@ TEST(AqueousCarbonicAcid, DAEConstraints)
   model.AddConstraints(hl_constraint, k2_constraint, kw_constraint, charge_balance);
 
   // -- DAE Solver --
-  auto system = System(sys.gas_phase, model);
+  auto system = System(sys.gas_phase);
   auto params = RosenbrockSolverParameters::FourStageDifferentialAlgebraicRosenbrockParameters();
   params.h_start_ = 1.0e-4;          // small initial step; Rosenbrock will grow it adaptively
   params.h_max_ = 1.0;               // cap step size: k1_r*h_max ~1.3e7, well-conditioned in debug+release

--- a/test/integration/test_cam_cloud_chemistry.cpp
+++ b/test/integration/test_cam_cloud_chemistry.cpp
@@ -154,15 +154,15 @@ namespace
               analytical_jac, fd_jac, num_species, atol, rtol)
         : CompareJacobianToFiniteDifference<DenseMatrix, SparseMatrixFD>(
               analytical_jac, fd_jac, num_species);
-    EXPECT_TRUE(comparison.passed) << "Process Jacobian mismatch: row=" << comparison.worst_row
-                                   << " col=" << comparison.worst_col
-                                   << " analytical=" << comparison.worst_analytical
-                                   << " fd=" << comparison.worst_fd;
+    EXPECT_TRUE(comparison.passed_) << "Process Jacobian mismatch: row=" << comparison.worst_row_
+                                   << " col=" << comparison.worst_col_
+                                   << " analytical=" << comparison.worst_analytical_
+                                   << " fd=" << comparison.worst_fd_;
     auto sparsity = CheckJacobianSparsityCompleteness<DenseMatrix, SparseMatrixFD>(
         analytical_jac, fd_jac, num_species);
-    EXPECT_TRUE(sparsity.passed) << "Missing sparsity at row=" << sparsity.worst_row
-                                 << " col=" << sparsity.worst_col
-                                 << " fd_value=" << sparsity.worst_fd;
+    EXPECT_TRUE(sparsity.passed_) << "Missing sparsity at row=" << sparsity.worst_row_
+                                 << " col=" << sparsity.worst_col_
+                                 << " fd_value=" << sparsity.worst_fd_;
   }
 
   void VerifyConstraintJacobian(
@@ -195,15 +195,15 @@ namespace
               analytical_jac, fd_jac, num_species, atol, rtol)
         : CompareJacobianToFiniteDifference<DenseMatrix, SparseMatrixFD>(
               analytical_jac, fd_jac, num_species);
-    EXPECT_TRUE(comparison.passed) << "Constraint Jacobian mismatch: row=" << comparison.worst_row
-                                   << " col=" << comparison.worst_col
-                                   << " analytical=" << comparison.worst_analytical
-                                   << " fd=" << comparison.worst_fd;
+    EXPECT_TRUE(comparison.passed_) << "Constraint Jacobian mismatch: row=" << comparison.worst_row_
+                                   << " col=" << comparison.worst_col_
+                                   << " analytical=" << comparison.worst_analytical_
+                                   << " fd=" << comparison.worst_fd_;
     auto sparsity = CheckJacobianSparsityCompleteness<DenseMatrix, SparseMatrixFD>(
         analytical_jac, fd_jac, num_species);
-    EXPECT_TRUE(sparsity.passed) << "Missing constraint sparsity at row=" << sparsity.worst_row
-                                 << " col=" << sparsity.worst_col
-                                 << " fd_value=" << sparsity.worst_fd;
+    EXPECT_TRUE(sparsity.passed_) << "Missing constraint sparsity at row=" << sparsity.worst_row_
+                                 << " col=" << sparsity.worst_col_
+                                 << " fd_value=" << sparsity.worst_fd_;
   }
 
 }  // namespace

--- a/test/integration/test_jacobian_verification.cpp
+++ b/test/integration/test_jacobian_verification.cpp
@@ -108,17 +108,17 @@ namespace
         : micm::CompareJacobianToFiniteDifference<DenseMatrix, SparseMatrixFD>(
               analytical_jac, fd_jac, num_species);
 
-    EXPECT_TRUE(comparison.passed) << "Process Jacobian mismatch: block=" << comparison.worst_block
-                                   << " row=" << comparison.worst_row << " col=" << comparison.worst_col
-                                   << " analytical=" << comparison.worst_analytical << " fd=" << comparison.worst_fd;
+    EXPECT_TRUE(comparison.passed_) << "Process Jacobian mismatch: block=" << comparison.worst_block_
+                                   << " row=" << comparison.worst_row_ << " col=" << comparison.worst_col_
+                                   << " analytical=" << comparison.worst_analytical_ << " fd=" << comparison.worst_fd_;
 
     // Check sparsity completeness
     auto sparsity =
         micm::CheckJacobianSparsityCompleteness<DenseMatrix, SparseMatrixFD>(analytical_jac, fd_jac, num_species);
 
-    EXPECT_TRUE(sparsity.passed) << "Missing sparsity at block=" << sparsity.worst_block
-                                 << " row=" << sparsity.worst_row << " col=" << sparsity.worst_col
-                                 << " fd_value=" << sparsity.worst_fd;
+    EXPECT_TRUE(sparsity.passed_) << "Missing sparsity at block=" << sparsity.worst_block_
+                                 << " row=" << sparsity.worst_row_ << " col=" << sparsity.worst_col_
+                                 << " fd_value=" << sparsity.worst_fd_;
   }
 
   /// Helper to verify constraint Jacobian (residual-based) for a given model
@@ -167,17 +167,17 @@ namespace
         : micm::CompareJacobianToFiniteDifference<DenseMatrix, SparseMatrixFD>(
               analytical_jac, fd_jac, num_species);
 
-    EXPECT_TRUE(comparison.passed) << "Constraint Jacobian mismatch: block=" << comparison.worst_block
-                                   << " row=" << comparison.worst_row << " col=" << comparison.worst_col
-                                   << " analytical=" << comparison.worst_analytical << " fd=" << comparison.worst_fd;
+    EXPECT_TRUE(comparison.passed_) << "Constraint Jacobian mismatch: block=" << comparison.worst_block_
+                                   << " row=" << comparison.worst_row_ << " col=" << comparison.worst_col_
+                                   << " analytical=" << comparison.worst_analytical_ << " fd=" << comparison.worst_fd_;
 
     // Check sparsity completeness
     auto sparsity =
         micm::CheckJacobianSparsityCompleteness<DenseMatrix, SparseMatrixFD>(analytical_jac, fd_jac, num_species);
 
-    EXPECT_TRUE(sparsity.passed) << "Missing sparsity at block=" << sparsity.worst_block
-                                 << " row=" << sparsity.worst_row << " col=" << sparsity.worst_col
-                                 << " fd_value=" << sparsity.worst_fd;
+    EXPECT_TRUE(sparsity.passed_) << "Missing sparsity at block=" << sparsity.worst_block_
+                                 << " row=" << sparsity.worst_row_ << " col=" << sparsity.worst_col_
+                                 << " fd_value=" << sparsity.worst_fd_;
   }
 }  // namespace
 

--- a/test/unit/constraints/dissolved_equilibrium_constraint.cpp
+++ b/test/unit/constraints/dissolved_equilibrium_constraint.cpp
@@ -656,15 +656,15 @@ namespace
 
     // Compare analytical vs FD
     auto cmp = micm::CompareJacobianToFiniteDifference(jacobian, fd_jac, num_vars, 1e-5, 1e-5);
-    EXPECT_TRUE(cmp.passed) << "FD mismatch: block=" << cmp.worst_block << " row=" << cmp.worst_row
-                            << " col=" << cmp.worst_col << " +J(analytical)=" << cmp.worst_analytical
-                            << " +J(fd)=" << cmp.worst_fd;
+    EXPECT_TRUE(cmp.passed_) << "FD mismatch: block=" << cmp.worst_block_ << " row=" << cmp.worst_row_
+                            << " col=" << cmp.worst_col_ << " +J(analytical)=" << cmp.worst_analytical_
+                            << " +J(fd)=" << cmp.worst_fd_;
 
     // Verify no significant FD signal outside the declared sparsity pattern
     auto spc = micm::CheckJacobianSparsityCompleteness(jacobian, fd_jac, num_vars);
-    EXPECT_TRUE(spc.passed) << "Missing sparsity entry: block=" << spc.worst_block
-                            << " row=" << spc.worst_row << " col=" << spc.worst_col
-                            << " fd=" << spc.worst_fd;
+    EXPECT_TRUE(spc.passed_) << "Missing sparsity entry: block=" << spc.worst_block_
+                            << " row=" << spc.worst_row_ << " col=" << spc.worst_col_
+                            << " fd=" << spc.worst_fd_;
   }
 
 }  // namespace

--- a/test/unit/constraints/henry_law_equilibrium_constraint.cpp
+++ b/test/unit/constraints/henry_law_equilibrium_constraint.cpp
@@ -507,15 +507,15 @@ namespace
 
     // Compare analytical vs FD
     auto cmp = micm::CompareJacobianToFiniteDifference(jacobian, fd_jac, num_vars, 1e-5, 1e-5);
-    EXPECT_TRUE(cmp.passed) << "FD mismatch: block=" << cmp.worst_block << " row=" << cmp.worst_row
-                            << " col=" << cmp.worst_col << " +J(analytical)=" << cmp.worst_analytical
-                            << " +J(fd)=" << cmp.worst_fd;
+    EXPECT_TRUE(cmp.passed_) << "FD mismatch: block=" << cmp.worst_block_ << " row=" << cmp.worst_row_
+                            << " col=" << cmp.worst_col_ << " +J(analytical)=" << cmp.worst_analytical_
+                            << " +J(fd)=" << cmp.worst_fd_;
 
     // Verify no significant FD signal outside the declared sparsity pattern
     auto spc = micm::CheckJacobianSparsityCompleteness(jacobian, fd_jac, num_vars);
-    EXPECT_TRUE(spc.passed) << "Missing sparsity entry: block=" << spc.worst_block
-                            << " row=" << spc.worst_row << " col=" << spc.worst_col
-                            << " fd=" << spc.worst_fd;
+    EXPECT_TRUE(spc.passed_) << "Missing sparsity entry: block=" << spc.worst_block_
+                            << " row=" << spc.worst_row_ << " col=" << spc.worst_col_
+                            << " fd=" << spc.worst_fd_;
   }
 }  // namespace
 

--- a/test/unit/constraints/linear_constraint.cpp
+++ b/test/unit/constraints/linear_constraint.cpp
@@ -470,15 +470,15 @@ namespace
 
     // Compare analytical vs FD
     auto cmp = micm::CompareJacobianToFiniteDifference(jacobian, fd_jac, num_vars, 1e-5, 1e-5);
-    EXPECT_TRUE(cmp.passed) << "FD mismatch: block=" << cmp.worst_block << " row=" << cmp.worst_row
-                            << " col=" << cmp.worst_col << " +J(analytical)=" << cmp.worst_analytical
-                            << " +J(fd)=" << cmp.worst_fd;
+    EXPECT_TRUE(cmp.passed_) << "FD mismatch: block=" << cmp.worst_block_ << " row=" << cmp.worst_row_
+                            << " col=" << cmp.worst_col_ << " +J(analytical)=" << cmp.worst_analytical_
+                            << " +J(fd)=" << cmp.worst_fd_;
 
     // Verify no significant FD signal outside the declared sparsity pattern
     auto spc = micm::CheckJacobianSparsityCompleteness(jacobian, fd_jac, num_vars);
-    EXPECT_TRUE(spc.passed) << "Missing sparsity entry: block=" << spc.worst_block
-                            << " row=" << spc.worst_row << " col=" << spc.worst_col
-                            << " fd=" << spc.worst_fd;
+    EXPECT_TRUE(spc.passed_) << "Missing sparsity entry: block=" << spc.worst_block_
+                            << " row=" << spc.worst_row_ << " col=" << spc.worst_col_
+                            << " fd=" << spc.worst_fd_;
   }
 }  // namespace
 

--- a/test/unit/processes/dissolved_reaction.cpp
+++ b/test/unit/processes/dissolved_reaction.cpp
@@ -62,15 +62,15 @@ namespace
 
     // Compare analytical vs FD (MICM defaults: atol=1e-7, rtol=1e-7)
     auto cmp = micm::CompareJacobianToFiniteDifference(jacobian, fd_jac, num_vars);
-    EXPECT_TRUE(cmp.passed) << "FD mismatch: block=" << cmp.worst_block << " row=" << cmp.worst_row
-                            << " col=" << cmp.worst_col << " +J(analytical)=" << cmp.worst_analytical
-                            << " +J(fd)=" << cmp.worst_fd;
+    EXPECT_TRUE(cmp.passed_) << "FD mismatch: block=" << cmp.worst_block_ << " row=" << cmp.worst_row_
+                            << " col=" << cmp.worst_col_ << " +J(analytical)=" << cmp.worst_analytical_
+                            << " +J(fd)=" << cmp.worst_fd_;
 
     // Verify no significant FD signal outside the declared sparsity pattern
     auto spc = micm::CheckJacobianSparsityCompleteness(jacobian, fd_jac, num_vars);
-    EXPECT_TRUE(spc.passed) << "Missing sparsity entry: block=" << spc.worst_block
-                            << " row=" << spc.worst_row << " col=" << spc.worst_col
-                            << " fd=" << spc.worst_fd;
+    EXPECT_TRUE(spc.passed_) << "Missing sparsity entry: block=" << spc.worst_block_
+                            << " row=" << spc.worst_row_ << " col=" << spc.worst_col_
+                            << " fd=" << spc.worst_fd_;
   }
 }  // namespace
 

--- a/test/unit/processes/dissolved_reversible_reaction.cpp
+++ b/test/unit/processes/dissolved_reversible_reaction.cpp
@@ -59,15 +59,15 @@ namespace
 
     // Compare analytical vs FD (MICM defaults: atol=1e-7, rtol=1e-7)
     auto cmp = micm::CompareJacobianToFiniteDifference(jacobian, fd_jac, num_vars);
-    EXPECT_TRUE(cmp.passed) << "FD mismatch: block=" << cmp.worst_block << " row=" << cmp.worst_row
-                            << " col=" << cmp.worst_col << " +J(analytical)=" << cmp.worst_analytical
-                            << " +J(fd)=" << cmp.worst_fd;
+    EXPECT_TRUE(cmp.passed_) << "FD mismatch: block=" << cmp.worst_block_ << " row=" << cmp.worst_row_
+                            << " col=" << cmp.worst_col_ << " +J(analytical)=" << cmp.worst_analytical_
+                            << " +J(fd)=" << cmp.worst_fd_;
 
     // Verify no significant FD signal outside the declared sparsity pattern
     auto spc = micm::CheckJacobianSparsityCompleteness(jacobian, fd_jac, num_vars);
-    EXPECT_TRUE(spc.passed) << "Missing sparsity entry: block=" << spc.worst_block
-                            << " row=" << spc.worst_row << " col=" << spc.worst_col
-                            << " fd=" << spc.worst_fd;
+    EXPECT_TRUE(spc.passed_) << "Missing sparsity entry: block=" << spc.worst_block_
+                            << " row=" << spc.worst_row_ << " col=" << spc.worst_col_
+                            << " fd=" << spc.worst_fd_;
   }
 }  // namespace
 

--- a/test/unit/processes/henry_law_phase_transfer.cpp
+++ b/test/unit/processes/henry_law_phase_transfer.cpp
@@ -887,15 +887,15 @@ namespace
 
     // Compare analytical vs FD (MICM defaults: atol=1e-7, rtol=1e-7)
     auto cmp = micm::CompareJacobianToFiniteDifference(jacobian, fd_jac, num_vars);
-    EXPECT_TRUE(cmp.passed) << "FD mismatch: block=" << cmp.worst_block << " row=" << cmp.worst_row
-                            << " col=" << cmp.worst_col << " +J(analytical)=" << cmp.worst_analytical
-                            << " +J(fd)=" << cmp.worst_fd;
+    EXPECT_TRUE(cmp.passed_) << "FD mismatch: block=" << cmp.worst_block_ << " row=" << cmp.worst_row_
+                            << " col=" << cmp.worst_col_ << " +J(analytical)=" << cmp.worst_analytical_
+                            << " +J(fd)=" << cmp.worst_fd_;
 
     // Verify no significant FD signal outside the declared sparsity pattern
     auto spc = micm::CheckJacobianSparsityCompleteness(jacobian, fd_jac, num_vars);
-    EXPECT_TRUE(spc.passed) << "Missing sparsity entry: block=" << spc.worst_block
-                            << " row=" << spc.worst_row << " col=" << spc.worst_col
-                            << " fd=" << spc.worst_fd;
+    EXPECT_TRUE(spc.passed_) << "Missing sparsity entry: block=" << spc.worst_block_
+                            << " row=" << spc.worst_row_ << " col=" << spc.worst_col_
+                            << " fd=" << spc.worst_fd_;
   }
 
   /// @brief Create a provider that varies linearly with given state variables:

--- a/test/unit/representations/single_moment_mode.cpp
+++ b/test/unit/representations/single_moment_mode.cpp
@@ -13,7 +13,6 @@
 #include <unordered_map>
 
 using namespace miam;
-using namespace miam;
 
 TEST(SingleMomentMode, StateSize)
 {


### PR DESCRIPTION
MICM adds a missing trailing underscore to its structs and this PR applies the changes across the codebase. 
- Fixes the test failure
```C++ 
// failure
System(gas_phase, model);

// fix
System(gas_phase);
```