### PR TITLE
Refactor DissolvedReactionBuilder APIs allowing for per-representation rate constants

### DIFF
--- a/include/miam/processes/dissolved_reaction.hpp
+++ b/include/miam/processes/dissolved_reaction.hpp
@@ -61,7 +61,8 @@ namespace miam
   class DissolvedReaction
   {
    public:
-    std::function<double(const micm::Conditions& conditions)> rate_constant_;  ///< Rate constant function
+    std::map<std::string, std::function<double(const micm::Conditions& conditions)>>
+        rate_constants_;  ///< Rate constant functions keyed by representation prefix
     std::vector<micm::Species> reactants_;                                     ///< Reactant species
     std::vector<micm::Species> products_;                                      ///< Product species
     micm::Species solvent_;                                                    ///< Solvent species
@@ -78,14 +79,14 @@ namespace miam
 
     /// @brief Constructor
     DissolvedReaction(
-        std::function<double(const micm::Conditions& conditions)> rate_constant,
+        std::map<std::string, std::function<double(const micm::Conditions& conditions)>> rate_constants,
         const std::vector<micm::Species>& reactants,
         const std::vector<micm::Species>& products,
         micm::Species solvent,
         micm::Phase phase,
         double solvent_floor = 1.0e-20,
         double min_halflife = 0.0)
-        : rate_constant_(rate_constant),
+        : rate_constants_(std::move(rate_constants)),
           reactants_(reactants),
           products_(products),
           solvent_(solvent),
@@ -100,7 +101,7 @@ namespace miam
     /// @return A new DissolvedReaction with the same properties but a unique UUID
     DissolvedReaction CopyWithNewUuid() const
     {
-      return DissolvedReaction(rate_constant_, reactants_, products_, solvent_, phase_, solvent_floor_, min_halflife_);
+      return DissolvedReaction(rate_constants_, reactants_, products_, solvent_, phase_, solvent_floor_, min_halflife_);
     }
 
     /// @brief Returns a set of unique parameter names for this process
@@ -109,11 +110,12 @@ namespace miam
     /// @return Set of unique parameter names for this process
     std::set<std::string> ProcessParameterNames(const std::map<std::string, std::set<std::string>>& phase_prefixes) const
     {
-      std::set<std::string> parameter_names;
-      // The conditions are shared by the whole system, so we just need one value for the rate
-      // constant. We can use the phase name and uuid to create a unique parameter name.
-      parameter_names.insert(phase_.name_ + "." + uuid_ + ".k");
-      return parameter_names;
+      std::set<std::string> names;
+      auto it = phase_prefixes.find(phase_.name_);
+      if (it != phase_prefixes.end())
+        for (const auto& prefix : it->second)
+          names.insert(prefix + "." + phase_.name_ + "." + uuid_ + ".k");
+      return names;
     }
 
     /// @brief Returns participating species' unique state names
@@ -235,29 +237,36 @@ namespace miam
         const auto& state_parameter_indices  // acts like std::unordered_map<std::string, std::size_t>
     ) const
     {
-      std::string k_param = phase_.name_ + "." + uuid_ + ".k";
-      if (state_parameter_indices.find(k_param) == state_parameter_indices.end())
+      std::vector<std::pair<std::size_t, std::function<double(const micm::Conditions&)>>> k_slots;
+      auto phase_it = phase_prefixes.find(phase_.name_);
+      for (const auto& prefix : phase_it->second)
       {
-        throw MiamException(
-            MIAM_ERROR_CATEGORY_INTERNAL,
-            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-            "Internal Error: UpdateStateParametersFunction: Rate constant parameter " + k_param +
-                " not found in state_parameter_indices");
+        std::string k_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k";
+        if (state_parameter_indices.find(k_param) == state_parameter_indices.end())
+          throw MiamException(
+              MIAM_ERROR_CATEGORY_INTERNAL,
+              MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+              "Internal Error: UpdateStateParametersFunction: Parameter " + k_param + " not found");
+        auto rate_it = rate_constants_.find(prefix);
+        if (rate_it == rate_constants_.end())
+          throw MiamException(
+              MIAM_ERROR_CATEGORY_CONFIGURATION,
+              MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
+              "DissolvedReaction: No rate constant configured for representation prefix '" + prefix + "'");
+        k_slots.push_back({ state_parameter_indices.at(k_param), rate_it->second });
       }
-      std::size_t k_index = state_parameter_indices.at(k_param);
 
-      // Set up dummy arguments to build the function
       DenseMatrixPolicy state_parameters{ 1, state_parameter_indices.size(), 0.0 };
       std::vector<micm::Conditions> conditions_vector;
 
-      // return a function that updates the rate constant parameter based on the current conditions
       return DenseMatrixPolicy::Function(
-          [this, k_index](auto&& conditions, auto&& params)
+          [k_slots](auto&& conditions, auto&& params)
           {
-            params.ForEachRow(
-                [&](const micm::Conditions& condition, double& parameter) { parameter = rate_constant_(condition); },
-                conditions,
-                params.GetColumnView(k_index));
+            for (const auto& [k_idx, rate_fn] : k_slots)
+              params.ForEachRow(
+                  [&](const micm::Conditions& cond, double& param) { param = rate_fn(cond); },
+                  conditions,
+                  params.GetColumnView(k_idx));
           },
           conditions_vector,
           state_parameters);
@@ -291,18 +300,18 @@ namespace miam
     ) const
     {
       StateVariableIndices variable_indices = GetStateVariableIndices(phase_prefixes, state_variable_indices);
-      std::size_t k_index = GetParameterIndex(state_parameter_indices);
+      std::vector<std::size_t> k_indices = GetParameterIndices(phase_prefixes, state_parameter_indices);
       DenseMatrixPolicy dummy_state_parameters{ 1, state_parameter_indices.size(), 0.0 };
       DenseMatrixPolicy dummy_state_variables{ 1, state_variable_indices.size(), 0.0 };
 
       if (min_halflife_ > 0.0)
       {
         return ForcingFunctionCapped<DenseMatrixPolicy>(
-            variable_indices, k_index, dummy_state_parameters, dummy_state_variables);
+            variable_indices, k_indices, dummy_state_parameters, dummy_state_variables);
       }
 
       return DenseMatrixPolicy::Function(
-          [this, variable_indices, k_index](auto&& state_parameters, auto&& state_variables, auto&& forcing_terms)
+          [this, variable_indices, k_indices](auto&& state_parameters, auto&& state_variables, auto&& forcing_terms)
           {
             auto rate = forcing_terms.GetRowVariable();
             const double eps = solvent_floor_;
@@ -315,7 +324,7 @@ namespace miam
               state_parameters.ForEachRow(
                   [&](const double& rate_constant, const double& solvent, double& rate)
                   { rate = rate_constant * solvent / std::pow(solvent + eps, n_r); },
-                  state_parameters.GetConstColumnView(k_index),
+                  state_parameters.GetConstColumnView(k_indices[i_phase]),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   rate);
               for (std::size_t r = 0; r < reactants_.size(); ++r)
@@ -371,18 +380,18 @@ namespace miam
     {
       StateVariableIndices variable_indices = GetStateVariableIndices(phase_prefixes, state_variable_indices);
       JacobianIndices jacobian_indices = GetJacobianIndices(variable_indices, jacobian);
-      std::size_t k_index = GetParameterIndex(state_parameter_indices);
+      std::vector<std::size_t> k_indices = GetParameterIndices(phase_prefixes, state_parameter_indices);
       DenseMatrixPolicy dummy_state_parameters{ 1, state_parameter_indices.size(), 0.0 };
       DenseMatrixPolicy dummy_state_variables{ 1, state_variable_indices.size(), 0.0 };
 
       if (min_halflife_ > 0.0)
       {
         return JacobianFunctionCapped<DenseMatrixPolicy, SparseMatrixPolicy>(
-            variable_indices, jacobian_indices, k_index, dummy_state_parameters, dummy_state_variables, jacobian);
+            variable_indices, jacobian_indices, k_indices, dummy_state_parameters, dummy_state_variables, jacobian);
       }
 
       return SparseMatrixPolicy::Function(
-          [this, variable_indices, jacobian_indices, k_index](
+          [this, variable_indices, jacobian_indices, k_indices](
               auto&& state_parameters, auto&& state_variables, auto&& jacobian_values)
           {
             auto d_rate_d_ind = jacobian_values.GetBlockVariable();
@@ -400,7 +409,7 @@ namespace miam
                 jacobian_values.ForEachBlock(
                     [&](const double& rate_constant, const double& solvent, double& partial)
                     { partial = rate_constant * solvent / std::pow(solvent + eps, n_r); },
-                    state_parameters.GetConstColumnView(k_index),
+                    state_parameters.GetConstColumnView(k_indices[i_phase]),
                     state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                     d_rate_d_ind);
                 // add contributions to the partial from the other reactants
@@ -437,7 +446,7 @@ namespace miam
                     partial =
                         rate_constant * (eps + (1.0 - static_cast<int>(n_r)) * solvent) / std::pow(solvent + eps, n_r + 1);
                   },
-                  state_parameters.GetConstColumnView(k_index),
+                  state_parameters.GetConstColumnView(k_indices[i_phase]),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   d_rate_d_ind);
               // add contributions to the partial from the reactants
@@ -502,12 +511,12 @@ namespace miam
     template<typename DenseMatrixPolicy>
     auto ForcingFunctionCapped(
         const StateVariableIndices& variable_indices,
-        std::size_t k_index,
+        const std::vector<std::size_t>& k_indices,
         DenseMatrixPolicy& dummy_state_parameters,
         DenseMatrixPolicy& dummy_state_variables) const
     {
       return DenseMatrixPolicy::Function(
-          [this, variable_indices, k_index](auto&& state_parameters, auto&& state_variables, auto&& forcing_terms)
+          [this, variable_indices, k_indices](auto&& state_parameters, auto&& state_variables, auto&& forcing_terms)
           {
             auto rate = forcing_terms.GetRowVariable();
             auto accum = forcing_terms.GetRowVariable();
@@ -521,7 +530,7 @@ namespace miam
               state_parameters.ForEachRow(
                   [&](const double& rate_constant, const double& solvent, double& rate)
                   { rate = rate_constant * solvent / std::pow(solvent + eps, n_r); },
-                  state_parameters.GetConstColumnView(k_index),
+                  state_parameters.GetConstColumnView(k_indices[i_phase]),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   rate);
               for (std::size_t r = 0; r < n_r; ++r)
@@ -592,13 +601,13 @@ namespace miam
     auto JacobianFunctionCapped(
         const StateVariableIndices& variable_indices,
         const JacobianIndices& jacobian_indices,
-        std::size_t k_index,
+        const std::vector<std::size_t>& k_indices,
         DenseMatrixPolicy& dummy_state_parameters,
         DenseMatrixPolicy& dummy_state_variables,
         const SparseMatrixPolicy& jacobian) const
     {
       return SparseMatrixPolicy::Function(
-          [this, variable_indices, jacobian_indices, k_index](
+          [this, variable_indices, jacobian_indices, k_indices](
               auto&& state_parameters, auto&& state_variables, auto&& jacobian_values)
           {
             auto d_rate_d_ind = jacobian_values.GetBlockVariable();
@@ -617,7 +626,7 @@ namespace miam
               jacobian_values.ForEachBlock(
                   [&](const double& rate_constant, const double& solvent, double& rr)
                   { rr = rate_constant * solvent / std::pow(solvent + eps, n_r); },
-                  state_parameters.GetConstColumnView(k_index),
+                  state_parameters.GetConstColumnView(k_indices[i_phase]),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   raw_rate);
               for (std::size_t r = 0; r < n_r; ++r)
@@ -672,7 +681,7 @@ namespace miam
                 jacobian_values.ForEachBlock(
                     [&](const double& rate_constant, const double& solvent, double& partial)
                     { partial = rate_constant * solvent / std::pow(solvent + eps, n_r); },
-                    state_parameters.GetConstColumnView(k_index),
+                    state_parameters.GetConstColumnView(k_indices[i_phase]),
                     state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                     d_rate_d_ind);
                 for (std::size_t r = 0; r < n_r; ++r)
@@ -723,7 +732,7 @@ namespace miam
                     partial =
                         rate_constant * (eps + (1.0 - static_cast<int>(n_r)) * solvent) / std::pow(solvent + eps, n_r + 1);
                   },
-                  state_parameters.GetConstColumnView(k_index),
+                  state_parameters.GetConstColumnView(k_indices[i_phase]),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   d_rate_d_ind);
               for (std::size_t r = 0; r < n_r; ++r)
@@ -761,21 +770,30 @@ namespace miam
           jacobian);
     }
 
-    /// @brief Helper function to return parameter index for the rate constant
-    std::size_t GetParameterIndex(
+    /// @brief Returns one parameter index per phase instance, in the same prefix-sorted order as GetStateVariableIndices
+    std::vector<std::size_t> GetParameterIndices(
+        const std::map<std::string, std::set<std::string>>& phase_prefixes,
         const auto& state_parameter_indices  // acts like std::unordered_map<std::string, std::size_t>
     ) const
     {
-      std::string k_param = phase_.name_ + "." + uuid_ + ".k";
-      if (state_parameter_indices.find(k_param) == state_parameter_indices.end())
-      {
+      std::vector<std::size_t> indices;
+      auto phase_it = phase_prefixes.find(phase_.name_);
+      if (phase_it == phase_prefixes.end())
         throw MiamException(
             MIAM_ERROR_CATEGORY_INTERNAL,
-            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-            "Internal Error: GetParameterIndex: Rate constant parameter " + k_param +
-                " not found in state_parameter_indices");
+            MIAM_INTERNAL_MISSING_PHASE_PREFIX,
+            "Internal Error: GetParameterIndices: Phase " + phase_.name_ + " not found in phase_prefixes");
+      for (const auto& prefix : phase_it->second)
+      {
+        std::string k_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k";
+        if (state_parameter_indices.find(k_param) == state_parameter_indices.end())
+          throw MiamException(
+              MIAM_ERROR_CATEGORY_INTERNAL,
+              MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+              "Internal Error: GetParameterIndices: Parameter " + k_param + " not found in state_parameter_indices");
+        indices.push_back(state_parameter_indices.at(k_param));
       }
-      return state_parameter_indices.at(k_param);
+      return indices;
     }
 
     /// @brief Helper function to return variable indices for all species involved in the reaction
@@ -786,13 +804,6 @@ namespace miam
     {
       StateVariableIndices indices;
       auto phase_it = phase_prefixes.find(phase_.name_);
-      if (phase_it == phase_prefixes.end())
-      {
-        throw MiamException(
-            MIAM_ERROR_CATEGORY_INTERNAL,
-            MIAM_INTERNAL_MISSING_PHASE_PREFIX,
-            "Internal Error: GetStateVariableIndices: Phase " + phase_.name_ + " not found in phase_prefixes");
-      }
       const auto& prefixes = phase_it->second;
       indices.number_of_phase_instances_ = prefixes.size();
       indices.reactant_indices_ = micm::Matrix<std::size_t>(prefixes.size(), reactants_.size());

--- a/include/miam/processes/dissolved_reaction_builder.hpp
+++ b/include/miam/processes/dissolved_reaction_builder.hpp
@@ -10,6 +10,8 @@
 #include <micm/system/conditions.hpp>
 
 #include <functional>
+#include <map>
+#include <string>
 
 namespace miam
 {
@@ -68,33 +70,24 @@ namespace miam
       return *this;
     }
 
-    /// @brief Sets the rate constant from an object with a Calculate method
-    template<typename T>
-      requires requires(const T& t, const micm::Conditions& c) {
-        { t.Calculate(c) };
-      }
-    DissolvedReactionBuilder& SetRateConstant(const T& rate_constant)
+    /// @brief Adds a rate constant for a specific representation prefix
+    DissolvedReactionBuilder& AddRateConstant(
+        const std::string& prefix,
+        std::function<double(const micm::Conditions&)> rate_constant)
     {
-      rate_constant_ = [rate_constant](const micm::Conditions& conditions) { return rate_constant.Calculate(conditions); };
-      return *this;
-    }
-
-    /// @brief Sets the rate constant from a std::function or lambda
-    DissolvedReactionBuilder& SetRateConstant(std::function<double(const micm::Conditions&)> rate_constant)
-    {
-      rate_constant_ = std::move(rate_constant);
+      rate_constants_[prefix] = std::move(rate_constant);
       return *this;
     }
 
     /// @brief Builds and returns the DissolvedReaction object
     DissolvedReaction Build() const
     {
-      if (!rate_constant_)
+      if (rate_constants_.empty())
       {
         throw MiamException(
             MIAM_ERROR_CATEGORY_CONFIGURATION,
             MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
-            "DissolvedReactionBuilder requires the rate constant to be set.");
+            "DissolvedReactionBuilder requires at least one rate constant via AddRateConstant.");
       }
       if (reactants_.empty())
       {
@@ -124,7 +117,7 @@ namespace miam
             MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
             "DissolvedReactionBuilder requires the solvent to be set.");
       }
-      return DissolvedReaction(rate_constant_, reactants_, products_, solvent_, phase_, solvent_floor_, min_halflife_);
+      return DissolvedReaction(rate_constants_, reactants_, products_, solvent_, phase_, solvent_floor_, min_halflife_);
     }
 
    private:
@@ -134,7 +127,7 @@ namespace miam
     std::vector<micm::Species> products_;                                      ///< Product species
     micm::Species solvent_;                                                    ///< Solvent species
     bool solvent_is_set_ = false;                                              ///< Flag to track if the solvent has been set
-    std::function<double(const micm::Conditions& conditions)> rate_constant_;  ///< Rate constant function
+    std::map<std::string, std::function<double(const micm::Conditions& conditions)>> rate_constants_;  ///< Per-prefix rate constants
     double solvent_floor_{ 1.0e-20 };  ///< Floor δ [mol m⁻³] added to [S] in ([S]+δ)^n denominator; see SetSolventFloor()
     double min_halflife_{ 0.0 };       ///< Minimum half-life for rate capping [s]
   };

--- a/include/miam/processes/dissolved_reversible_reaction.hpp
+++ b/include/miam/processes/dissolved_reversible_reaction.hpp
@@ -56,10 +56,14 @@ namespace miam
     double solvent_floor_{
       1.0e-20
     };  ///< Floor [mol m⁻³] added to [S] in ([S]+δ)^n denominator to prevent singularity as [S] → 0
+    std::map<std::string, std::function<double(const micm::Conditions& conditions)>>
+        forward_rate_constants_{};  ///< Per-prefix forward rates; when non-empty, overrides forward_rate_constant_
+    std::map<std::string, std::function<double(const micm::Conditions& conditions)>>
+        reverse_rate_constants_{};  ///< Per-prefix reverse rates; when non-empty, overrides reverse_rate_constant_
 
     DissolvedReversibleReaction() = delete;
 
-    /// @brief Constructor
+    /// @brief Constructor — shared rates (all instances use the same forward and reverse rate functions)
     DissolvedReversibleReaction(
         std::function<double(const micm::Conditions& conditions)> forward_rate_constant,
         std::function<double(const micm::Conditions& conditions)> reverse_rate_constant,
@@ -79,10 +83,33 @@ namespace miam
     {
     }
 
+    /// @brief Constructor — per-representation rates (each prefix gets its own forward and reverse rate functions)
+    DissolvedReversibleReaction(
+        std::map<std::string, std::function<double(const micm::Conditions& conditions)>> forward_rate_constants,
+        std::map<std::string, std::function<double(const micm::Conditions& conditions)>> reverse_rate_constants,
+        const std::vector<micm::Species>& reactants,
+        const std::vector<micm::Species>& products,
+        micm::Species solvent,
+        micm::Phase phase,
+        double solvent_floor = 1.0e-20)
+        : reactants_(reactants),
+          products_(products),
+          solvent_(solvent),
+          phase_(phase),
+          uuid_(GenerateUuid()),
+          solvent_floor_(solvent_floor),
+          forward_rate_constants_(std::move(forward_rate_constants)),
+          reverse_rate_constants_(std::move(reverse_rate_constants))
+    {
+    }
+
     /// @brief Create a copy of this reaction with a new UUID
     /// @return A new DissolvedReversibleReaction with the same properties but a unique UUID
     DissolvedReversibleReaction CopyWithNewUuid() const
     {
+      if (!forward_rate_constants_.empty())
+        return DissolvedReversibleReaction(
+            forward_rate_constants_, reverse_rate_constants_, reactants_, products_, solvent_, phase_, solvent_floor_);
       return DissolvedReversibleReaction(
           forward_rate_constant_, reverse_rate_constant_, reactants_, products_, solvent_, phase_, solvent_floor_);
     }
@@ -93,11 +120,24 @@ namespace miam
     /// @return Set of unique parameter names for this process
     std::set<std::string> ProcessParameterNames(const std::map<std::string, std::set<std::string>>& phase_prefixes) const
     {
-      // The conditions are shared by the whole system, so we just need one value each for the forward and reverse rate
-      // constants. We can use the phase name and uuid to create unique parameter names.
       std::set<std::string> parameter_names;
-      parameter_names.insert(phase_.name_ + "." + uuid_ + ".k_forward");
-      parameter_names.insert(phase_.name_ + "." + uuid_ + ".k_reverse");
+      if (forward_rate_constants_.empty())
+      {
+        // Shared mode: one slot each for all instances
+        parameter_names.insert(phase_.name_ + "." + uuid_ + ".k_forward");
+        parameter_names.insert(phase_.name_ + "." + uuid_ + ".k_reverse");
+      }
+      else
+      {
+        // Per-prefix mode: one slot per representation prefix
+        auto phase_it = phase_prefixes.find(phase_.name_);
+        if (phase_it != phase_prefixes.end())
+          for (const auto& prefix : phase_it->second)
+          {
+            parameter_names.insert(prefix + "." + phase_.name_ + "." + uuid_ + ".k_forward");
+            parameter_names.insert(prefix + "." + phase_.name_ + "." + uuid_ + ".k_reverse");
+          }
+      }
       return parameter_names;
     }
 
@@ -234,47 +274,88 @@ namespace miam
         const auto& state_parameter_indices  // acts like std::unordered_map<std::string, std::size_t>
     ) const
     {
-      // throw an error if the expected parameters don't exist
-      std::string forward_param = phase_.name_ + "." + uuid_ + ".k_forward";
-      std::string reverse_param = phase_.name_ + "." + uuid_ + ".k_reverse";
-      if (state_parameter_indices.find(forward_param) == state_parameter_indices.end())
-      {
-        throw MiamException(
-            MIAM_ERROR_CATEGORY_INTERNAL,
-            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-            "Internal Error: UpdateStateParametersFunction: Forward rate constant parameter " + forward_param +
-                " not found in state_parameter_indices");
-      }
-      if (state_parameter_indices.find(reverse_param) == state_parameter_indices.end())
-      {
-        throw MiamException(
-            MIAM_ERROR_CATEGORY_INTERNAL,
-            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-            "Internal Error: UpdateStateParametersFunction: Reverse rate constant parameter " + reverse_param +
-                " not found in state_parameter_indices");
-      }
-      std::size_t forward_index = state_parameter_indices.at(forward_param);
-      std::size_t reverse_index = state_parameter_indices.at(reverse_param);
-
-      // Set up dummy arguments to build the function
       DenseMatrixPolicy state_parameters{ 1, state_parameter_indices.size(), 0.0 };
       std::vector<micm::Conditions> conditions_vector;
 
-      // return a function that updates the forward and reverse rate constant parameters based on the current conditions
-      return DenseMatrixPolicy::Function(
-          [this, forward_index, reverse_index](auto&& conditions, auto&& params)
-          {
-            params.ForEachRow(
-                [&](const micm::Conditions& condition, double& parameter) { parameter = forward_rate_constant_(condition); },
-                conditions,
-                params.GetColumnView(forward_index));
-            params.ForEachRow(
-                [&](const micm::Conditions& condition, double& parameter) { parameter = reverse_rate_constant_(condition); },
-                conditions,
-                params.GetColumnView(reverse_index));
-          },
-          conditions_vector,
-          state_parameters);
+      if (forward_rate_constants_.empty())
+      {
+        // Shared mode: existing single-slot path
+        std::string forward_param = phase_.name_ + "." + uuid_ + ".k_forward";
+        std::string reverse_param = phase_.name_ + "." + uuid_ + ".k_reverse";
+        if (state_parameter_indices.find(forward_param) == state_parameter_indices.end())
+          throw MiamException(
+              MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+              "Internal Error: UpdateStateParametersFunction: " + forward_param + " not found");
+        if (state_parameter_indices.find(reverse_param) == state_parameter_indices.end())
+          throw MiamException(
+              MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+              "Internal Error: UpdateStateParametersFunction: " + reverse_param + " not found");
+        std::size_t forward_index = state_parameter_indices.at(forward_param);
+        std::size_t reverse_index = state_parameter_indices.at(reverse_param);
+        return DenseMatrixPolicy::Function(
+            [this, forward_index, reverse_index](auto&& conditions, auto&& params)
+            {
+              params.ForEachRow(
+                  [&](const micm::Conditions& c, double& p) { p = forward_rate_constant_(c); },
+                  conditions,
+                  params.GetColumnView(forward_index));
+              params.ForEachRow(
+                  [&](const micm::Conditions& c, double& p) { p = reverse_rate_constant_(c); },
+                  conditions,
+                  params.GetColumnView(reverse_index));
+            },
+            conditions_vector,
+            state_parameters);
+      }
+      else
+      {
+        // Per-prefix mode: one slot per representation
+        auto phase_it = phase_prefixes.find(phase_.name_);
+        if (phase_it == phase_prefixes.end())
+          throw MiamException(
+              MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_PHASE_PREFIX,
+              "Internal Error: UpdateStateParametersFunction: Phase " + phase_.name_ + " not found");
+
+        using RateFn = std::function<double(const micm::Conditions&)>;
+        std::vector<std::pair<std::size_t, RateFn>> fwd_slots, rev_slots;
+        for (const auto& prefix : phase_it->second)
+        {
+          std::string fwd_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k_forward";
+          std::string rev_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k_reverse";
+          if (state_parameter_indices.find(fwd_param) == state_parameter_indices.end())
+            throw MiamException(
+                MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+                "Internal Error: UpdateStateParametersFunction: " + fwd_param + " not found");
+          if (state_parameter_indices.find(rev_param) == state_parameter_indices.end())
+            throw MiamException(
+                MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+                "Internal Error: UpdateStateParametersFunction: " + rev_param + " not found");
+          auto fwd_it = forward_rate_constants_.find(prefix);
+          auto rev_it = reverse_rate_constants_.find(prefix);
+          if (fwd_it == forward_rate_constants_.end())
+            throw MiamException(
+                MIAM_ERROR_CATEGORY_CONFIGURATION, MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
+                "DissolvedReversibleReaction: No forward rate for prefix '" + prefix + "'");
+          if (rev_it == reverse_rate_constants_.end())
+            throw MiamException(
+                MIAM_ERROR_CATEGORY_CONFIGURATION, MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
+                "DissolvedReversibleReaction: No reverse rate for prefix '" + prefix + "'");
+          fwd_slots.push_back({ state_parameter_indices.at(fwd_param), fwd_it->second });
+          rev_slots.push_back({ state_parameter_indices.at(rev_param), rev_it->second });
+        }
+        return DenseMatrixPolicy::Function(
+            [fwd_slots, rev_slots](auto&& conditions, auto&& params)
+            {
+              for (const auto& [idx, fn] : fwd_slots)
+                params.ForEachRow(
+                    [&](const micm::Conditions& c, double& p) { p = fn(c); }, conditions, params.GetColumnView(idx));
+              for (const auto& [idx, fn] : rev_slots)
+                params.ForEachRow(
+                    [&](const micm::Conditions& c, double& p) { p = fn(c); }, conditions, params.GetColumnView(idx));
+            },
+            conditions_vector,
+            state_parameters);
+      }
     }
 
     /// @brief Returns a function that calculates the forcing terms for this process
@@ -305,11 +386,11 @@ namespace miam
     ) const
     {
       StateVariableIndices variable_indices = GetStateVariableIndices(phase_prefixes, state_variable_indices);
-      auto [forward_index, reverse_index] = GetParameterIndices(state_parameter_indices);
+      auto [forward_indices, reverse_indices] = GetParameterIndices(phase_prefixes, state_parameter_indices);
       DenseMatrixPolicy dummy_state_parameters{ 1, state_parameter_indices.size(), 0.0 };
       DenseMatrixPolicy dummy_state_variables{ 1, state_variable_indices.size(), 0.0 };
       return DenseMatrixPolicy::Function(
-          [this, variable_indices, forward_index, reverse_index](
+          [this, variable_indices, forward_indices, reverse_indices](
               auto&& state_parameters, auto&& state_variables, auto&& forcing_terms)
           {
             auto forward_rate = forcing_terms.GetRowVariable();
@@ -332,8 +413,8 @@ namespace miam
                     forward_rate = forward_rate_constant * solvent / std::pow(solvent + eps, n_r);
                     reverse_rate = reverse_rate_constant * solvent / std::pow(solvent + eps, n_p);
                   },
-                  state_parameters.GetConstColumnView(forward_index),
-                  state_parameters.GetConstColumnView(reverse_index),
+                  state_parameters.GetConstColumnView(forward_indices[i_phase]),
+                  state_parameters.GetConstColumnView(reverse_indices[i_phase]),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   forward_rate,
                   reverse_rate);
@@ -407,11 +488,11 @@ namespace miam
     {
       StateVariableIndices variable_indices = GetStateVariableIndices(phase_prefixes, state_variable_indices);
       JacobianIndices jacobian_indices = GetJacobianIndices(variable_indices, jacobian);
-      auto [forward_index, reverse_index] = GetParameterIndices(state_parameter_indices);
+      auto [forward_indices, reverse_indices] = GetParameterIndices(phase_prefixes, state_parameter_indices);
       DenseMatrixPolicy dummy_state_parameters{ 1, state_parameter_indices.size(), 0.0 };
       DenseMatrixPolicy dummy_state_variables{ 1, state_variable_indices.size(), 0.0 };
       return SparseMatrixPolicy::Function(
-          [this, variable_indices, jacobian_indices, forward_index, reverse_index](
+          [this, variable_indices, jacobian_indices, forward_indices, reverse_indices](
               auto&& state_parameters, auto&& state_variables, auto&& jacobian_values)
           {
             auto d_forward_rate_d_ind = jacobian_values.GetBlockVariable();
@@ -431,7 +512,7 @@ namespace miam
                 jacobian_values.ForEachBlock(
                     [&](const double& forward_rate_constant, const double& solvent, double& partial)
                     { partial = forward_rate_constant * solvent / std::pow(solvent + eps, n_r); },
-                    state_parameters.GetConstColumnView(forward_index),
+                    state_parameters.GetConstColumnView(forward_indices[i_phase]),
                     state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                     d_forward_rate_d_ind);
                 // add contributions to the partial from the other reactants
@@ -468,7 +549,7 @@ namespace miam
                 jacobian_values.ForEachBlock(
                     [&](const double& reverse_rate_constant, const double& solvent, double& partial)
                     { partial = reverse_rate_constant * solvent / std::pow(solvent + eps, n_p); },
-                    state_parameters.GetConstColumnView(reverse_index),
+                    state_parameters.GetConstColumnView(reverse_indices[i_phase]),
                     state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                     d_reverse_rate_d_ind);
                 // add contributions to the partial from the other products
@@ -512,8 +593,8 @@ namespace miam
                     reverse_partial = reverse_rate_constant * (eps + (1.0 - static_cast<int>(n_p)) * solvent) /
                                       std::pow(solvent + eps, n_p + 1);
                   },
-                  state_parameters.GetConstColumnView(forward_index),
-                  state_parameters.GetConstColumnView(reverse_index),
+                  state_parameters.GetConstColumnView(forward_indices[i_phase]),
+                  state_parameters.GetConstColumnView(reverse_indices[i_phase]),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   d_forward_rate_d_ind,
                   d_reverse_rate_d_ind);
@@ -586,30 +667,56 @@ namespace miam
           indices_;  // Index in sparse matrix for each dependent/independent pair (num_pairs x num_prefixes)
     };
 
-    /// @brief Helper function to return parameter indices for the forward and reverse rate constants
-    std::pair<std::size_t, std::size_t> GetParameterIndices(
+    /// @brief Returns per-instance forward and reverse parameter indices in prefix-sorted order
+    std::pair<std::vector<std::size_t>, std::vector<std::size_t>> GetParameterIndices(
+        const std::map<std::string, std::set<std::string>>& phase_prefixes,
         const auto& state_parameter_indices  // acts like std::unordered_map<std::string, std::size_t>
     ) const
     {
-      std::string forward_param = phase_.name_ + "." + uuid_ + ".k_forward";
-      std::string reverse_param = phase_.name_ + "." + uuid_ + ".k_reverse";
-      if (state_parameter_indices.find(forward_param) == state_parameter_indices.end())
+      std::vector<std::size_t> forward_indices, reverse_indices;
+      if (forward_rate_constants_.empty())
       {
-        throw MiamException(
-            MIAM_ERROR_CATEGORY_INTERNAL,
-            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-            "Internal Error: GetParameterIndices: Forward rate constant parameter " + forward_param +
-                " not found in state_parameter_indices");
+        // Shared mode: fill N copies of the single shared slot
+        std::string fwd_param = phase_.name_ + "." + uuid_ + ".k_forward";
+        std::string rev_param = phase_.name_ + "." + uuid_ + ".k_reverse";
+        if (state_parameter_indices.find(fwd_param) == state_parameter_indices.end())
+          throw MiamException(
+              MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+              "Internal Error: GetParameterIndices: " + fwd_param + " not found");
+        if (state_parameter_indices.find(rev_param) == state_parameter_indices.end())
+          throw MiamException(
+              MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+              "Internal Error: GetParameterIndices: " + rev_param + " not found");
+        auto phase_it = phase_prefixes.find(phase_.name_);
+        std::size_t n = (phase_it != phase_prefixes.end()) ? phase_it->second.size() : 0;
+        forward_indices.assign(n, state_parameter_indices.at(fwd_param));
+        reverse_indices.assign(n, state_parameter_indices.at(rev_param));
       }
-      if (state_parameter_indices.find(reverse_param) == state_parameter_indices.end())
+      else
       {
-        throw MiamException(
-            MIAM_ERROR_CATEGORY_INTERNAL,
-            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-            "Internal Error: GetParameterIndices: Reverse rate constant parameter " + reverse_param +
-                " not found in state_parameter_indices");
+        // Per-prefix mode: one slot per prefix
+        auto phase_it = phase_prefixes.find(phase_.name_);
+        if (phase_it == phase_prefixes.end())
+          throw MiamException(
+              MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_PHASE_PREFIX,
+              "Internal Error: GetParameterIndices: Phase " + phase_.name_ + " not found");
+        for (const auto& prefix : phase_it->second)
+        {
+          std::string fwd_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k_forward";
+          std::string rev_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k_reverse";
+          if (state_parameter_indices.find(fwd_param) == state_parameter_indices.end())
+            throw MiamException(
+                MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+                "Internal Error: GetParameterIndices: " + fwd_param + " not found");
+          if (state_parameter_indices.find(rev_param) == state_parameter_indices.end())
+            throw MiamException(
+                MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+                "Internal Error: GetParameterIndices: " + rev_param + " not found");
+          forward_indices.push_back(state_parameter_indices.at(fwd_param));
+          reverse_indices.push_back(state_parameter_indices.at(rev_param));
+        }
       }
-      return { state_parameter_indices.at(forward_param), state_parameter_indices.at(reverse_param) };
+      return { forward_indices, reverse_indices };
     }
 
     /// @brief Helper function to return variable indices for all species involved in the reaction

--- a/include/miam/processes/dissolved_reversible_reaction.hpp
+++ b/include/miam/processes/dissolved_reversible_reaction.hpp
@@ -56,10 +56,6 @@ namespace miam
     double solvent_floor_{
       1.0e-20
     };  ///< Floor [mol m⁻³] added to [S] in ([S]+δ)^n denominator to prevent singularity as [S] → 0
-    std::map<std::string, std::function<double(const micm::Conditions& conditions)>>
-        forward_rate_constants_{};  ///< Per-prefix forward rates; when non-empty, overrides forward_rate_constant_
-    std::map<std::string, std::function<double(const micm::Conditions& conditions)>>
-        reverse_rate_constants_{};  ///< Per-prefix reverse rates; when non-empty, overrides reverse_rate_constant_
 
     DissolvedReversibleReaction() = delete;
 
@@ -83,33 +79,10 @@ namespace miam
     {
     }
 
-    /// @brief Constructor — per-representation rates (each prefix gets its own forward and reverse rate functions)
-    DissolvedReversibleReaction(
-        std::map<std::string, std::function<double(const micm::Conditions& conditions)>> forward_rate_constants,
-        std::map<std::string, std::function<double(const micm::Conditions& conditions)>> reverse_rate_constants,
-        const std::vector<micm::Species>& reactants,
-        const std::vector<micm::Species>& products,
-        micm::Species solvent,
-        micm::Phase phase,
-        double solvent_floor = 1.0e-20)
-        : reactants_(reactants),
-          products_(products),
-          solvent_(solvent),
-          phase_(phase),
-          uuid_(GenerateUuid()),
-          solvent_floor_(solvent_floor),
-          forward_rate_constants_(std::move(forward_rate_constants)),
-          reverse_rate_constants_(std::move(reverse_rate_constants))
-    {
-    }
-
     /// @brief Create a copy of this reaction with a new UUID
     /// @return A new DissolvedReversibleReaction with the same properties but a unique UUID
     DissolvedReversibleReaction CopyWithNewUuid() const
     {
-      if (!forward_rate_constants_.empty())
-        return DissolvedReversibleReaction(
-            forward_rate_constants_, reverse_rate_constants_, reactants_, products_, solvent_, phase_, solvent_floor_);
       return DissolvedReversibleReaction(
           forward_rate_constant_, reverse_rate_constant_, reactants_, products_, solvent_, phase_, solvent_floor_);
     }
@@ -120,24 +93,11 @@ namespace miam
     /// @return Set of unique parameter names for this process
     std::set<std::string> ProcessParameterNames(const std::map<std::string, std::set<std::string>>& phase_prefixes) const
     {
+      // The conditions are shared by the whole system, so we just need one value each for the forward and reverse rate
+      // constants. We can use the phase name and uuid to create unique parameter names.
       std::set<std::string> parameter_names;
-      if (forward_rate_constants_.empty())
-      {
-        // Shared mode: one slot each for all instances
-        parameter_names.insert(phase_.name_ + "." + uuid_ + ".k_forward");
-        parameter_names.insert(phase_.name_ + "." + uuid_ + ".k_reverse");
-      }
-      else
-      {
-        // Per-prefix mode: one slot per representation prefix
-        auto phase_it = phase_prefixes.find(phase_.name_);
-        if (phase_it != phase_prefixes.end())
-          for (const auto& prefix : phase_it->second)
-          {
-            parameter_names.insert(prefix + "." + phase_.name_ + "." + uuid_ + ".k_forward");
-            parameter_names.insert(prefix + "." + phase_.name_ + "." + uuid_ + ".k_reverse");
-          }
-      }
+      parameter_names.insert(phase_.name_ + "." + uuid_ + ".k_forward");
+      parameter_names.insert(phase_.name_ + "." + uuid_ + ".k_reverse");
       return parameter_names;
     }
 
@@ -274,88 +234,47 @@ namespace miam
         const auto& state_parameter_indices  // acts like std::unordered_map<std::string, std::size_t>
     ) const
     {
+      // throw an error if the expected parameters don't exist
+      std::string forward_param = phase_.name_ + "." + uuid_ + ".k_forward";
+      std::string reverse_param = phase_.name_ + "." + uuid_ + ".k_reverse";
+      if (state_parameter_indices.find(forward_param) == state_parameter_indices.end())
+      {
+        throw MiamException(
+            MIAM_ERROR_CATEGORY_INTERNAL,
+            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+            "Internal Error: UpdateStateParametersFunction: Forward rate constant parameter " + forward_param +
+                " not found in state_parameter_indices");
+      }
+      if (state_parameter_indices.find(reverse_param) == state_parameter_indices.end())
+      {
+        throw MiamException(
+            MIAM_ERROR_CATEGORY_INTERNAL,
+            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+            "Internal Error: UpdateStateParametersFunction: Reverse rate constant parameter " + reverse_param +
+                " not found in state_parameter_indices");
+      }
+      std::size_t forward_index = state_parameter_indices.at(forward_param);
+      std::size_t reverse_index = state_parameter_indices.at(reverse_param);
+
+      // Set up dummy arguments to build the function
       DenseMatrixPolicy state_parameters{ 1, state_parameter_indices.size(), 0.0 };
       std::vector<micm::Conditions> conditions_vector;
 
-      if (forward_rate_constants_.empty())
-      {
-        // Shared mode: existing single-slot path
-        std::string forward_param = phase_.name_ + "." + uuid_ + ".k_forward";
-        std::string reverse_param = phase_.name_ + "." + uuid_ + ".k_reverse";
-        if (state_parameter_indices.find(forward_param) == state_parameter_indices.end())
-          throw MiamException(
-              MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-              "Internal Error: UpdateStateParametersFunction: " + forward_param + " not found");
-        if (state_parameter_indices.find(reverse_param) == state_parameter_indices.end())
-          throw MiamException(
-              MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-              "Internal Error: UpdateStateParametersFunction: " + reverse_param + " not found");
-        std::size_t forward_index = state_parameter_indices.at(forward_param);
-        std::size_t reverse_index = state_parameter_indices.at(reverse_param);
-        return DenseMatrixPolicy::Function(
-            [this, forward_index, reverse_index](auto&& conditions, auto&& params)
-            {
-              params.ForEachRow(
-                  [&](const micm::Conditions& c, double& p) { p = forward_rate_constant_(c); },
-                  conditions,
-                  params.GetColumnView(forward_index));
-              params.ForEachRow(
-                  [&](const micm::Conditions& c, double& p) { p = reverse_rate_constant_(c); },
-                  conditions,
-                  params.GetColumnView(reverse_index));
-            },
-            conditions_vector,
-            state_parameters);
-      }
-      else
-      {
-        // Per-prefix mode: one slot per representation
-        auto phase_it = phase_prefixes.find(phase_.name_);
-        if (phase_it == phase_prefixes.end())
-          throw MiamException(
-              MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_PHASE_PREFIX,
-              "Internal Error: UpdateStateParametersFunction: Phase " + phase_.name_ + " not found");
-
-        using RateFn = std::function<double(const micm::Conditions&)>;
-        std::vector<std::pair<std::size_t, RateFn>> fwd_slots, rev_slots;
-        for (const auto& prefix : phase_it->second)
-        {
-          std::string fwd_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k_forward";
-          std::string rev_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k_reverse";
-          if (state_parameter_indices.find(fwd_param) == state_parameter_indices.end())
-            throw MiamException(
-                MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-                "Internal Error: UpdateStateParametersFunction: " + fwd_param + " not found");
-          if (state_parameter_indices.find(rev_param) == state_parameter_indices.end())
-            throw MiamException(
-                MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-                "Internal Error: UpdateStateParametersFunction: " + rev_param + " not found");
-          auto fwd_it = forward_rate_constants_.find(prefix);
-          auto rev_it = reverse_rate_constants_.find(prefix);
-          if (fwd_it == forward_rate_constants_.end())
-            throw MiamException(
-                MIAM_ERROR_CATEGORY_CONFIGURATION, MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
-                "DissolvedReversibleReaction: No forward rate for prefix '" + prefix + "'");
-          if (rev_it == reverse_rate_constants_.end())
-            throw MiamException(
-                MIAM_ERROR_CATEGORY_CONFIGURATION, MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
-                "DissolvedReversibleReaction: No reverse rate for prefix '" + prefix + "'");
-          fwd_slots.push_back({ state_parameter_indices.at(fwd_param), fwd_it->second });
-          rev_slots.push_back({ state_parameter_indices.at(rev_param), rev_it->second });
-        }
-        return DenseMatrixPolicy::Function(
-            [fwd_slots, rev_slots](auto&& conditions, auto&& params)
-            {
-              for (const auto& [idx, fn] : fwd_slots)
-                params.ForEachRow(
-                    [&](const micm::Conditions& c, double& p) { p = fn(c); }, conditions, params.GetColumnView(idx));
-              for (const auto& [idx, fn] : rev_slots)
-                params.ForEachRow(
-                    [&](const micm::Conditions& c, double& p) { p = fn(c); }, conditions, params.GetColumnView(idx));
-            },
-            conditions_vector,
-            state_parameters);
-      }
+      // return a function that updates the forward and reverse rate constant parameters based on the current conditions
+      return DenseMatrixPolicy::Function(
+          [this, forward_index, reverse_index](auto&& conditions, auto&& params)
+          {
+            params.ForEachRow(
+                [&](const micm::Conditions& condition, double& parameter) { parameter = forward_rate_constant_(condition); },
+                conditions,
+                params.GetColumnView(forward_index));
+            params.ForEachRow(
+                [&](const micm::Conditions& condition, double& parameter) { parameter = reverse_rate_constant_(condition); },
+                conditions,
+                params.GetColumnView(reverse_index));
+          },
+          conditions_vector,
+          state_parameters);
     }
 
     /// @brief Returns a function that calculates the forcing terms for this process
@@ -386,11 +305,11 @@ namespace miam
     ) const
     {
       StateVariableIndices variable_indices = GetStateVariableIndices(phase_prefixes, state_variable_indices);
-      auto [forward_indices, reverse_indices] = GetParameterIndices(phase_prefixes, state_parameter_indices);
+      auto [forward_index, reverse_index] = GetParameterIndices(state_parameter_indices);
       DenseMatrixPolicy dummy_state_parameters{ 1, state_parameter_indices.size(), 0.0 };
       DenseMatrixPolicy dummy_state_variables{ 1, state_variable_indices.size(), 0.0 };
       return DenseMatrixPolicy::Function(
-          [this, variable_indices, forward_indices, reverse_indices](
+          [this, variable_indices, forward_index, reverse_index](
               auto&& state_parameters, auto&& state_variables, auto&& forcing_terms)
           {
             auto forward_rate = forcing_terms.GetRowVariable();
@@ -413,8 +332,8 @@ namespace miam
                     forward_rate = forward_rate_constant * solvent / std::pow(solvent + eps, n_r);
                     reverse_rate = reverse_rate_constant * solvent / std::pow(solvent + eps, n_p);
                   },
-                  state_parameters.GetConstColumnView(forward_indices[i_phase]),
-                  state_parameters.GetConstColumnView(reverse_indices[i_phase]),
+                  state_parameters.GetConstColumnView(forward_index),
+                  state_parameters.GetConstColumnView(reverse_index),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   forward_rate,
                   reverse_rate);
@@ -488,11 +407,11 @@ namespace miam
     {
       StateVariableIndices variable_indices = GetStateVariableIndices(phase_prefixes, state_variable_indices);
       JacobianIndices jacobian_indices = GetJacobianIndices(variable_indices, jacobian);
-      auto [forward_indices, reverse_indices] = GetParameterIndices(phase_prefixes, state_parameter_indices);
+      auto [forward_index, reverse_index] = GetParameterIndices(state_parameter_indices);
       DenseMatrixPolicy dummy_state_parameters{ 1, state_parameter_indices.size(), 0.0 };
       DenseMatrixPolicy dummy_state_variables{ 1, state_variable_indices.size(), 0.0 };
       return SparseMatrixPolicy::Function(
-          [this, variable_indices, jacobian_indices, forward_indices, reverse_indices](
+          [this, variable_indices, jacobian_indices, forward_index, reverse_index](
               auto&& state_parameters, auto&& state_variables, auto&& jacobian_values)
           {
             auto d_forward_rate_d_ind = jacobian_values.GetBlockVariable();
@@ -512,7 +431,7 @@ namespace miam
                 jacobian_values.ForEachBlock(
                     [&](const double& forward_rate_constant, const double& solvent, double& partial)
                     { partial = forward_rate_constant * solvent / std::pow(solvent + eps, n_r); },
-                    state_parameters.GetConstColumnView(forward_indices[i_phase]),
+                    state_parameters.GetConstColumnView(forward_index),
                     state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                     d_forward_rate_d_ind);
                 // add contributions to the partial from the other reactants
@@ -549,7 +468,7 @@ namespace miam
                 jacobian_values.ForEachBlock(
                     [&](const double& reverse_rate_constant, const double& solvent, double& partial)
                     { partial = reverse_rate_constant * solvent / std::pow(solvent + eps, n_p); },
-                    state_parameters.GetConstColumnView(reverse_indices[i_phase]),
+                    state_parameters.GetConstColumnView(reverse_index),
                     state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                     d_reverse_rate_d_ind);
                 // add contributions to the partial from the other products
@@ -593,8 +512,8 @@ namespace miam
                     reverse_partial = reverse_rate_constant * (eps + (1.0 - static_cast<int>(n_p)) * solvent) /
                                       std::pow(solvent + eps, n_p + 1);
                   },
-                  state_parameters.GetConstColumnView(forward_indices[i_phase]),
-                  state_parameters.GetConstColumnView(reverse_indices[i_phase]),
+                  state_parameters.GetConstColumnView(forward_index),
+                  state_parameters.GetConstColumnView(reverse_index),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   d_forward_rate_d_ind,
                   d_reverse_rate_d_ind);
@@ -667,56 +586,30 @@ namespace miam
           indices_;  // Index in sparse matrix for each dependent/independent pair (num_pairs x num_prefixes)
     };
 
-    /// @brief Returns per-instance forward and reverse parameter indices in prefix-sorted order
-    std::pair<std::vector<std::size_t>, std::vector<std::size_t>> GetParameterIndices(
-        const std::map<std::string, std::set<std::string>>& phase_prefixes,
+    /// @brief Helper function to return parameter indices for the forward and reverse rate constants
+    std::pair<std::size_t, std::size_t> GetParameterIndices(
         const auto& state_parameter_indices  // acts like std::unordered_map<std::string, std::size_t>
     ) const
     {
-      std::vector<std::size_t> forward_indices, reverse_indices;
-      if (forward_rate_constants_.empty())
+      std::string forward_param = phase_.name_ + "." + uuid_ + ".k_forward";
+      std::string reverse_param = phase_.name_ + "." + uuid_ + ".k_reverse";
+      if (state_parameter_indices.find(forward_param) == state_parameter_indices.end())
       {
-        // Shared mode: fill N copies of the single shared slot
-        std::string fwd_param = phase_.name_ + "." + uuid_ + ".k_forward";
-        std::string rev_param = phase_.name_ + "." + uuid_ + ".k_reverse";
-        if (state_parameter_indices.find(fwd_param) == state_parameter_indices.end())
-          throw MiamException(
-              MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-              "Internal Error: GetParameterIndices: " + fwd_param + " not found");
-        if (state_parameter_indices.find(rev_param) == state_parameter_indices.end())
-          throw MiamException(
-              MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-              "Internal Error: GetParameterIndices: " + rev_param + " not found");
-        auto phase_it = phase_prefixes.find(phase_.name_);
-        std::size_t n = (phase_it != phase_prefixes.end()) ? phase_it->second.size() : 0;
-        forward_indices.assign(n, state_parameter_indices.at(fwd_param));
-        reverse_indices.assign(n, state_parameter_indices.at(rev_param));
+        throw MiamException(
+            MIAM_ERROR_CATEGORY_INTERNAL,
+            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+            "Internal Error: GetParameterIndices: Forward rate constant parameter " + forward_param +
+                " not found in state_parameter_indices");
       }
-      else
+      if (state_parameter_indices.find(reverse_param) == state_parameter_indices.end())
       {
-        // Per-prefix mode: one slot per prefix
-        auto phase_it = phase_prefixes.find(phase_.name_);
-        if (phase_it == phase_prefixes.end())
-          throw MiamException(
-              MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_PHASE_PREFIX,
-              "Internal Error: GetParameterIndices: Phase " + phase_.name_ + " not found");
-        for (const auto& prefix : phase_it->second)
-        {
-          std::string fwd_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k_forward";
-          std::string rev_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k_reverse";
-          if (state_parameter_indices.find(fwd_param) == state_parameter_indices.end())
-            throw MiamException(
-                MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-                "Internal Error: GetParameterIndices: " + fwd_param + " not found");
-          if (state_parameter_indices.find(rev_param) == state_parameter_indices.end())
-            throw MiamException(
-                MIAM_ERROR_CATEGORY_INTERNAL, MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-                "Internal Error: GetParameterIndices: " + rev_param + " not found");
-          forward_indices.push_back(state_parameter_indices.at(fwd_param));
-          reverse_indices.push_back(state_parameter_indices.at(rev_param));
-        }
+        throw MiamException(
+            MIAM_ERROR_CATEGORY_INTERNAL,
+            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+            "Internal Error: GetParameterIndices: Reverse rate constant parameter " + reverse_param +
+                " not found in state_parameter_indices");
       }
-      return { forward_indices, reverse_indices };
+      return { state_parameter_indices.at(forward_param), state_parameter_indices.at(reverse_param) };
     }
 
     /// @brief Helper function to return variable indices for all species involved in the reaction

--- a/include/miam/processes/dissolved_reversible_reaction_builder.hpp
+++ b/include/miam/processes/dissolved_reversible_reaction_builder.hpp
@@ -12,11 +12,15 @@
 #include <micm/system/conditions.hpp>
 
 #include <functional>
+#include <string>
 
 namespace miam
 {
   /// @brief A dissolved reversible reaction builder
   /// @details Builder class for constructing DissolvedReversibleReaction objects.
+  ///          Exactly two of SetForwardRateConstant, SetReverseRateConstant, and
+  ///          SetEquilibriumConstant must be called; the third is derived automatically.
+  ///          Rate constants are shared across all representations of the phase.
   class DissolvedReversibleReactionBuilder
   {
    public:
@@ -60,115 +64,145 @@ namespace miam
       return *this;
     }
 
-    /// @brief Sets the forward rate constant function
-    DissolvedReversibleReactionBuilder& SetForwardRateConstant(const auto& forward_rate_constant)
+    /// @brief Sets the forward rate constant function (shared across all representations)
+    DissolvedReversibleReactionBuilder& SetForwardRateConstant(
+        std::function<double(const micm::Conditions&)> forward_rate_constant)
     {
-      forward_rate_constant_ = [forward_rate_constant](const micm::Conditions& conditions)
-      { return forward_rate_constant.Calculate(conditions); };
+      forward_rate_constant_ = std::move(forward_rate_constant);
       return *this;
     }
 
-    /// @brief Sets the reverse rate constant function
-    DissolvedReversibleReactionBuilder& SetReverseRateConstant(const auto& reverse_rate_constant)
+    /// @brief Sets the forward rate constant from an object with a Calculate() method
+    template<typename RateConstantT>
+      requires requires(const RateConstantT& kc, const micm::Conditions& c) {
+        { kc.Calculate(c) } -> std::convertible_to<double>;
+      }
+    DissolvedReversibleReactionBuilder& SetForwardRateConstant(const RateConstantT& forward_rate_constant)
     {
-      reverse_rate_constant_ = [reverse_rate_constant](const micm::Conditions& conditions)
-      { return reverse_rate_constant.Calculate(conditions); };
+      forward_rate_constant_ = [forward_rate_constant](const micm::Conditions& c)
+      { return forward_rate_constant.Calculate(c); };
+      return *this;
+    }
+
+    /// @brief Sets the forward rate constant from Arrhenius parameters
+    DissolvedReversibleReactionBuilder& SetForwardRateConstant(
+        const micm::ArrheniusRateConstantParameters& forward_rate_constant)
+    {
+      forward_rate_constant_ = [forward_rate_constant](const micm::Conditions& c)
+      { return micm::CalculateArrhenius(forward_rate_constant, c.temperature_, c.pressure_); };
+      return *this;
+    }
+
+    /// @brief Sets the reverse rate constant function (shared across all representations)
+    DissolvedReversibleReactionBuilder& SetReverseRateConstant(
+        std::function<double(const micm::Conditions&)> reverse_rate_constant)
+    {
+      reverse_rate_constant_ = std::move(reverse_rate_constant);
+      return *this;
+    }
+
+    /// @brief Sets the reverse rate constant from an object with a Calculate() method
+    template<typename RateConstantT>
+      requires requires(const RateConstantT& kc, const micm::Conditions& c) {
+        { kc.Calculate(c) } -> std::convertible_to<double>;
+      }
+    DissolvedReversibleReactionBuilder& SetReverseRateConstant(const RateConstantT& reverse_rate_constant)
+    {
+      reverse_rate_constant_ = [reverse_rate_constant](const micm::Conditions& c)
+      { return reverse_rate_constant.Calculate(c); };
       return *this;
     }
 
     /// @brief Sets the reverse rate constant from Arrhenius parameters
-    DissolvedReversibleReactionBuilder& SetReverseRateConstant(const micm::ArrheniusRateConstantParameters& params)
+    DissolvedReversibleReactionBuilder& SetReverseRateConstant(
+        const micm::ArrheniusRateConstantParameters& reverse_rate_constant)
     {
-      reverse_rate_constant_ = [params](const micm::Conditions& conditions)
-      { return micm::CalculateArrhenius(params, conditions.temperature_, conditions.pressure_); };
+      reverse_rate_constant_ = [reverse_rate_constant](const micm::Conditions& c)
+      { return micm::CalculateArrhenius(reverse_rate_constant, c.temperature_, c.pressure_); };
       return *this;
     }
 
-    /// @brief Sets the equilibrium constant function
-    DissolvedReversibleReactionBuilder& SetEquilibriumConstant(const auto& equilibrium_constant)
+    /// @brief Sets the equilibrium constant function (shared across all representations)
+    /// @details When provided, the missing rate constant is derived: k_f = K_eq * k_r or k_r = k_f / K_eq
+    DissolvedReversibleReactionBuilder& SetEquilibriumConstant(
+        std::function<double(const micm::Conditions&)> equilibrium_constant)
     {
-      equilibrium_constant_ = [equilibrium_constant](const micm::Conditions& conditions)
-      { return equilibrium_constant.Calculate(conditions); };
+      equilibrium_constant_ = std::move(equilibrium_constant);
+      return *this;
+    }
+
+    /// @brief Sets the equilibrium constant from an object with a Calculate() method
+    template<typename RateConstantT>
+      requires requires(const RateConstantT& kc, const micm::Conditions& c) {
+        { kc.Calculate(c) } -> std::convertible_to<double>;
+      }
+    DissolvedReversibleReactionBuilder& SetEquilibriumConstant(const RateConstantT& equilibrium_constant)
+    {
+      equilibrium_constant_ = [equilibrium_constant](const micm::Conditions& c)
+      { return equilibrium_constant.Calculate(c); };
+      return *this;
+    }
+
+    /// @brief Sets the equilibrium constant from Arrhenius parameters
+    DissolvedReversibleReactionBuilder& SetEquilibriumConstant(
+        const micm::ArrheniusRateConstantParameters& equilibrium_constant)
+    {
+      equilibrium_constant_ = [equilibrium_constant](const micm::Conditions& c)
+      { return micm::CalculateArrhenius(equilibrium_constant, c.temperature_, c.pressure_); };
       return *this;
     }
 
     /// @brief Builds and returns the DissolvedReversibleReaction object
     DissolvedReversibleReaction Build() const
     {
-      // Check that exactly two of the three rate constant/equilibrium constant functions are set
       int num_set = 0;
-      if (forward_rate_constant_)
-        ++num_set;
-      if (reverse_rate_constant_)
-        ++num_set;
-      if (equilibrium_constant_)
-        ++num_set;
+      if (forward_rate_constant_) ++num_set;
+      if (reverse_rate_constant_) ++num_set;
+      if (equilibrium_constant_) ++num_set;
       if (num_set != 2)
-      {
         throw MiamException(
             MIAM_ERROR_CATEGORY_CONFIGURATION,
             MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
-            "DissolvedReversibleReactionBuilder requires exactly two of forward rate constant, reverse rate constant, or "
-            "equilibrium constant to be set.");
-      }
+            "DissolvedReversibleReactionBuilder requires exactly two of SetForwardRateConstant, "
+            "SetReverseRateConstant, or SetEquilibriumConstant to be called.");
       if (reactants_.empty())
-      {
         throw MiamException(
             MIAM_ERROR_CATEGORY_CONFIGURATION,
             MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
             "DissolvedReversibleReactionBuilder requires at least one reactant species.");
-      }
       if (products_.empty())
-      {
         throw MiamException(
             MIAM_ERROR_CATEGORY_CONFIGURATION,
             MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
             "DissolvedReversibleReactionBuilder requires at least one product species.");
-      }
       if (!phase_is_set_)
-      {
         throw MiamException(
             MIAM_ERROR_CATEGORY_CONFIGURATION,
             MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
             "DissolvedReversibleReactionBuilder requires the phase to be set.");
-      }
       if (!solvent_is_set_)
-      {
         throw MiamException(
             MIAM_ERROR_CATEGORY_CONFIGURATION,
             MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
             "DissolvedReversibleReactionBuilder requires the solvent to be set.");
-      }
-      // If equilibrium constant is set, compute the missing rate constant
+
+      auto forward = forward_rate_constant_;
+      auto reverse = reverse_rate_constant_;
       if (equilibrium_constant_)
       {
-        if (!forward_rate_constant_)
+        auto keq = equilibrium_constant_;
+        if (!forward)
         {
-          // Capture the necessary functions by value to avoid dangling references
-          auto eq_const = equilibrium_constant_;
-          auto rev_const = reverse_rate_constant_;
-          forward_rate_constant_ = [eq_const, rev_const](const micm::Conditions& conditions)
-          {
-            double K_eq = eq_const(conditions);
-            double k_r = rev_const(conditions);
-            return K_eq * k_r;
-          };
+          auto rev = reverse;
+          forward = [keq, rev](const micm::Conditions& c) { return keq(c) * rev(c); };
         }
-        else if (!reverse_rate_constant_)
+        else
         {
-          // Capture the necessary functions by value to avoid dangling references
-          auto eq_const = equilibrium_constant_;
-          auto fwd_const = forward_rate_constant_;
-          reverse_rate_constant_ = [eq_const, fwd_const](const micm::Conditions& conditions)
-          {
-            double K_eq = eq_const(conditions);
-            double k_f = fwd_const(conditions);
-            return k_f / K_eq;
-          };
+          auto fwd = forward;
+          reverse = [keq, fwd](const micm::Conditions& c) { return fwd(c) / keq(c); };
         }
       }
-      return DissolvedReversibleReaction(
-          forward_rate_constant_, reverse_rate_constant_, reactants_, products_, solvent_, phase_, solvent_floor_);
+      return DissolvedReversibleReaction(forward, reverse, reactants_, products_, solvent_, phase_, solvent_floor_);
     }
 
    private:
@@ -178,12 +212,9 @@ namespace miam
     std::vector<micm::Species> products_;   ///< Product species
     micm::Species solvent_;                 ///< Solvent species
     bool solvent_is_set_ = false;           ///< Flag to track if the solvent has been set
-    mutable std::function<double(const micm::Conditions& conditions)>
-        forward_rate_constant_;  ///< Forward rate constant function
-    mutable std::function<double(const micm::Conditions& conditions)>
-        reverse_rate_constant_;  ///< Reverse rate constant function
-    mutable std::function<double(const micm::Conditions& conditions)>
-        equilibrium_constant_;         ///< Equilibrium constant function
-    double solvent_floor_{ 1.0e-20 };  ///< Floor δ [mol m⁻³] added to [S] in ([S]+δ)^n denominator; see SetSolventFloor()
+    double solvent_floor_{ 1.0e-20 };       ///< Floor δ [mol m⁻³]
+    std::function<double(const micm::Conditions&)> forward_rate_constant_;  ///< Shared forward rate constant
+    std::function<double(const micm::Conditions&)> reverse_rate_constant_;  ///< Shared reverse rate constant
+    std::function<double(const micm::Conditions&)> equilibrium_constant_;   ///< Shared equilibrium constant
   };
 }  // namespace miam

--- a/include/miam/processes/dissolved_reversible_reaction_builder.hpp
+++ b/include/miam/processes/dissolved_reversible_reaction_builder.hpp
@@ -12,15 +12,11 @@
 #include <micm/system/conditions.hpp>
 
 #include <functional>
-#include <string>
 
 namespace miam
 {
   /// @brief A dissolved reversible reaction builder
   /// @details Builder class for constructing DissolvedReversibleReaction objects.
-  ///          Exactly two of SetForwardRateConstant, SetReverseRateConstant, and
-  ///          SetEquilibriumConstant must be called; the third is derived automatically.
-  ///          Rate constants are shared across all representations of the phase.
   class DissolvedReversibleReactionBuilder
   {
    public:
@@ -64,145 +60,115 @@ namespace miam
       return *this;
     }
 
-    /// @brief Sets the forward rate constant function (shared across all representations)
-    DissolvedReversibleReactionBuilder& SetForwardRateConstant(
-        std::function<double(const micm::Conditions&)> forward_rate_constant)
+    /// @brief Sets the forward rate constant function
+    DissolvedReversibleReactionBuilder& SetForwardRateConstant(const auto& forward_rate_constant)
     {
-      forward_rate_constant_ = std::move(forward_rate_constant);
+      forward_rate_constant_ = [forward_rate_constant](const micm::Conditions& conditions)
+      { return forward_rate_constant.Calculate(conditions); };
       return *this;
     }
 
-    /// @brief Sets the forward rate constant from an object with a Calculate() method
-    template<typename RateConstantT>
-      requires requires(const RateConstantT& kc, const micm::Conditions& c) {
-        { kc.Calculate(c) } -> std::convertible_to<double>;
-      }
-    DissolvedReversibleReactionBuilder& SetForwardRateConstant(const RateConstantT& forward_rate_constant)
+    /// @brief Sets the reverse rate constant function
+    DissolvedReversibleReactionBuilder& SetReverseRateConstant(const auto& reverse_rate_constant)
     {
-      forward_rate_constant_ = [forward_rate_constant](const micm::Conditions& c)
-      { return forward_rate_constant.Calculate(c); };
-      return *this;
-    }
-
-    /// @brief Sets the forward rate constant from Arrhenius parameters
-    DissolvedReversibleReactionBuilder& SetForwardRateConstant(
-        const micm::ArrheniusRateConstantParameters& forward_rate_constant)
-    {
-      forward_rate_constant_ = [forward_rate_constant](const micm::Conditions& c)
-      { return micm::CalculateArrhenius(forward_rate_constant, c.temperature_, c.pressure_); };
-      return *this;
-    }
-
-    /// @brief Sets the reverse rate constant function (shared across all representations)
-    DissolvedReversibleReactionBuilder& SetReverseRateConstant(
-        std::function<double(const micm::Conditions&)> reverse_rate_constant)
-    {
-      reverse_rate_constant_ = std::move(reverse_rate_constant);
-      return *this;
-    }
-
-    /// @brief Sets the reverse rate constant from an object with a Calculate() method
-    template<typename RateConstantT>
-      requires requires(const RateConstantT& kc, const micm::Conditions& c) {
-        { kc.Calculate(c) } -> std::convertible_to<double>;
-      }
-    DissolvedReversibleReactionBuilder& SetReverseRateConstant(const RateConstantT& reverse_rate_constant)
-    {
-      reverse_rate_constant_ = [reverse_rate_constant](const micm::Conditions& c)
-      { return reverse_rate_constant.Calculate(c); };
+      reverse_rate_constant_ = [reverse_rate_constant](const micm::Conditions& conditions)
+      { return reverse_rate_constant.Calculate(conditions); };
       return *this;
     }
 
     /// @brief Sets the reverse rate constant from Arrhenius parameters
-    DissolvedReversibleReactionBuilder& SetReverseRateConstant(
-        const micm::ArrheniusRateConstantParameters& reverse_rate_constant)
+    DissolvedReversibleReactionBuilder& SetReverseRateConstant(const micm::ArrheniusRateConstantParameters& params)
     {
-      reverse_rate_constant_ = [reverse_rate_constant](const micm::Conditions& c)
-      { return micm::CalculateArrhenius(reverse_rate_constant, c.temperature_, c.pressure_); };
+      reverse_rate_constant_ = [params](const micm::Conditions& conditions)
+      { return micm::CalculateArrhenius(params, conditions.temperature_, conditions.pressure_); };
       return *this;
     }
 
-    /// @brief Sets the equilibrium constant function (shared across all representations)
-    /// @details When provided, the missing rate constant is derived: k_f = K_eq * k_r or k_r = k_f / K_eq
-    DissolvedReversibleReactionBuilder& SetEquilibriumConstant(
-        std::function<double(const micm::Conditions&)> equilibrium_constant)
+    /// @brief Sets the equilibrium constant function
+    DissolvedReversibleReactionBuilder& SetEquilibriumConstant(const auto& equilibrium_constant)
     {
-      equilibrium_constant_ = std::move(equilibrium_constant);
-      return *this;
-    }
-
-    /// @brief Sets the equilibrium constant from an object with a Calculate() method
-    template<typename RateConstantT>
-      requires requires(const RateConstantT& kc, const micm::Conditions& c) {
-        { kc.Calculate(c) } -> std::convertible_to<double>;
-      }
-    DissolvedReversibleReactionBuilder& SetEquilibriumConstant(const RateConstantT& equilibrium_constant)
-    {
-      equilibrium_constant_ = [equilibrium_constant](const micm::Conditions& c)
-      { return equilibrium_constant.Calculate(c); };
-      return *this;
-    }
-
-    /// @brief Sets the equilibrium constant from Arrhenius parameters
-    DissolvedReversibleReactionBuilder& SetEquilibriumConstant(
-        const micm::ArrheniusRateConstantParameters& equilibrium_constant)
-    {
-      equilibrium_constant_ = [equilibrium_constant](const micm::Conditions& c)
-      { return micm::CalculateArrhenius(equilibrium_constant, c.temperature_, c.pressure_); };
+      equilibrium_constant_ = [equilibrium_constant](const micm::Conditions& conditions)
+      { return equilibrium_constant.Calculate(conditions); };
       return *this;
     }
 
     /// @brief Builds and returns the DissolvedReversibleReaction object
     DissolvedReversibleReaction Build() const
     {
+      // Check that exactly two of the three rate constant/equilibrium constant functions are set
       int num_set = 0;
-      if (forward_rate_constant_) ++num_set;
-      if (reverse_rate_constant_) ++num_set;
-      if (equilibrium_constant_) ++num_set;
+      if (forward_rate_constant_)
+        ++num_set;
+      if (reverse_rate_constant_)
+        ++num_set;
+      if (equilibrium_constant_)
+        ++num_set;
       if (num_set != 2)
+      {
         throw MiamException(
             MIAM_ERROR_CATEGORY_CONFIGURATION,
             MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
-            "DissolvedReversibleReactionBuilder requires exactly two of SetForwardRateConstant, "
-            "SetReverseRateConstant, or SetEquilibriumConstant to be called.");
+            "DissolvedReversibleReactionBuilder requires exactly two of forward rate constant, reverse rate constant, or "
+            "equilibrium constant to be set.");
+      }
       if (reactants_.empty())
+      {
         throw MiamException(
             MIAM_ERROR_CATEGORY_CONFIGURATION,
             MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
             "DissolvedReversibleReactionBuilder requires at least one reactant species.");
+      }
       if (products_.empty())
+      {
         throw MiamException(
             MIAM_ERROR_CATEGORY_CONFIGURATION,
             MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
             "DissolvedReversibleReactionBuilder requires at least one product species.");
+      }
       if (!phase_is_set_)
+      {
         throw MiamException(
             MIAM_ERROR_CATEGORY_CONFIGURATION,
             MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
             "DissolvedReversibleReactionBuilder requires the phase to be set.");
+      }
       if (!solvent_is_set_)
+      {
         throw MiamException(
             MIAM_ERROR_CATEGORY_CONFIGURATION,
             MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
             "DissolvedReversibleReactionBuilder requires the solvent to be set.");
-
-      auto forward = forward_rate_constant_;
-      auto reverse = reverse_rate_constant_;
+      }
+      // If equilibrium constant is set, compute the missing rate constant
       if (equilibrium_constant_)
       {
-        auto keq = equilibrium_constant_;
-        if (!forward)
+        if (!forward_rate_constant_)
         {
-          auto rev = reverse;
-          forward = [keq, rev](const micm::Conditions& c) { return keq(c) * rev(c); };
+          // Capture the necessary functions by value to avoid dangling references
+          auto eq_const = equilibrium_constant_;
+          auto rev_const = reverse_rate_constant_;
+          forward_rate_constant_ = [eq_const, rev_const](const micm::Conditions& conditions)
+          {
+            double K_eq = eq_const(conditions);
+            double k_r = rev_const(conditions);
+            return K_eq * k_r;
+          };
         }
-        else
+        else if (!reverse_rate_constant_)
         {
-          auto fwd = forward;
-          reverse = [keq, fwd](const micm::Conditions& c) { return fwd(c) / keq(c); };
+          // Capture the necessary functions by value to avoid dangling references
+          auto eq_const = equilibrium_constant_;
+          auto fwd_const = forward_rate_constant_;
+          reverse_rate_constant_ = [eq_const, fwd_const](const micm::Conditions& conditions)
+          {
+            double K_eq = eq_const(conditions);
+            double k_f = fwd_const(conditions);
+            return k_f / K_eq;
+          };
         }
       }
-      return DissolvedReversibleReaction(forward, reverse, reactants_, products_, solvent_, phase_, solvent_floor_);
+      return DissolvedReversibleReaction(
+          forward_rate_constant_, reverse_rate_constant_, reactants_, products_, solvent_, phase_, solvent_floor_);
     }
 
    private:
@@ -212,9 +178,12 @@ namespace miam
     std::vector<micm::Species> products_;   ///< Product species
     micm::Species solvent_;                 ///< Solvent species
     bool solvent_is_set_ = false;           ///< Flag to track if the solvent has been set
-    double solvent_floor_{ 1.0e-20 };       ///< Floor δ [mol m⁻³]
-    std::function<double(const micm::Conditions&)> forward_rate_constant_;  ///< Shared forward rate constant
-    std::function<double(const micm::Conditions&)> reverse_rate_constant_;  ///< Shared reverse rate constant
-    std::function<double(const micm::Conditions&)> equilibrium_constant_;   ///< Shared equilibrium constant
+    mutable std::function<double(const micm::Conditions& conditions)>
+        forward_rate_constant_;  ///< Forward rate constant function
+    mutable std::function<double(const micm::Conditions& conditions)>
+        reverse_rate_constant_;  ///< Reverse rate constant function
+    mutable std::function<double(const micm::Conditions& conditions)>
+        equilibrium_constant_;         ///< Equilibrium constant function
+    double solvent_floor_{ 1.0e-20 };  ///< Floor δ [mol m⁻³] added to [S] in ([S]+δ)^n denominator; see SetSolventFloor()
   };
 }  // namespace miam

--- a/test/integration/test_cam_cloud_chemistry.cpp
+++ b/test/integration/test_cam_cloud_chemistry.cpp
@@ -1296,7 +1296,8 @@ TEST(CamCloudChemistry, Step4_FullSystemWithKinetics)
                    .SetReactants({ so2oohm, hp })
                    .SetProducts({ so4mm })
                    .SetSolvent(h2o)
-                   .SetRateConstant(
+                   .AddRateConstant(
+                       "CLOUD",
                        [](const Conditions& c) -> double
                        { return c_H2O_M * 2.4e6 * std::exp(-4430.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                    .Build();
@@ -1307,7 +1308,8 @@ TEST(CamCloudChemistry, Step4_FullSystemWithKinetics)
                   .SetReactants({ hso3m, o3_aq })
                   .SetProducts({ so4mm, hp })
                   .SetSolvent(h2o)
-                  .SetRateConstant(
+                  .AddRateConstant(
+                      "CLOUD",
                       [](const Conditions& c) -> double
                       { return c_H2O_M * 3.75e5 * std::exp(-5530.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                   .Build();
@@ -1318,7 +1320,8 @@ TEST(CamCloudChemistry, Step4_FullSystemWithKinetics)
                   .SetReactants({ so3mm, o3_aq })
                   .SetProducts({ so4mm })
                   .SetSolvent(h2o)
-                  .SetRateConstant(
+                  .AddRateConstant(
+                      "CLOUD",
                       [](const Conditions& c) -> double
                       { return c_H2O_M * 1.59e9 * std::exp(-5280.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                   .Build();
@@ -1621,7 +1624,8 @@ TEST(CamCloudChemistry, Step4b_NaiveInitialConditions)
                    .SetReactants({ so2oohm, hp })
                    .SetProducts({ so4mm })
                    .SetSolvent(h2o)
-                   .SetRateConstant(
+                   .AddRateConstant(
+                       "CLOUD",
                        [](const Conditions& c) -> double
                        { return c_H2O_M * 2.4e6 * std::exp(-4430.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                    .Build();
@@ -1631,7 +1635,8 @@ TEST(CamCloudChemistry, Step4b_NaiveInitialConditions)
                   .SetReactants({ hso3m, o3_aq })
                   .SetProducts({ so4mm, hp })
                   .SetSolvent(h2o)
-                  .SetRateConstant(
+                  .AddRateConstant(
+                      "CLOUD",
                       [](const Conditions& c) -> double
                       { return c_H2O_M * 3.75e5 * std::exp(-5530.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                   .Build();
@@ -1641,7 +1646,8 @@ TEST(CamCloudChemistry, Step4b_NaiveInitialConditions)
                   .SetReactants({ so3mm, o3_aq })
                   .SetProducts({ so4mm })
                   .SetSolvent(h2o)
-                  .SetRateConstant(
+                  .AddRateConstant(
+                      "CLOUD",
                       [](const Conditions& c) -> double
                       { return c_H2O_M * 1.59e9 * std::exp(-5280.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                   .Build();
@@ -1891,7 +1897,8 @@ TEST(CamCloudChemistry, Step5_JacobianVerification)
                    .SetReactants({ so2oohm, hp })
                    .SetProducts({ so4mm })
                    .SetSolvent(h2o)
-                   .SetRateConstant(
+                   .AddRateConstant(
+                       "CLOUD",
                        [](const Conditions& c) -> double
                        { return c_H2O_M * 2.4e6 * std::exp(-4430.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                    .Build();
@@ -1901,7 +1908,8 @@ TEST(CamCloudChemistry, Step5_JacobianVerification)
                   .SetReactants({ hso3m, o3_aq })
                   .SetProducts({ so4mm, hp })
                   .SetSolvent(h2o)
-                  .SetRateConstant(
+                  .AddRateConstant(
+                      "CLOUD",
                       [](const Conditions& c) -> double
                       { return c_H2O_M * 3.75e5 * std::exp(-5530.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                   .Build();
@@ -1911,7 +1919,8 @@ TEST(CamCloudChemistry, Step5_JacobianVerification)
                   .SetReactants({ so3mm, o3_aq })
                   .SetProducts({ so4mm })
                   .SetSolvent(h2o)
-                  .SetRateConstant(
+                  .AddRateConstant(
+                      "CLOUD",
                       [](const Conditions& c) -> double
                       { return c_H2O_M * 1.59e9 * std::exp(-5280.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                   .Build();

--- a/test/integration/test_dissolved_reaction.cpp
+++ b/test/integration/test_dissolved_reaction.cpp
@@ -312,8 +312,8 @@ TEST(DissolvedReactionIntegration, MultiPhaseInstances)
 
   auto aqueous_phase = Phase{ "AQUEOUS", { { A }, { B }, { C } } };
 
-  auto small_droplet = UniformSection{ "SMALL", { aqueous_phase } };
-  auto large_droplet = UniformSection{ "LARGE", { aqueous_phase } };
+  auto small_droplet = UniformSection{ "DROPLET_SMALL", { aqueous_phase } };
+  auto large_droplet = UniformSection{ "DROPLET_LARGE", { aqueous_phase } };
 
   double k_small = 0.1;
   double k_large = 0.2;
@@ -326,8 +326,8 @@ TEST(DissolvedReactionIntegration, MultiPhaseInstances)
                       .SetReactants({ A })
                       .SetProducts({ B })
                       .SetSolvent(C)
-                      .AddRateConstant("SMALL", rate_small)
-                      .AddRateConstant("LARGE", rate_large)
+                      .AddRateConstant("DROPLET_SMALL", rate_small)
+                      .AddRateConstant("DROPLET_LARGE", rate_large)
                       .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { small_droplet, large_droplet } };
@@ -347,13 +347,13 @@ TEST(DissolvedReactionIntegration, MultiPhaseInstances)
 
   State state = solver.GetState();
 
-  std::size_t i_A_small = state.variable_map_.at("SMALL.AQUEOUS.A");
-  std::size_t i_B_small = state.variable_map_.at("SMALL.AQUEOUS.B");
-  std::size_t i_C_small = state.variable_map_.at("SMALL.AQUEOUS.C");
+  std::size_t i_A_small = state.variable_map_.at("DROPLET_SMALL.AQUEOUS.A");
+  std::size_t i_B_small = state.variable_map_.at("DROPLET_SMALL.AQUEOUS.B");
+  std::size_t i_C_small = state.variable_map_.at("DROPLET_SMALL.AQUEOUS.C");
 
-  std::size_t i_A_large = state.variable_map_.at("LARGE.AQUEOUS.A");
-  std::size_t i_B_large = state.variable_map_.at("LARGE.AQUEOUS.B");
-  std::size_t i_C_large = state.variable_map_.at("LARGE.AQUEOUS.C");
+  std::size_t i_A_large = state.variable_map_.at("DROPLET_LARGE.AQUEOUS.A");
+  std::size_t i_B_large = state.variable_map_.at("DROPLET_LARGE.AQUEOUS.B");
+  std::size_t i_C_large = state.variable_map_.at("DROPLET_LARGE.AQUEOUS.C");
 
   state.variables_[0][i_A_small] = A0_small;
   state.variables_[0][i_B_small] = 0.0;

--- a/test/integration/test_dissolved_reaction.cpp
+++ b/test/integration/test_dissolved_reaction.cpp
@@ -31,11 +31,13 @@ TEST(DissolvedReactionIntegration, SimpleFirstOrderDecay)
   auto rate = [k](const Conditions& conditions) { return k; };
 
   // A -> B with solvent C
-  auto reaction = DissolvedReaction{ rate,
-                                     { A },  // reactants
-                                     { B },  // products
-                                     C,      // solvent
-                                     aqueous_phase };
+  auto reaction = DissolvedReactionBuilder{}
+                      .SetPhase(aqueous_phase)
+                      .SetReactants({ A })
+                      .SetProducts({ B })
+                      .SetSolvent(C)
+                      .AddRateConstant("DROPLET", rate)
+                      .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
   model.AddProcesses({ reaction });
@@ -124,11 +126,13 @@ TEST(DissolvedReactionIntegration, SolventAsReactant)
 
   // A + C -> B with solvent C
   // rate = k / [C]^(2-1) * [A] * [C] = k * [A]
-  auto reaction = DissolvedReaction{ rate,
-                                     { A, C },  // reactants
-                                     { B },     // products
-                                     C,         // solvent
-                                     aqueous_phase };
+  auto reaction = DissolvedReactionBuilder{}
+                      .SetPhase(aqueous_phase)
+                      .SetReactants({ A, C })
+                      .SetProducts({ B })
+                      .SetSolvent(C)
+                      .AddRateConstant("DROPLET", rate)
+                      .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
   model.AddProcesses({ reaction });
@@ -218,11 +222,13 @@ TEST(DissolvedReactionIntegration, SolventAsProduct)
 
   // A -> B + C with solvent C
   // rate = k * [A] (1 reactant, no solvent normalization)
-  auto reaction = DissolvedReaction{ rate,
-                                     { A },     // reactants
-                                     { B, C },  // products (solvent is a product)
-                                     C,         // solvent
-                                     aqueous_phase };
+  auto reaction = DissolvedReactionBuilder{}
+                      .SetPhase(aqueous_phase)
+                      .SetReactants({ A })
+                      .SetProducts({ B, C })
+                      .SetSolvent(C)
+                      .AddRateConstant("DROPLET", rate)
+                      .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
   model.AddProcesses({ reaction });
@@ -304,12 +310,10 @@ TEST(DissolvedReactionIntegration, MultiPhaseInstances)
   auto B = Species{ "B" };
   auto C = Species{ "C" };  // solvent
 
-  auto small_aqueous = Phase{ "AQUEOUS_SMALL", { { A }, { B }, { C } } };
-  auto large_aqueous = Phase{ "AQUEOUS_LARGE", { { A }, { B }, { C } } };
+  auto aqueous_phase = Phase{ "AQUEOUS", { { A }, { B }, { C } } };
 
-  auto small_droplet = UniformSection{ "DROPLET_SMALL", { small_aqueous } };
-
-  auto large_droplet = UniformSection{ "DROPLET_LARGE", { large_aqueous } };
+  auto small_droplet = UniformSection{ "SMALL", { aqueous_phase } };
+  auto large_droplet = UniformSection{ "LARGE", { aqueous_phase } };
 
   double k_small = 0.1;
   double k_large = 0.2;
@@ -317,12 +321,17 @@ TEST(DissolvedReactionIntegration, MultiPhaseInstances)
   auto rate_small = [k_small](const Conditions& conditions) { return k_small; };
   auto rate_large = [k_large](const Conditions& conditions) { return k_large; };
 
-  auto reaction_small = DissolvedReaction{ rate_small, { A }, { B }, C, small_aqueous };
-
-  auto reaction_large = DissolvedReaction{ rate_large, { A }, { B }, C, large_aqueous };
+  auto reaction = DissolvedReactionBuilder{}
+                      .SetPhase(aqueous_phase)
+                      .SetReactants({ A })
+                      .SetProducts({ B })
+                      .SetSolvent(C)
+                      .AddRateConstant("SMALL", rate_small)
+                      .AddRateConstant("LARGE", rate_large)
+                      .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { small_droplet, large_droplet } };
-  model.AddProcesses({ reaction_small, reaction_large });
+  model.AddProcesses({ reaction });
 
   Phase gas_phase{ "GAS", {} };
 
@@ -338,13 +347,13 @@ TEST(DissolvedReactionIntegration, MultiPhaseInstances)
 
   State state = solver.GetState();
 
-  std::size_t i_A_small = state.variable_map_.at("DROPLET_SMALL.AQUEOUS_SMALL.A");
-  std::size_t i_B_small = state.variable_map_.at("DROPLET_SMALL.AQUEOUS_SMALL.B");
-  std::size_t i_C_small = state.variable_map_.at("DROPLET_SMALL.AQUEOUS_SMALL.C");
+  std::size_t i_A_small = state.variable_map_.at("SMALL.AQUEOUS.A");
+  std::size_t i_B_small = state.variable_map_.at("SMALL.AQUEOUS.B");
+  std::size_t i_C_small = state.variable_map_.at("SMALL.AQUEOUS.C");
 
-  std::size_t i_A_large = state.variable_map_.at("DROPLET_LARGE.AQUEOUS_LARGE.A");
-  std::size_t i_B_large = state.variable_map_.at("DROPLET_LARGE.AQUEOUS_LARGE.B");
-  std::size_t i_C_large = state.variable_map_.at("DROPLET_LARGE.AQUEOUS_LARGE.C");
+  std::size_t i_A_large = state.variable_map_.at("LARGE.AQUEOUS.A");
+  std::size_t i_B_large = state.variable_map_.at("LARGE.AQUEOUS.B");
+  std::size_t i_C_large = state.variable_map_.at("LARGE.AQUEOUS.C");
 
   state.variables_[0][i_A_small] = A0_small;
   state.variables_[0][i_B_small] = 0.0;
@@ -430,11 +439,13 @@ TEST(DissolvedReactionIntegration, SecondOrderTwoReactants)
 
   // A + B -> C with solvent S
   // rate = k / [S] * [A] * [B]
-  auto reaction = DissolvedReaction{ rate,
-                                     { A, B },  // reactants
-                                     { C },     // products
-                                     S,         // solvent
-                                     aqueous_phase };
+  auto reaction = DissolvedReactionBuilder{}
+                      .SetPhase(aqueous_phase)
+                      .SetReactants({ A, B })
+                      .SetProducts({ C })
+                      .SetSolvent(S)
+                      .AddRateConstant("DROPLET", rate)
+                      .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
   model.AddProcesses({ reaction });
@@ -537,15 +548,15 @@ TEST(DissolvedReactionIntegration, MinHalflifeZeroReactant)
   double t_half = 10.0;  // seconds
 
   // A + B -> C with min_halflife cap
-  auto reaction = DissolvedReaction{
-    rate,
-    { A, B },  // reactants: two species so soft-min is tested
-    { C },     // products
-    S,         // solvent
-    aqueous_phase,
-    1.0e-20,  // solvent_damping_epsilon (default)
-    t_half    // min_halflife — triggers the capped code path
-  };
+  auto reaction = DissolvedReactionBuilder{}
+                      .SetPhase(aqueous_phase)
+                      .SetReactants({ A, B })
+                      .SetProducts({ C })
+                      .SetSolvent(S)
+                      .SetSolventFloor(1.0e-20)
+                      .SetMinHalflife(t_half)
+                      .AddRateConstant("DROPLET", rate)
+                      .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
   model.AddProcesses({ reaction });

--- a/test/integration/test_equilibrium_constraints.cpp
+++ b/test/integration/test_equilibrium_constraints.cpp
@@ -205,7 +205,8 @@ TEST(EquilibriumConstraintsIntegration, PerInstanceEquilibrium)
                       .SetReactants({ A })
                       .SetProducts({ B })
                       .SetSolvent(S)
-                      .AddRateConstant("DROPLET", rate)
+                      .AddRateConstant("SMALL", rate)
+                      .AddRateConstant("LARGE", rate)
                       .Build();
 
   // Equilibrium constraint: C = K_eq * B (C is algebraic)

--- a/test/integration/test_equilibrium_constraints.cpp
+++ b/test/integration/test_equilibrium_constraints.cpp
@@ -53,11 +53,13 @@ TEST(EquilibriumConstraintsIntegration, DissolvedEquilibriumWithKineticDriver)
 
   // Kinetic process: A → B (dissolved reaction)
   auto rate = [k](const Conditions& conditions) { return k; };
-  auto reaction = DissolvedReaction{ rate,
-                                     { A },  // reactants
-                                     { B },  // products
-                                     S,      // solvent
-                                     aqueous_phase };
+  auto reaction = DissolvedReactionBuilder{}
+                      .SetPhase(aqueous_phase)
+                      .SetReactants({ A })
+                      .SetProducts({ B })
+                      .SetSolvent(S)
+                      .AddRateConstant("DROPLET", rate)
+                      .Build();
 
   // Equilibrium constraint: B <-> C, K_eq, algebraic species = C
   // Residual: G = K_eq * [B] - [C] = 0
@@ -198,7 +200,13 @@ TEST(EquilibriumConstraintsIntegration, PerInstanceEquilibrium)
   double A0_large = 2.0;
 
   auto rate = [k](const Conditions& conditions) { return k; };
-  auto reaction = DissolvedReaction{ rate, { A }, { B }, S, aqueous_phase };
+  auto reaction = DissolvedReactionBuilder{}
+                      .SetPhase(aqueous_phase)
+                      .SetReactants({ A })
+                      .SetProducts({ B })
+                      .SetSolvent(S)
+                      .AddRateConstant("DROPLET", rate)
+                      .Build();
 
   // Equilibrium constraint: C = K_eq * B (C is algebraic)
   auto equil = DissolvedEquilibriumConstraintBuilder()
@@ -316,7 +324,13 @@ TEST(EquilibriumConstraintsIntegration, InconsistentInitialConditions)
   double total = A0;
 
   auto rate = [k](const Conditions& conditions) { return k; };
-  auto reaction = DissolvedReaction{ rate, { A }, { B }, S, aqueous_phase };
+  auto reaction = DissolvedReactionBuilder{}
+                      .SetPhase(aqueous_phase)
+                      .SetReactants({ A })
+                      .SetProducts({ B })
+                      .SetSolvent(S)
+                      .AddRateConstant("DROPLET", rate)
+                      .Build();
 
   auto equil = DissolvedEquilibriumConstraintBuilder()
                    .SetPhase(aqueous_phase)

--- a/test/integration/test_henry_law_phase_transfer.cpp
+++ b/test/integration/test_henry_law_phase_transfer.cpp
@@ -208,36 +208,23 @@ TEST(HenryLawPhaseTransferIntegration, MultiInstanceMassConservation)
   auto H2O = MakeCondensedSpecies("H2O", solvent_molecular_weight, solvent_density);
 
   Phase gas_phase{ "GAS", { { A_g } } };
-  Phase aqueous_small{ "AQ_SMALL", { { A_aq }, { H2O } } };
-  Phase aqueous_large{ "AQ_LARGE", { { A_aq }, { H2O } } };
+  Phase aqueous_phase{ "AQUEOUS", { { A_aq }, { H2O } } };
 
-  auto small_drop = SingleMomentMode{ "SMALL", { aqueous_small }, 1.0e-6, 1.2 };
-  auto large_drop = SingleMomentMode{ "LARGE", { aqueous_large }, 1.0e-5, 1.4 };
+  auto small_drop = SingleMomentMode{ "SMALL", { aqueous_phase }, 1.0e-6, 1.2 };
+  auto large_drop = SingleMomentMode{ "LARGE", { aqueous_phase }, 1.0e-5, 1.4 };
 
-  // Build two transfer processes — one for each phase
-  auto transfer_small = HenryLawPhaseTransferBuilder()
-                            .SetCondensedPhase(aqueous_small)
-                            .SetGasSpecies(A_g)
-                            .SetCondensedSpecies(A_aq)
-                            .SetSolvent(H2O)
-                            .SetHenrysLawConstant(HenrysLawConstant(HenrysLawConstantParameters{ .HLC_ref_ = HLC_val }))
-                            .SetDiffusionCoefficient(D_g)
-                            .SetAccommodationCoefficient(alpha)
-                            .Build();
-
-  auto transfer_large = HenryLawPhaseTransferBuilder()
-                            .SetCondensedPhase(aqueous_large)
-                            .SetGasSpecies(A_g)
-                            .SetCondensedSpecies(A_aq)
-                            .SetSolvent(H2O)
-                            .SetHenrysLawConstant(HenrysLawConstant(HenrysLawConstantParameters{ .HLC_ref_ = HLC_val }))
-                            .SetDiffusionCoefficient(D_g)
-                            .SetAccommodationCoefficient(alpha)
-                            .Build();
+  auto transfer = HenryLawPhaseTransferBuilder()
+                      .SetCondensedPhase(aqueous_phase)
+                      .SetGasSpecies(A_g)
+                      .SetCondensedSpecies(A_aq)
+                      .SetSolvent(H2O)
+                      .SetHenrysLawConstant(HenrysLawConstant(HenrysLawConstantParameters{ .HLC_ref_ = HLC_val }))
+                      .SetDiffusionCoefficient(D_g)
+                      .SetAccommodationCoefficient(alpha)
+                      .Build();
 
   auto model = Model{ .name_ = "CLOUD", .representations_ = { small_drop, large_drop } };
-  model.AddProcesses({ transfer_small });
-  model.AddProcesses({ transfer_large });
+  model.AddProcesses({ transfer });
 
   auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
@@ -249,10 +236,10 @@ TEST(HenryLawPhaseTransferIntegration, MultiInstanceMassConservation)
   State state = solver.GetState();
 
   std::size_t i_gas = state.variable_map_.at("A_g");
-  std::size_t i_aq_small = state.variable_map_.at("SMALL.AQ_SMALL.A_aq");
-  std::size_t i_h2o_small = state.variable_map_.at("SMALL.AQ_SMALL.H2O");
-  std::size_t i_aq_large = state.variable_map_.at("LARGE.AQ_LARGE.A_aq");
-  std::size_t i_h2o_large = state.variable_map_.at("LARGE.AQ_LARGE.H2O");
+  std::size_t i_aq_small = state.variable_map_.at("SMALL.AQUEOUS.A_aq");
+  std::size_t i_h2o_small = state.variable_map_.at("SMALL.AQUEOUS.H2O");
+  std::size_t i_aq_large = state.variable_map_.at("LARGE.AQUEOUS.A_aq");
+  std::size_t i_h2o_large = state.variable_map_.at("LARGE.AQUEOUS.H2O");
 
   double gas_0 = 1.0e-2;
   double solvent = 0.017;
@@ -443,10 +430,9 @@ TEST(HenryLawPhaseTransferIntegration, SmallVsLargeParticleRate)
   double solvent = 0.017;
 
   // Run HLPT for a given particle radius, return (gas, aq) after fixed time
-  auto run_with_radius =
-      [&](double r_mean, const std::string& prefix, const std::string& phase_name) -> std::pair<double, double>
+  auto run_with_radius = [&](double r_mean, const std::string& prefix) -> std::pair<double, double>
   {
-    Phase aqueous_phase{ phase_name, { { A_aq }, { H2O } } };
+    Phase aqueous_phase{ "AQUEOUS", { { A_aq }, { H2O } } };
 
     auto droplet = SingleMomentMode{
       prefix, { aqueous_phase }, r_mean, 1.01  // nearly monodisperse
@@ -475,8 +461,8 @@ TEST(HenryLawPhaseTransferIntegration, SmallVsLargeParticleRate)
     State state = solver.GetState();
 
     std::size_t i_gas = state.variable_map_.at("A_g");
-    std::size_t i_aq = state.variable_map_.at(prefix + "." + phase_name + ".A_aq");
-    std::size_t i_h2o = state.variable_map_.at(prefix + "." + phase_name + ".H2O");
+    std::size_t i_aq = state.variable_map_.at(prefix + ".AQUEOUS.A_aq");
+    std::size_t i_h2o = state.variable_map_.at(prefix + ".AQUEOUS.H2O");
 
     state.variables_[0][i_gas] = gas_0;
     state.variables_[0][i_aq] = 0.0;
@@ -505,10 +491,10 @@ TEST(HenryLawPhaseTransferIntegration, SmallVsLargeParticleRate)
   };
 
   // Small particles (transition regime): r ~ 50 nm
-  auto [gas_small, aq_small] = run_with_radius(5.0e-8, "SMALL", "AQ_S");
+  auto [gas_small, aq_small] = run_with_radius(5.0e-8, "SMALL");
 
   // Large particles (near continuum): r ~ 10 μm
-  auto [gas_large, aq_large] = run_with_radius(1.0e-5, "LARGE", "AQ_L");
+  auto [gas_large, aq_large] = run_with_radius(1.0e-5, "LARGE");
 
   // Both should show condensation
   EXPECT_GT(aq_small, 0.0) << "Small particles should absorb gas";

--- a/test/integration/test_jacobian_verification.cpp
+++ b/test/integration/test_jacobian_verification.cpp
@@ -192,7 +192,13 @@ TEST(JacobianVerification, DissolvedReactionProcess)
 
   double k = 0.1;
   auto rate = [k](const Conditions&) { return k; };
-  auto reaction = DissolvedReaction{ rate, { A }, { B }, C, aqueous_phase };
+  auto reaction = DissolvedReactionBuilder{}
+                      .SetPhase(aqueous_phase)
+                      .SetReactants({ A })
+                      .SetProducts({ B })
+                      .SetSolvent(C)
+                      .AddRateConstant("DROPLET", rate)
+                      .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
   model.AddProcesses({ reaction });
@@ -379,7 +385,13 @@ TEST(JacobianVerification, MultipleProcessesCombined)
   auto droplet = UniformSection{ "DROPLET", { aqueous_phase } };
 
   // A → B (irreversible)
-  auto reaction1 = DissolvedReaction{ [](const Conditions&) { return 0.1; }, { A }, { B }, S, aqueous_phase };
+  auto reaction1 = DissolvedReactionBuilder{}
+                       .SetPhase(aqueous_phase)
+                       .SetReactants({ A })
+                       .SetProducts({ B })
+                       .SetSolvent(S)
+                       .AddRateConstant("DROPLET", [](const Conditions&) { return 0.1; })
+                       .Build();
 
   // C ⇌ D (reversible)
   auto reaction2 = DissolvedReversibleReaction{
@@ -574,7 +586,13 @@ TEST(JacobianVerification, ProcessAndConstraintsCombined)
   double K_eq = 2.0;
   double total = 1.0;
 
-  auto reaction = DissolvedReaction{ [k](const Conditions&) { return k; }, { A }, { B }, S, aqueous_phase };
+  auto reaction = DissolvedReactionBuilder{}
+                      .SetPhase(aqueous_phase)
+                      .SetReactants({ A })
+                      .SetProducts({ B })
+                      .SetSolvent(S)
+                      .AddRateConstant("DROPLET", [k](const Conditions&) { return k; })
+                      .Build();
 
   auto equil = DissolvedEquilibriumConstraintBuilder()
                    .SetPhase(aqueous_phase)
@@ -698,7 +716,13 @@ TEST(JacobianVerification, DissolvedReactionDampingRange)
 
   double k = 0.1;
   auto rate = [k](const Conditions&) { return k; };
-  auto reaction = DissolvedReaction{ rate, { A }, { B }, C, aqueous_phase };
+  auto reaction = DissolvedReactionBuilder{}
+                      .SetPhase(aqueous_phase)
+                      .SetReactants({ A })
+                      .SetProducts({ B })
+                      .SetSolvent(C)
+                      .AddRateConstant("DROPLET", rate)
+                      .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
   model.AddProcesses({ reaction });
@@ -938,7 +962,13 @@ TEST(JacobianVerification, CombinedProcessAndConstraintZeroSolvent)
   double K_eq = 2.0;
   double total = 1.0;
 
-  auto reaction = DissolvedReaction{ [k](const Conditions&) { return k; }, { A }, { B }, S, aqueous_phase };
+  auto reaction = DissolvedReactionBuilder{}
+                      .SetPhase(aqueous_phase)
+                      .SetReactants({ A })
+                      .SetProducts({ B })
+                      .SetSolvent(S)
+                      .AddRateConstant("DROPLET", [k](const Conditions&) { return k; })
+                      .Build();
 
   auto equil = DissolvedEquilibriumConstraintBuilder()
                    .SetPhase(aqueous_phase)
@@ -1039,7 +1069,7 @@ TEST(JacobianVerification, DissolvedReactionCappedSingleReactant)
                       .SetReactants({ A })
                       .SetProducts({ B })
                       .SetSolvent(C)
-                      .SetRateConstant([](const Conditions&) { return 0.5; })
+                      .AddRateConstant("DROPLET", [](const Conditions&) { return 0.5; })
                       .SetMinHalflife(t_half)
                       .Build();
 
@@ -1087,7 +1117,7 @@ TEST(JacobianVerification, DissolvedReactionCappedTwoReactants)
                       .SetReactants({ A, B })
                       .SetProducts({ P })
                       .SetSolvent(S)
-                      .SetRateConstant([](const Conditions&) { return 1.0; })
+                      .AddRateConstant("DROPLET", [](const Conditions&) { return 1.0; })
                       .SetMinHalflife(t_half)
                       .Build();
 
@@ -1136,7 +1166,7 @@ TEST(JacobianVerification, DissolvedReactionCappedSolventRange)
                       .SetReactants({ A })
                       .SetProducts({ B })
                       .SetSolvent(C)
-                      .SetRateConstant([](const Conditions&) { return 1.0; })
+                      .AddRateConstant("DROPLET", [](const Conditions&) { return 1.0; })
                       .SetMinHalflife(1.0)
                       .Build();
 
@@ -1216,7 +1246,7 @@ TEST(JacobianVerification, DissolvedReactionCappedMultiBlock)
                       .SetReactants({ A })
                       .SetProducts({ B })
                       .SetSolvent(C)
-                      .SetRateConstant([](const Conditions&) { return 2.0; })
+                      .AddRateConstant("DROPLET", [](const Conditions&) { return 2.0; })
                       .SetMinHalflife(0.1)
                       .Build();
 
@@ -1283,7 +1313,7 @@ namespace
                             .SetReactants(reactants)
                             .SetProducts(products)
                             .SetSolvent(solvent)
-                            .SetRateConstant(rate_fn)
+                            .AddRateConstant("DROPLET", rate_fn)
                             .Build();
     auto model_uncapped = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
     model_uncapped.AddProcesses({ rxn_uncapped });
@@ -1294,7 +1324,7 @@ namespace
                           .SetReactants(reactants)
                           .SetProducts(products)
                           .SetSolvent(solvent)
-                          .SetRateConstant(rate_fn)
+                          .AddRateConstant("DROPLET", rate_fn)
                           .SetMinHalflife(min_halflife)
                           .Build();
     auto model_capped = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };

--- a/test/integration/test_kinetic_vs_constrained.cpp
+++ b/test/integration/test_kinetic_vs_constrained.cpp
@@ -33,7 +33,13 @@ namespace
     auto droplet = UniformSection{ "DROPLET", { aqueous_phase } };
 
     auto rate = [k](const Conditions& conditions) { return k; };
-    auto reaction = DissolvedReaction{ rate, { A }, { B }, S, aqueous_phase };
+    auto reaction = DissolvedReactionBuilder{}
+                        .SetPhase(aqueous_phase)
+                        .SetReactants({ A })
+                        .SetProducts({ B })
+                        .SetSolvent(S)
+                        .AddRateConstant("DROPLET", rate)
+                        .Build();
 
     auto forward_rate = [k_f](const Conditions& conditions) { return k_f; };
     auto reverse_rate = [k_r](const Conditions& conditions) { return k_r; };
@@ -117,7 +123,13 @@ TEST(KineticVsConstrained, DissolvedReversibleVsEquilibriumConstraint)
     auto droplet = UniformSection{ "DROPLET", { aqueous_phase } };
 
     auto rate = [k](const Conditions& conditions) { return k; };
-    auto reaction = DissolvedReaction{ rate, { A }, { B }, S, aqueous_phase };
+    auto reaction = DissolvedReactionBuilder{}
+                        .SetPhase(aqueous_phase)
+                        .SetReactants({ A })
+                        .SetProducts({ B })
+                        .SetSolvent(S)
+                        .AddRateConstant("DROPLET", rate)
+                        .Build();
 
     auto forward_rate = [k_f](const Conditions& conditions) { return k_f; };
     auto reverse_rate = [k_r](const Conditions& conditions) { return k_r; };
@@ -175,7 +187,13 @@ TEST(KineticVsConstrained, DissolvedReversibleVsEquilibriumConstraint)
     auto droplet = UniformSection{ "DROPLET", { aqueous_phase } };
 
     auto rate = [k](const Conditions& conditions) { return k; };
-    auto reaction = DissolvedReaction{ rate, { A }, { B }, S, aqueous_phase };
+    auto reaction = DissolvedReactionBuilder{}
+                        .SetPhase(aqueous_phase)
+                        .SetReactants({ A })
+                        .SetProducts({ B })
+                        .SetSolvent(S)
+                        .AddRateConstant("DROPLET", rate)
+                        .Build();
 
     auto equil = DissolvedEquilibriumConstraintBuilder()
                      .SetPhase(aqueous_phase)

--- a/test/integration/test_miam_api.cpp
+++ b/test/integration/test_miam_api.cpp
@@ -1,6 +1,7 @@
 #include <miam/miam.hpp>
 
 #include <micm/CPU.hpp>
+#include <micm/process/rate_constant/rate_constant_functions.hpp>
 
 #include <gtest/gtest.h>
 

--- a/test/integration/test_solvent_robustness.cpp
+++ b/test/integration/test_solvent_robustness.cpp
@@ -264,7 +264,8 @@ namespace
                      .SetReactants({ sp.so2oohm, sp.hp })
                      .SetProducts({ sp.so4mm })
                      .SetSolvent(sp.h2o)
-                     .SetRateConstant(
+                     .AddRateConstant(
+                         "CLOUD",
                          [](const Conditions& c) -> double
                          { return c_H2O_M * 2.4e6 * std::exp(-4430.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                      .Build();
@@ -274,7 +275,8 @@ namespace
                     .SetReactants({ sp.hso3m, sp.o3_aq })
                     .SetProducts({ sp.so4mm, sp.hp })
                     .SetSolvent(sp.h2o)
-                    .SetRateConstant(
+                    .AddRateConstant(
+                        "CLOUD",
                         [](const Conditions& c) -> double
                         { return c_H2O_M * 3.75e5 * std::exp(-5530.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                     .Build();
@@ -284,7 +286,8 @@ namespace
                     .SetReactants({ sp.so3mm, sp.o3_aq })
                     .SetProducts({ sp.so4mm })
                     .SetSolvent(sp.h2o)
-                    .SetRateConstant(
+                    .AddRateConstant(
+                        "CLOUD",
                         [](const Conditions& c) -> double
                         { return c_H2O_M * 1.59e9 * std::exp(-5280.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                     .Build();
@@ -324,7 +327,8 @@ TEST(SolventRobustness, A1_DissolvedReaction_SolventSweep)
                    .SetReactants({ hso3m, o3_aq })
                    .SetProducts({ so4mm, hp })
                    .SetSolvent(h2o)
-                   .SetRateConstant(
+                   .AddRateConstant(
+                       "CLOUD",
                        [](const Conditions& c) -> double
                        { return c_H2O_M * 3.75e5 * std::exp(-5530.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                    .Build();

--- a/test/unit/processes/dissolved_reaction.cpp
+++ b/test/unit/processes/dissolved_reaction.cpp
@@ -86,7 +86,7 @@ TEST(DissolvedReaction, SpeciesUsedWithSinglePrefix)
 
   auto rate = [](const micm::Conditions& conditions) { return 0.1; };
 
-  DissolvedReaction reaction{ rate,
+  DissolvedReaction reaction{ { { "SMALL_DROP", rate } },
                               { a },    // reactants
                               { b },    // products
                               solvent,  // solvent
@@ -115,7 +115,7 @@ TEST(DissolvedReaction, SpeciesUsedWithMultiplePrefixes)
 
   auto rate = [](const micm::Conditions& conditions) { return 0.1; };
 
-  DissolvedReaction reaction{ rate,
+  DissolvedReaction reaction{ { { "SMALL_DROP", rate }, { "LARGE_DROP", rate } },
                               { a, b },  // reactants
                               { c },     // products
                               solvent,   // solvent
@@ -149,7 +149,7 @@ TEST(DissolvedReaction, SpeciesUsedWithNoMatchingPhase)
 
   auto rate = [](const micm::Conditions& conditions) { return 0.1; };
 
-  DissolvedReaction reaction{ rate, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { { "DROP", rate } }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["ORGANIC"].insert("AEROSOL_MODE");
@@ -167,7 +167,7 @@ TEST(DissolvedReaction, SpeciesUsedDuplicateHandling)
 
   auto rate = [](const micm::Conditions& conditions) { return 0.1; };
 
-  DissolvedReaction reaction{ rate,
+  DissolvedReaction reaction{ { { "MODE1", rate } },
                               { a },  // reactants
                               { b },  // products
                               a,      // solvent (same as reactant)
@@ -203,7 +203,7 @@ TEST(DissolvedReaction, NonZeroJacobianElementsBasic)
 
   auto rate = [](const micm::Conditions& conditions) { return 0.1; };
 
-  DissolvedReaction reaction{ rate,
+  DissolvedReaction reaction{ { { "MODE1", rate } },
                               { a },     // 1 reactant
                               { b, c },  // 2 products
                               solvent,
@@ -255,7 +255,7 @@ TEST(DissolvedReaction, NonZeroJacobianElementsMultipleReactants)
 
   auto rate = [](const micm::Conditions& conditions) { return 0.1; };
 
-  DissolvedReaction reaction{ rate,
+  DissolvedReaction reaction{ { { "DROP", rate } },
                               { a, b },  // 2 reactants
                               { c },     // 1 product
                               solvent,
@@ -292,7 +292,7 @@ TEST(DissolvedReaction, NonZeroJacobianElementsMultiplePrefixes)
   auto rate = [](const micm::Conditions& conditions) { return 0.1; };
 
   // A -> B with solvent S
-  DissolvedReaction reaction{ rate, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { { "SMALL_DROP", rate }, { "LARGE_DROP", rate } }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("SMALL_DROP");
@@ -329,12 +329,12 @@ TEST(DissolvedReaction, UpdateStateParametersFunctionBasic)
   double k = 0.1;
   auto rate = [k](const micm::Conditions& conditions) { return k; };
 
-  DissolvedReaction reaction{ rate, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { { "MODE1", rate } }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "MODE1." + phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -368,12 +368,12 @@ TEST(DissolvedReaction, UpdateStateParametersFunctionTemperatureDependent)
 
   auto rate = [](const micm::Conditions& conditions) { return 0.1 * std::exp(-3000.0 / conditions.temperature_); };
 
-  DissolvedReaction reaction{ rate, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { { "DROPLET", rate } }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROPLET");
 
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "DROPLET." + phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -410,7 +410,7 @@ TEST(DissolvedReaction, UpdateStateParametersFunctionMissingParameter)
 
   auto rate = [](const micm::Conditions& conditions) { return 0.1; };
 
-  DissolvedReaction reaction{ rate, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { { "MODE1", rate } }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
@@ -440,12 +440,12 @@ TEST(DissolvedReaction, ForcingFunctionBasicRates)
   auto rate = [k](const micm::Conditions& conditions) { return k; };
 
   // A -> B with solvent S
-  DissolvedReaction reaction{ rate, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { { "MODE1", rate } }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "MODE1." + phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -496,7 +496,7 @@ TEST(DissolvedReaction, ForcingFunctionSolventNormalization)
   auto rate = [k](const micm::Conditions& conditions) { return k; };
 
   // A + B -> C with solvent S
-  DissolvedReaction reaction{ rate,
+  DissolvedReaction reaction{ { { "DROP", rate } },
                               { a, b },  // 2 reactants
                               { c },     // 1 product
                               solvent,
@@ -505,7 +505,7 @@ TEST(DissolvedReaction, ForcingFunctionSolventNormalization)
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -556,7 +556,7 @@ TEST(DissolvedReaction, ForcingFunctionMultipleProducts)
   auto rate = [k](const micm::Conditions& conditions) { return k; };
 
   // A -> B + C with solvent S
-  DissolvedReaction reaction{ rate,
+  DissolvedReaction reaction{ { { "DROP", rate } },
                               { a },     // 1 reactant
                               { b, c },  // 2 products
                               solvent,
@@ -565,7 +565,7 @@ TEST(DissolvedReaction, ForcingFunctionMultipleProducts)
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -614,12 +614,12 @@ TEST(DissolvedReaction, ForcingFunctionMultipleCells)
   double k = 0.1;
   auto rate = [k](const micm::Conditions& conditions) { return k; };
 
-  DissolvedReaction reaction{ rate, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { { "MODE1", rate } }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "MODE1." + phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -670,16 +670,18 @@ TEST(DissolvedReaction, ForcingFunctionMultiplePhaseInstances)
   double k = 0.1;
   auto rate = [k](const micm::Conditions& conditions) { return k; };
 
-  DissolvedReaction reaction{ rate, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { { "SMALL_DROP", rate }, { "LARGE_DROP", rate } }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("SMALL_DROP");
   phase_prefixes["AQUEOUS"].insert("LARGE_DROP");
 
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_small = "SMALL_DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_large = "LARGE_DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
-  state_parameter_indices[k_param] = 0;
+  state_parameter_indices[k_small] = 0;
+  state_parameter_indices[k_large] = 1;
 
   std::unordered_map<std::string, std::size_t> state_variable_indices;
   state_variable_indices["SMALL_DROP.AQUEOUS.A"] = 0;
@@ -692,8 +694,9 @@ TEST(DissolvedReaction, ForcingFunctionMultiplePhaseInstances)
   auto forcing_func =
       reaction.ForcingFunction<MatrixPolicy>(phase_prefixes, state_parameter_indices, state_variable_indices);
 
-  MatrixPolicy state_parameters(1, 1);
+  MatrixPolicy state_parameters(1, 2);
   state_parameters[0][0] = k;
+  state_parameters[0][1] = k;
 
   MatrixPolicy state_variables(1, 6);
   // Small drop
@@ -741,12 +744,12 @@ TEST(DissolvedReaction, JacobianFunctionBasicPartials)
   auto rate = [k](const micm::Conditions& conditions) { return k; };
 
   // A -> B with solvent S
-  DissolvedReaction reaction{ rate, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { { "MODE1", rate } }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "MODE1." + phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -809,7 +812,7 @@ TEST(DissolvedReaction, JacobianFunctionMultipleReactants)
   auto rate = [k](const micm::Conditions& conditions) { return k; };
 
   // A + B -> C with solvent S
-  DissolvedReaction reaction{ rate,
+  DissolvedReaction reaction{ { { "DROP", rate } },
                               { a, b },  // 2 reactants
                               { c },     // 1 product
                               solvent,
@@ -818,7 +821,7 @@ TEST(DissolvedReaction, JacobianFunctionMultipleReactants)
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -897,7 +900,7 @@ TEST(DissolvedReaction, JacobianFunctionSolventPartial)
 
   // A + C -> B with solvent C (solvent is a reactant)
   // n_r = 2, rate = k / [C]^1 * [A] * [C] = k * [A]
-  DissolvedReaction reaction{ rate,
+  DissolvedReaction reaction{ { { "MODE1", rate } },
                               { a, c },  // 2 reactants (C is also solvent)
                               { b },     // 1 product
                               c,         // solvent = reactant C
@@ -906,7 +909,7 @@ TEST(DissolvedReaction, JacobianFunctionSolventPartial)
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "MODE1." + phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -970,12 +973,12 @@ TEST(DissolvedReaction, JacobianFDUnimolecular)
   auto phase = micm::Phase{ "AQUEOUS", { { a }, { b }, { s } } };
 
   double k = 0.1;
-  DissolvedReaction reaction{ [k](const micm::Conditions&) { return k; }, { a }, { b }, s, phase };
+  DissolvedReaction reaction{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a }, { b }, s, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{ { "DROP.AQUEOUS.A", 0 },
                                                     { "DROP.AQUEOUS.B", 1 },
@@ -1001,12 +1004,12 @@ TEST(DissolvedReaction, JacobianFDBimolecular)
   auto phase = micm::Phase{ "AQUEOUS", { { a }, { b }, { c }, { s } } };
 
   double k = 1.0;
-  DissolvedReaction reaction{ [k](const micm::Conditions&) { return k; }, { a, b }, { c }, s, phase };
+  DissolvedReaction reaction{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a, b }, { c }, s, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{
     { "DROP.AQUEOUS.A", 0 }, { "DROP.AQUEOUS.B", 1 }, { "DROP.AQUEOUS.C", 2 }, { "DROP.AQUEOUS.S", 3 }
@@ -1032,12 +1035,12 @@ TEST(DissolvedReaction, JacobianFDMultiCell)
   auto phase = micm::Phase{ "AQUEOUS", { { a }, { b }, { s } } };
 
   double k = 0.5;
-  DissolvedReaction reaction{ [k](const micm::Conditions&) { return k; }, { a }, { b }, s, phase };
+  DissolvedReaction reaction{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a }, { b }, s, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{ { "DROP.AQUEOUS.A", 0 },
                                                     { "DROP.AQUEOUS.B", 1 },
@@ -1068,20 +1071,27 @@ TEST(DissolvedReaction, JacobianFDMultiPhaseInstance)
   auto phase = micm::Phase{ "AQUEOUS", { { a }, { b }, { s } } };
 
   double k = 0.2;
-  DissolvedReaction reaction{ [k](const micm::Conditions&) { return k; }, { a }, { b }, s, phase };
+  DissolvedReaction reaction{ { { "SMALL", [k](const micm::Conditions&) { return k; } },
+                                { "LARGE", [k](const micm::Conditions&) { return k; } } },
+                              { a },
+                              { b },
+                              s,
+                              phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("SMALL");
   phase_prefixes["AQUEOUS"].insert("LARGE");
 
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
-  std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
+  std::string k_small = "SMALL." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_large = "LARGE." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::unordered_map<std::string, std::size_t> spi{ { k_small, 0 }, { k_large, 1 } };
   std::unordered_map<std::string, std::size_t> svi{ { "SMALL.AQUEOUS.A", 0 }, { "SMALL.AQUEOUS.B", 1 },
                                                     { "SMALL.AQUEOUS.S", 2 }, { "LARGE.AQUEOUS.A", 3 },
                                                     { "LARGE.AQUEOUS.B", 4 }, { "LARGE.AQUEOUS.S", 5 } };
 
-  MatrixPolicy params(1, 1);
+  MatrixPolicy params(1, 2);
   params[0][0] = k;
+  params[0][1] = k;
   MatrixPolicy vars(1, 6);
   vars[0][0] = 2.0e-3;
   vars[0][1] = 0.0;
@@ -1102,12 +1112,12 @@ TEST(DissolvedReaction, JacobianFDSolventIsReactant)
   auto phase = micm::Phase{ "AQUEOUS", { { a }, { b }, { c } } };
 
   double k = 2.0;
-  DissolvedReaction reaction{ [k](const micm::Conditions&) { return k; }, { a, c }, { b }, c, phase };
+  DissolvedReaction reaction{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a, c }, { b }, c, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{ { "DROP.AQUEOUS.A", 0 },
                                                     { "DROP.AQUEOUS.C", 1 },
@@ -1139,12 +1149,12 @@ TEST(DissolvedReaction, ForcingFunctionSolventFloorZeroSolvent)
   auto phase = micm::Phase{ "AQUEOUS", { { a }, { b }, { c }, { s } } };
 
   double k = 1.0;
-  DissolvedReaction reaction{ [k](const micm::Conditions&) { return k; }, { a, b }, { c }, s, phase };
+  DissolvedReaction reaction{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a, b }, { c }, s, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{
     { "DROP.AQUEOUS.A", 0 }, { "DROP.AQUEOUS.B", 1 }, { "DROP.AQUEOUS.C", 2 }, { "DROP.AQUEOUS.S", 3 }

--- a/test/unit/processes/dissolved_reaction.cpp
+++ b/test/unit/processes/dissolved_reaction.cpp
@@ -1191,12 +1191,12 @@ TEST(DissolvedReaction, JacobianFunctionSolventFloorZeroSolvent)
   auto phase = micm::Phase{ "AQUEOUS", { { a }, { b }, { c }, { s } } };
 
   double k = 1.0;
-  DissolvedReaction reaction{ [k](const micm::Conditions&) { return k; }, { a, b }, { c }, s, phase };
+  DissolvedReaction reaction{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a, b }, { c }, s, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{
     { "DROP.AQUEOUS.A", 0 }, { "DROP.AQUEOUS.B", 1 }, { "DROP.AQUEOUS.C", 2 }, { "DROP.AQUEOUS.S", 3 }
@@ -1273,13 +1273,13 @@ TEST(DissolvedReaction, ForcingFunctionCappedUncappedRegime)
   double k = 1.0e-6;    // very slow
   double t_half = 1.0;  // short half-life → r_max = [A] / t_half = large compared to r
 
-  DissolvedReaction uncapped{ [k](const micm::Conditions&) { return k; }, { a }, { b }, s, phase };
-  DissolvedReaction capped{ [k](const micm::Conditions&) { return k; }, { a }, { b }, s, phase, 1.0e-20, t_half };
+  DissolvedReaction uncapped{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a }, { b }, s, phase };
+  DissolvedReaction capped{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a }, { b }, s, phase, 1.0e-20, t_half };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
-  std::string k_param = phase.name_ + "." + uncapped.uuid_ + ".k";
-  std::string k_param_c = phase.name_ + "." + capped.uuid_ + ".k";
+  std::string k_param = "DROP." + phase.name_ + "." + uncapped.uuid_ + ".k";
+  std::string k_param_c = "DROP." + phase.name_ + "." + capped.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi_u{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> spi_c{ { k_param_c, 0 } };
   std::unordered_map<std::string, std::size_t> svi{ { "DROP.AQUEOUS.A", 0 },
@@ -1320,11 +1320,11 @@ TEST(DissolvedReaction, ForcingFunctionCappedSaturatedRegime)
   double k = 1.0e6;        // very fast reaction
   double t_half = 1000.0;  // long half-life → r_max = [A] / t_half = small
 
-  DissolvedReaction reaction{ [k](const micm::Conditions&) { return k; }, { a }, { b }, s, phase, 1.0e-20, t_half };
+  DissolvedReaction reaction{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a }, { b }, s, phase, 1.0e-20, t_half };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{ { "DROP.AQUEOUS.A", 0 },
                                                     { "DROP.AQUEOUS.B", 1 },
@@ -1361,11 +1361,11 @@ TEST(DissolvedReaction, JacobianFDCappedUncappedRegime)
   double k = 1.0e-5;    // slow reaction, uncapped
   double t_half = 0.1;  // r_max = [A]/t_half >> r
 
-  DissolvedReaction reaction{ [k](const micm::Conditions&) { return k; }, { a }, { b }, s, phase, 1.0e-20, t_half };
+  DissolvedReaction reaction{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a }, { b }, s, phase, 1.0e-20, t_half };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{ { "DROP.AQUEOUS.A", 0 },
                                                     { "DROP.AQUEOUS.B", 1 },
@@ -1392,11 +1392,11 @@ TEST(DissolvedReaction, JacobianFDCappedSaturatedRegime)
   double k = 1.0e5;  // fast reaction, deeply capped
   double t_half = 1000.0;
 
-  DissolvedReaction reaction{ [k](const micm::Conditions&) { return k; }, { a }, { b }, s, phase, 1.0e-20, t_half };
+  DissolvedReaction reaction{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a }, { b }, s, phase, 1.0e-20, t_half };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{ { "DROP.AQUEOUS.A", 0 },
                                                     { "DROP.AQUEOUS.B", 1 },
@@ -1428,11 +1428,11 @@ TEST(DissolvedReaction, JacobianFDCappedBimolecular)
   double k = 50.0;       // moderately fast
   double t_half = 10.0;  // r_max = min(A,B) / t_half
 
-  DissolvedReaction reaction{ [k](const micm::Conditions&) { return k; }, { a, b }, { c }, s, phase, 1.0e-20, t_half };
+  DissolvedReaction reaction{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a, b }, { c }, s, phase, 1.0e-20, t_half };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
-  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{
     { "DROP.AQUEOUS.A", 0 }, { "DROP.AQUEOUS.B", 1 }, { "DROP.AQUEOUS.C", 2 }, { "DROP.AQUEOUS.S", 3 }


### PR DESCRIPTION
- `DissolvedReaction` uses `AddRateConstant()` because rate constant can differ per representation
- `DissolvedReversibleReaction` uses `SetForwardRateConstant` / `SetReverseRateConstant` / `SetEquilibriumConstant` without  representation prefix because its rate constants depend on the temperature, which can be shared across all representations of the phase. - there is no code change in this implementation

```C++
  // Current PR requires to create phase per representation for DissolvedReaction
  auto small_aqueous = Phase{ "AQUEOUS_SMALL", { { A }, { B }, { C } } };
  auto large_aqueous = Phase{ "AQUEOUS_LARGE", { { A }, { B }, { C } } };
  auto reaction_small = DissolvedReaction{ rate_small, { A }, { B }, C, small_aqueous };
  auto reaction_large = DissolvedReaction{ rate_large, { A }, { B }, C, large_aqueous };

  // This PR adds rate constant per representation which allows the use of the same phase, 
  // unlike the current implementation
  auto aqueous_phase = Phase{ "AQUEOUS", { { A }, { B }, { C } } };
  auto reaction = DissolvedReactionBuilder{}
                      .SetPhase(aqueous_phase)
                      .SetReactants({ A })
                      .SetProducts({ B })
                      .SetSolvent(C)
                      .AddRateConstant("DROPLET_SMALL", rate_small)
                      .AddRateConstant("DROPLET_LARGE", rate_large)
                      .Build();
```
- Closes #35 