### PR TITLE
Investigate why mass conservation is not enforced when a model has multiple representations

### DIFF
--- a/include/miam/constraints/linear_constraint.hpp
+++ b/include/miam/constraints/linear_constraint.hpp
@@ -35,6 +35,15 @@ namespace miam
   ///          - If the algebraic species is in an instanced phase, one constraint is generated
   ///            per phase instance. Each constraint refers only to that instance's variables
   ///            (plus any non-instanced terms that are shared).
+  ///
+  ///          Limitation with multiple representations:
+  ///          When diagnose_from_state_ is false, the same constant_ is broadcast to every
+  ///          representation instance. A LinearConstraint with a fixed constant_ therefore
+  ///          cannot encode different conserved totals across representations (e.g., two
+  ///          droplets initialized to different amounts). In that case either set
+  ///          diagnose_from_state_ = true so the solver diagnoses a per-instance constant
+  ///          from the initial state, or omit the constraint if the system is already fully
+  ///          determined by the remaining equilibrium and charge constraints.
   class LinearConstraint
   {
    public:

--- a/test/integration/test_equilibrium_constraints.cpp
+++ b/test/integration/test_equilibrium_constraints.cpp
@@ -168,9 +168,10 @@ TEST(EquilibriumConstraintsIntegration, DissolvedEquilibriumWithKineticDriver)
 // Same chemistry as Test 1 (A → B kinetics, B <-> C equilibrium), but with
 // two differently-sized droplet representations (SMALL, LARGE) with different
 // initial concentrations. Only the equilibrium constraint is used (no mass
-// conservation constraint, since a single constant cannot serve instances with
-// different totals). The kinetics naturally conserve A+B, and C is purely
-// algebraic via the equilibrium relation C = K_eq * B.
+// conservation constraint). The system is fully determined: 1 algebraic
+// variable (C) and 1 equilibrium equation (C = K_eq * B) per instance.
+// The kinetics naturally conserve A+B, and C is purely algebraic via the
+// equilibrium relation C = K_eq * B.
 //
 // Analytical solution per instance (A0 = initial [A] for that instance):
 //   A(t) = A0 * exp(-k*t)


### PR DESCRIPTION
The test case in question where two droplets consists of an aerosol model is actually fully determined (2 ODE species + 1 algebraic species) and does not need any additional mass balance equations. 

Changes included in this PR:
- Clarifies and updates the comments in the test description.
- Updates `LinearConstraint` class documentation to note that :
  - when `diagnose_from_state_` is false, a single shared `constant_` value can't properly represent multiple aerosol models with different conserved totals. It only works when all instances share the same total.
  - Setting `diagnose_from_state_ = true` allows each instance to compute its own constant.
 
- Closes #34