### PR TITLE
Fix inconsistent naming in Henry's Law implementation 

### DIFF
--- a/docs/source/api_reference/utilities.rst
+++ b/docs/source/api_reference/utilities.rst
@@ -21,7 +21,7 @@ Rate Constants
    :members:
    :undoc-members:
 
-.. doxygenclass:: miam::HenrysLawConstant
+.. doxygenclass:: miam::HenryLawConstant
    :members:
    :undoc-members:
 

--- a/docs/source/developer_guide/testing.rst
+++ b/docs/source/developer_guide/testing.rst
@@ -26,7 +26,7 @@ Test Structure
    │   └── processes/                 # process unit tests
    │       ├── dissolved_reversible_reaction.cpp
    │       ├── henry_law_phase_transfer.cpp
-   │       └── henrys_law_constant.cpp
+   │       └── henry_law_constant.cpp
    └── integration/
        ├── CMakeLists.txt
        ├── test_dissolved_reversible_reaction.cpp

--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -13,7 +13,7 @@ Save the following as ``cloud_chem.cpp``:
 .. code-block:: c++
 
    #include <miam/miam.hpp>
-   #include <miam/processes/constants/henrys_law_constant.hpp>
+   #include <miam/processes/constants/henry_law_constant.hpp>
    #include <micm/CPU.hpp>
 
    #include <iomanip>
@@ -50,7 +50,7 @@ Save the following as ``cloud_chem.cpp``:
        .SetGasSpecies(co2)
        .SetCondensedSpecies(co2)
        .SetSolvent(h2o)
-       .SetHenrysLawConstant(HenrysLawConstant(
+       .SetHenryLawConstant(HenryLawConstant(
            { .HLC_ref_ = 3.4e-2 }))       // mol m-3 Pa-1 at 298 K
        .SetDiffusionCoefficient(1.5e-5)    // m2 s-1
        .SetAccommodationCoefficient(5.0e-6)

--- a/docs/source/user_guide/processes.rst
+++ b/docs/source/user_guide/processes.rst
@@ -74,14 +74,14 @@ Gas-condensed phase mass transfer governed by Henry's Law:
 .. code-block:: c++
 
    #include <miam/miam.hpp>
-   #include <miam/processes/constants/henrys_law_constant.hpp>
+   #include <miam/processes/constants/henry_law_constant.hpp>
 
    auto transfer = HenryLawPhaseTransferBuilder()
      .SetCondensedPhase(aqueous_phase)
      .SetGasSpecies(A_gas)
      .SetCondensedSpecies(A_aq)
      .SetSolvent(H2O)
-     .SetHenrysLawConstant(HenrysLawConstant(
+     .SetHenryLawConstant(HenryLawConstant(
          { .HLC_ref_ = 3.4e-2, .C_ = 2400.0, .T0_ = 298.15 }))
      .SetDiffusionCoefficient(1.5e-5)    // m2 s-1
      .SetAccommodationCoefficient(0.05)  // dimensionless
@@ -105,7 +105,7 @@ Builder methods
        and ``density``)
    * - ``SetSolvent(species)``
      - Solvent species (must carry ``molecular weight`` and ``density``)
-   * - ``SetHenrysLawConstant(obj)``
+   * - ``SetHenryLawConstant(obj)``
      - Temperature-dependent HLC: :math:`H(T) = H_\text{ref} \exp(C(1/T - 1/T_0))`
    * - ``SetDiffusionCoefficient(D_g)``
      - Gas-phase diffusion coefficient [m² s⁻¹]
@@ -138,7 +138,7 @@ Temperature-dependent equilibrium constant:
 
    double value = keq.Calculate(conditions);
 
-HenrysLawConstant
+HenryLawConstant
 ------------------
 
 Temperature-dependent Henry's Law constant:
@@ -149,7 +149,7 @@ Temperature-dependent Henry's Law constant:
 
 .. code-block:: c++
 
-   HenrysLawConstant hlc(
+   HenryLawConstant hlc(
        { .HLC_ref_ = 3.4e-2, .C_ = 2400.0, .T0_ = 298.15 });
 
    double value = hlc.Calculate(conditions);  // mol m-3 Pa-1

--- a/include/miam/processes.hpp
+++ b/include/miam/processes.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <miam/processes/constants/equilibrium_constant.hpp>
-#include <miam/processes/constants/henrys_law_constant.hpp>
+#include <miam/processes/constants/henry_law_constant.hpp>
 #include <miam/processes/dissolved_reaction.hpp>
 #include <miam/processes/dissolved_reaction_builder.hpp>
 #include <miam/processes/dissolved_reversible_reaction.hpp>

--- a/include/miam/processes/constants/henry_law_constant.hpp
+++ b/include/miam/processes/constants/henry_law_constant.hpp
@@ -10,7 +10,7 @@
 namespace miam
 {
   /// @brief Parameters for a Henry's Law constant
-  struct HenrysLawConstantParameters
+  struct HenryLawConstantParameters
   {
     /// @brief Henry's Law constant at reference temperature [mol m⁻³ Pa⁻¹]
     double HLC_ref_{ 1.0 };
@@ -23,20 +23,20 @@ namespace miam
   /// @brief A Henry's Law constant dependent on temperature
   /// @details Calculates Henry's Law constant as:
   ///          HLC(T) = HLC_ref * exp( C * ( 1 / T - 1 / T0 ) )
-  class HenrysLawConstant
+  class HenryLawConstant
   {
    public:
-    const HenrysLawConstantParameters parameters_;
+    const HenryLawConstantParameters parameters_;
 
     /// @brief Default constructor
-    HenrysLawConstant()
+    HenryLawConstant()
         : parameters_()
     {
     }
 
     /// @brief Constructor with parameters
     /// @param parameters A set of Henry's Law constant parameters
-    HenrysLawConstant(const HenrysLawConstantParameters& parameters)
+    HenryLawConstant(const HenryLawConstantParameters& parameters)
         : parameters_(parameters)
     {
     }

--- a/include/miam/processes/henry_law_phase_transfer_builder.hpp
+++ b/include/miam/processes/henry_law_phase_transfer_builder.hpp
@@ -56,7 +56,7 @@ namespace miam
     }
 
     /// @brief Sets the Henry's Law constant
-    HenryLawPhaseTransferBuilder& SetHenrysLawConstant(const auto& henry_law_constant)
+    HenryLawPhaseTransferBuilder& SetHenryLawConstant(const auto& henry_law_constant)
     {
       henry_law_constant_ = [henry_law_constant](const micm::Conditions& conditions)
       { return henry_law_constant.Calculate(conditions); };

--- a/test/integration/test_aqueous_carbonic_acid.cpp
+++ b/test/integration/test_aqueous_carbonic_acid.cpp
@@ -33,7 +33,7 @@
 
 #include <miam/miam.hpp>
 #include <miam/processes/constants/equilibrium_constant.hpp>
-#include <miam/processes/constants/henrys_law_constant.hpp>
+#include <miam/processes/constants/henry_law_constant.hpp>
 
 #include <micm/CPU.hpp>
 #include <micm/util/constants.hpp>
@@ -244,7 +244,7 @@ TEST(AqueousCarbonicAcid, KineticODE)
                       .SetGasSpecies(sys.CO2_g)
                       .SetCondensedSpecies(sys.CO2_aq)
                       .SetSolvent(sys.H2O)
-                      .SetHenrysLawConstant(HenrysLawConstant(HenrysLawConstantParameters{ .HLC_ref_ = K_H }))
+                      .SetHenryLawConstant(HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = K_H }))
                       .SetDiffusionCoefficient(D_CO2)
                       .SetAccommodationCoefficient(alpha)
                       .Build();
@@ -428,7 +428,7 @@ TEST(AqueousCarbonicAcid, DAEConstraints)
                            .SetGasSpecies(sys.CO2_g)
                            .SetCondensedSpecies(sys.CO2_aq)
                            .SetSolvent(sys.H2O)
-                           .SetHenryLawConstant(HenrysLawConstant(HenrysLawConstantParameters{ .HLC_ref_ = K_H }))
+                           .SetHenryLawConstant(HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = K_H }))
                            .Build();
 
   // OH-: water autodissociation equilibrium

--- a/test/integration/test_cam_cloud_chemistry.cpp
+++ b/test/integration/test_cam_cloud_chemistry.cpp
@@ -19,7 +19,7 @@
 
 #include <miam/miam.hpp>
 #include <miam/processes/constants/equilibrium_constant.hpp>
-#include <miam/processes/constants/henrys_law_constant.hpp>
+#include <miam/processes/constants/henry_law_constant.hpp>
 
 #include <micm/CPU.hpp>
 #include <micm/util/constants.hpp>
@@ -232,7 +232,7 @@ TEST(CamCloudChemistry, Step1_SingleHLC)
                     .SetCondensedSpecies(so2_aq)
                     .SetSolvent(h2o)
                     .SetCondensedPhase(aqueous_phase)
-                    .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = HLC_ref, .C_ = C_hlc }))
+                    .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = HLC_ref, .C_ = C_hlc }))
                     .Build();
 
   // Mass conservation: [SO2_g] + [SO2_aq] = total  (SO2_g algebraic)
@@ -520,7 +520,7 @@ TEST(CamCloudChemistry, Step2_HLC_Plus_Dissociation)
                     .SetCondensedSpecies(so2_aq)
                     .SetSolvent(h2o)
                     .SetCondensedPhase(aqueous_phase)
-                    .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = HLC_ref, .C_ = C_hlc }))
+                    .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = HLC_ref, .C_ = C_hlc }))
                     .Build();
 
   // Kw: H2O ⇌ H+ + OH-
@@ -733,7 +733,7 @@ TEST(CamCloudChemistry, Step3_FullEquilibrium)
                     .SetCondensedSpecies(so2_aq)
                     .SetSolvent(h2o)
                     .SetCondensedPhase(aqueous_phase)
-                    .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
+                    .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
                     .Build();
 
   auto hl_h2o2 = HenryLawEquilibriumConstraintBuilder()
@@ -741,7 +741,7 @@ TEST(CamCloudChemistry, Step3_FullEquilibrium)
                      .SetCondensedSpecies(h2o2_aq)
                      .SetSolvent(h2o)
                      .SetCondensedPhase(aqueous_phase)
-                     .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
+                     .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
                      .Build();
 
   auto hl_o3 = HenryLawEquilibriumConstraintBuilder()
@@ -749,7 +749,7 @@ TEST(CamCloudChemistry, Step3_FullEquilibrium)
                    .SetCondensedSpecies(o3_aq)
                    .SetSolvent(h2o)
                    .SetCondensedPhase(aqueous_phase)
-                   .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
+                   .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
                    .Build();
 
   // --- Dissociation equilibria ---
@@ -977,7 +977,7 @@ TEST(CamCloudChemistry, Step3b_NaiveInitialConditions)
                     .SetCondensedSpecies(so2_aq)
                     .SetSolvent(h2o)
                     .SetCondensedPhase(aqueous_phase)
-                    .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
+                    .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
                     .Build();
 
   auto hl_h2o2 = HenryLawEquilibriumConstraintBuilder()
@@ -985,7 +985,7 @@ TEST(CamCloudChemistry, Step3b_NaiveInitialConditions)
                      .SetCondensedSpecies(h2o2_aq)
                      .SetSolvent(h2o)
                      .SetCondensedPhase(aqueous_phase)
-                     .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
+                     .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
                      .Build();
 
   auto hl_o3 = HenryLawEquilibriumConstraintBuilder()
@@ -993,7 +993,7 @@ TEST(CamCloudChemistry, Step3b_NaiveInitialConditions)
                    .SetCondensedSpecies(o3_aq)
                    .SetSolvent(h2o)
                    .SetCondensedPhase(aqueous_phase)
-                   .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
+                   .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
                    .Build();
 
   auto eq_kw = DissolvedEquilibriumConstraintBuilder()
@@ -1184,7 +1184,7 @@ TEST(CamCloudChemistry, Step4_FullSystemWithKinetics)
                     .SetCondensedSpecies(so2_aq)
                     .SetSolvent(h2o)
                     .SetCondensedPhase(aqueous_phase)
-                    .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
+                    .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
                     .Build();
 
   auto hl_h2o2 = HenryLawEquilibriumConstraintBuilder()
@@ -1192,7 +1192,7 @@ TEST(CamCloudChemistry, Step4_FullSystemWithKinetics)
                      .SetCondensedSpecies(h2o2_aq)
                      .SetSolvent(h2o)
                      .SetCondensedPhase(aqueous_phase)
-                     .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
+                     .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
                      .Build();
 
   auto hl_o3 = HenryLawEquilibriumConstraintBuilder()
@@ -1200,7 +1200,7 @@ TEST(CamCloudChemistry, Step4_FullSystemWithKinetics)
                    .SetCondensedSpecies(o3_aq)
                    .SetSolvent(h2o)
                    .SetCondensedPhase(aqueous_phase)
-                   .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
+                   .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
                    .Build();
 
   // --- Dissociation equilibria ---
@@ -1521,7 +1521,7 @@ TEST(CamCloudChemistry, Step4b_NaiveInitialConditions)
                     .SetCondensedSpecies(so2_aq)
                     .SetSolvent(h2o)
                     .SetCondensedPhase(aqueous_phase)
-                    .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
+                    .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
                     .Build();
 
   auto hl_h2o2 = HenryLawEquilibriumConstraintBuilder()
@@ -1529,7 +1529,7 @@ TEST(CamCloudChemistry, Step4b_NaiveInitialConditions)
                      .SetCondensedSpecies(h2o2_aq)
                      .SetSolvent(h2o)
                      .SetCondensedPhase(aqueous_phase)
-                     .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
+                     .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
                      .Build();
 
   auto hl_o3 = HenryLawEquilibriumConstraintBuilder()
@@ -1537,7 +1537,7 @@ TEST(CamCloudChemistry, Step4b_NaiveInitialConditions)
                    .SetCondensedSpecies(o3_aq)
                    .SetSolvent(h2o)
                    .SetCondensedPhase(aqueous_phase)
-                   .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
+                   .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
                    .Build();
 
   auto eq_kw = DissolvedEquilibriumConstraintBuilder()
@@ -1799,7 +1799,7 @@ TEST(CamCloudChemistry, Step5_JacobianVerification)
                     .SetCondensedSpecies(so2_aq)
                     .SetSolvent(h2o)
                     .SetCondensedPhase(aqueous_phase)
-                    .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
+                    .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
                     .Build();
 
   auto hl_h2o2 = HenryLawEquilibriumConstraintBuilder()
@@ -1807,7 +1807,7 @@ TEST(CamCloudChemistry, Step5_JacobianVerification)
                      .SetCondensedSpecies(h2o2_aq)
                      .SetSolvent(h2o)
                      .SetCondensedPhase(aqueous_phase)
-                     .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
+                     .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
                      .Build();
 
   auto hl_o3 = HenryLawEquilibriumConstraintBuilder()
@@ -1815,7 +1815,7 @@ TEST(CamCloudChemistry, Step5_JacobianVerification)
                    .SetCondensedSpecies(o3_aq)
                    .SetSolvent(h2o)
                    .SetCondensedPhase(aqueous_phase)
-                   .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
+                   .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
                    .Build();
 
   auto eq_kw = DissolvedEquilibriumConstraintBuilder()

--- a/test/integration/test_henry_law_equilibrium_constraint.cpp
+++ b/test/integration/test_henry_law_equilibrium_constraint.cpp
@@ -4,7 +4,7 @@
 // Integration tests for HenryLawEquilibriumConstraint with the MICM DAE solver.
 
 #include <miam/miam.hpp>
-#include <miam/processes/constants/henrys_law_constant.hpp>
+#include <miam/processes/constants/henry_law_constant.hpp>
 
 #include <micm/CPU.hpp>
 
@@ -75,7 +75,7 @@ TEST(HenryLawEquilibriumConstraintIntegration, GasPhaseDriverSingleInstance)
                            .SetCondensedSpecies(A_aq)
                            .SetSolvent(H2O)
                            .SetCondensedPhase(aqueous_phase)
-                           .SetHenryLawConstant(HenrysLawConstant(HenrysLawConstantParameters{ .HLC_ref_ = HLC }))
+                           .SetHenryLawConstant(HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = HLC }))
                            .Build();
 
   // Mass conservation: [Precursor] + [A_g] + [A_aq] = total, A_g algebraic (global)
@@ -213,7 +213,7 @@ TEST(HenryLawEquilibriumConstraintIntegration, MultipleInstances)
                            .SetCondensedSpecies(A_aq)
                            .SetSolvent(H2O)
                            .SetCondensedPhase(aqueous_phase)
-                           .SetHenryLawConstant(HenrysLawConstant(HenrysLawConstantParameters{ .HLC_ref_ = HLC }))
+                           .SetHenryLawConstant(HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = HLC }))
                            .Build();
 
   double P0 = 1.0;

--- a/test/integration/test_henry_law_phase_transfer.cpp
+++ b/test/integration/test_henry_law_phase_transfer.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <miam/miam.hpp>
-#include <miam/processes/constants/henrys_law_constant.hpp>
+#include <miam/processes/constants/henry_law_constant.hpp>
 
 #include <micm/CPU.hpp>
 #include <micm/util/constants.hpp>
@@ -83,7 +83,7 @@ TEST(HenryLawPhaseTransferIntegration, SimpleOneInstance)
                       .SetGasSpecies(A_g)
                       .SetCondensedSpecies(A_aq)
                       .SetSolvent(H2O)
-                      .SetHenrysLawConstant(miam::HenrysLawConstant(HenrysLawConstantParameters{ .HLC_ref_ = HLC_val }))
+                      .SetHenryLawConstant(miam::HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = HLC_val }))
                       .SetDiffusionCoefficient(D_g)
                       .SetAccommodationCoefficient(alpha)
                       .Build();
@@ -218,7 +218,7 @@ TEST(HenryLawPhaseTransferIntegration, MultiInstanceMassConservation)
                       .SetGasSpecies(A_g)
                       .SetCondensedSpecies(A_aq)
                       .SetSolvent(H2O)
-                      .SetHenrysLawConstant(HenrysLawConstant(HenrysLawConstantParameters{ .HLC_ref_ = HLC_val }))
+                      .SetHenryLawConstant(HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = HLC_val }))
                       .SetDiffusionCoefficient(D_g)
                       .SetAccommodationCoefficient(alpha)
                       .Build();
@@ -321,7 +321,7 @@ TEST(HenryLawPhaseTransferIntegration, TemperatureDependentHLC)
 
   auto droplet = SingleMomentMode{ "DROP", { aqueous_phase }, 5.0e-6, 1.2 };
 
-  HenrysLawConstantParameters hlc_params{ .HLC_ref_ = HLC_ref, .C_ = C, .T0_ = T0 };
+  HenryLawConstantParameters hlc_params{ .HLC_ref_ = HLC_ref, .C_ = C, .T0_ = T0 };
 
   auto build_transfer = [&]()
   {
@@ -330,7 +330,7 @@ TEST(HenryLawPhaseTransferIntegration, TemperatureDependentHLC)
         .SetGasSpecies(A_g)
         .SetCondensedSpecies(A_aq)
         .SetSolvent(H2O)
-        .SetHenrysLawConstant(HenrysLawConstant(hlc_params))
+        .SetHenryLawConstant(HenryLawConstant(hlc_params))
         .SetDiffusionCoefficient(D_g)
         .SetAccommodationCoefficient(alpha)
         .Build();
@@ -443,7 +443,7 @@ TEST(HenryLawPhaseTransferIntegration, SmallVsLargeParticleRate)
                         .SetGasSpecies(A_g)
                         .SetCondensedSpecies(A_aq)
                         .SetSolvent(H2O)
-                        .SetHenrysLawConstant(HenrysLawConstant(HenrysLawConstantParameters{ .HLC_ref_ = HLC_val }))
+                        .SetHenryLawConstant(HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = HLC_val }))
                         .SetDiffusionCoefficient(D_g)
                         .SetAccommodationCoefficient(alpha)
                         .Build();

--- a/test/integration/test_jacobian_verification.cpp
+++ b/test/integration/test_jacobian_verification.cpp
@@ -7,7 +7,7 @@
 
 #include <miam/miam.hpp>
 #include <miam/processes/constants/equilibrium_constant.hpp>
-#include <miam/processes/constants/henrys_law_constant.hpp>
+#include <miam/processes/constants/henry_law_constant.hpp>
 
 #include <micm/CPU.hpp>
 #include <micm/util/jacobian_verification.hpp>
@@ -288,7 +288,7 @@ TEST(JacobianVerification, HenryLawPhaseTransferProcess)
                       .SetGasSpecies(A_g)
                       .SetCondensedSpecies(A_aq)
                       .SetSolvent(H2O)
-                      .SetHenrysLawConstant(HenrysLawConstant(HenrysLawConstantParameters{ .HLC_ref_ = HLC_val }))
+                      .SetHenryLawConstant(HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = HLC_val }))
                       .SetDiffusionCoefficient(D_g)
                       .SetAccommodationCoefficient(alpha)
                       .Build();
@@ -343,7 +343,7 @@ TEST(JacobianVerification, HenryLawPhaseTransferTwoMomentMode)
                       .SetGasSpecies(A_g)
                       .SetCondensedSpecies(A_aq)
                       .SetSolvent(H2O)
-                      .SetHenrysLawConstant(HenrysLawConstant(HenrysLawConstantParameters{ .HLC_ref_ = HLC_val }))
+                      .SetHenryLawConstant(HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = HLC_val }))
                       .SetDiffusionCoefficient(D_g)
                       .SetAccommodationCoefficient(alpha)
                       .Build();
@@ -540,7 +540,7 @@ TEST(JacobianVerification, HenryLawEquilibriumConstraint)
                            .SetCondensedSpecies(A_aq)
                            .SetSolvent(H2O)
                            .SetCondensedPhase(aqueous_phase)
-                           .SetHenryLawConstant(HenrysLawConstant(HenrysLawConstantParameters{ .HLC_ref_ = HLC }))
+                           .SetHenryLawConstant(HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = HLC }))
                            .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
@@ -663,7 +663,7 @@ TEST(JacobianVerification, HenryLawEquilibriumWithConservation)
                            .SetCondensedSpecies(A_aq)
                            .SetSolvent(H2O)
                            .SetCondensedPhase(aqueous_phase)
-                           .SetHenryLawConstant(HenrysLawConstant(HenrysLawConstantParameters{ .HLC_ref_ = HLC }))
+                           .SetHenryLawConstant(HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = HLC }))
                            .Build();
 
   double total = 1.0;

--- a/test/integration/test_kinetic_vs_constrained.cpp
+++ b/test/integration/test_kinetic_vs_constrained.cpp
@@ -6,7 +6,7 @@
 
 #include <miam/miam.hpp>
 #include <miam/processes/constants/equilibrium_constant.hpp>
-#include <miam/processes/constants/henrys_law_constant.hpp>
+#include <miam/processes/constants/henry_law_constant.hpp>
 
 #include <micm/CPU.hpp>
 #include <micm/util/constants.hpp>
@@ -331,7 +331,7 @@ TEST(KineticVsConstrained, HenryLawPhaseTransferVsEquilibriumConstraint)
                         .SetGasSpecies(A_g)
                         .SetCondensedSpecies(A_aq)
                         .SetSolvent(H2O)
-                        .SetHenrysLawConstant(HenrysLawConstant(HenrysLawConstantParameters{ .HLC_ref_ = HLC }))
+                        .SetHenryLawConstant(HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = HLC }))
                         .SetDiffusionCoefficient(D_g)
                         .SetAccommodationCoefficient(accommodation)
                         .Build();
@@ -382,7 +382,7 @@ TEST(KineticVsConstrained, HenryLawPhaseTransferVsEquilibriumConstraint)
                              .SetCondensedSpecies(A_aq)
                              .SetSolvent(H2O)
                              .SetCondensedPhase(aqueous_phase)
-                             .SetHenryLawConstant(HenrysLawConstant(HenrysLawConstantParameters{ .HLC_ref_ = HLC }))
+                             .SetHenryLawConstant(HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = HLC }))
                              .Build();
 
     auto mass_cons = LinearConstraintBuilder()

--- a/test/integration/test_readme_example.cpp
+++ b/test/integration/test_readme_example.cpp
@@ -4,7 +4,7 @@
 // Test that the README example compiles, runs, and produces expected output.
 
 #include <miam/miam.hpp>
-#include <miam/processes/constants/henrys_law_constant.hpp>
+#include <miam/processes/constants/henry_law_constant.hpp>
 
 #include <micm/CPU.hpp>
 
@@ -41,7 +41,7 @@ TEST(ReadmeExample, HenryLawPhaseTransfer)
                           .SetGasSpecies(co2)
                           .SetCondensedSpecies(co2)
                           .SetSolvent(h2o)
-                          .SetHenrysLawConstant(HenrysLawConstant({ .HLC_ref_ = 3.4e-2 }))  // mol m-3 Pa-1 at 298 K
+                          .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 3.4e-2 }))  // mol m-3 Pa-1 at 298 K
                           .SetDiffusionCoefficient(1.5e-5)                                  // m2 s-1
                           .SetAccommodationCoefficient(5.0e-6)  // Set artificially low to see transfer over 10 time steps
                           .Build();

--- a/test/integration/test_solvent_robustness.cpp
+++ b/test/integration/test_solvent_robustness.cpp
@@ -16,7 +16,7 @@
 
 #include <miam/miam.hpp>
 #include <miam/processes/constants/equilibrium_constant.hpp>
-#include <miam/processes/constants/henrys_law_constant.hpp>
+#include <miam/processes/constants/henry_law_constant.hpp>
 
 #include <micm/CPU.hpp>
 
@@ -168,7 +168,7 @@ namespace
                       .SetCondensedSpecies(sp.so2_aq)
                       .SetSolvent(sp.h2o)
                       .SetCondensedPhase(sp.aqueous_phase)
-                      .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
+                      .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
                       .Build();
 
     auto hl_h2o2 = HenryLawEquilibriumConstraintBuilder()
@@ -176,7 +176,7 @@ namespace
                        .SetCondensedSpecies(sp.h2o2_aq)
                        .SetSolvent(sp.h2o)
                        .SetCondensedPhase(sp.aqueous_phase)
-                       .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
+                       .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
                        .Build();
 
     auto hl_o3 = HenryLawEquilibriumConstraintBuilder()
@@ -184,7 +184,7 @@ namespace
                      .SetCondensedSpecies(sp.o3_aq)
                      .SetSolvent(sp.h2o)
                      .SetCondensedPhase(sp.aqueous_phase)
-                     .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
+                     .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
                      .Build();
 
     auto eq_kw = DissolvedEquilibriumConstraintBuilder()
@@ -566,7 +566,7 @@ TEST(SolventRobustness, A4_HenryLawConstraint_SolventSweep)
                       .SetCondensedSpecies(so2_aq)
                       .SetSolvent(h2o)
                       .SetCondensedPhase(aqueous_phase)
-                      .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
+                      .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
                       .Build();
 
     auto mass = LinearConstraintBuilder()
@@ -646,7 +646,7 @@ TEST(SolventRobustness, A5_HLC_Plus_Dissociation_SolventSweep)
                       .SetCondensedSpecies(so2_aq)
                       .SetSolvent(h2o)
                       .SetCondensedPhase(aqueous_phase)
-                      .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
+                      .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
                       .Build();
 
     auto eq_ka1 = DissolvedEquilibriumConstraintBuilder()
@@ -746,7 +746,7 @@ TEST(SolventRobustness, A6_FullEquilibrium_SolventSweep)
                       .SetCondensedSpecies(so2_aq)
                       .SetSolvent(h2o)
                       .SetCondensedPhase(aqueous_phase)
-                      .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
+                      .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 1.23 * M_ATM_TO_MOL_M3_PA, .C_ = 3120.0 }))
                       .Build();
 
     auto hl_h2o2 = HenryLawEquilibriumConstraintBuilder()
@@ -754,7 +754,7 @@ TEST(SolventRobustness, A6_FullEquilibrium_SolventSweep)
                        .SetCondensedSpecies(h2o2_aq)
                        .SetSolvent(h2o)
                        .SetCondensedPhase(aqueous_phase)
-                       .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
+                       .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 7.4e4 * M_ATM_TO_MOL_M3_PA, .C_ = 6621.0 }))
                        .Build();
 
     auto hl_o3 = HenryLawEquilibriumConstraintBuilder()
@@ -762,7 +762,7 @@ TEST(SolventRobustness, A6_FullEquilibrium_SolventSweep)
                      .SetCondensedSpecies(o3_aq)
                      .SetSolvent(h2o)
                      .SetCondensedPhase(aqueous_phase)
-                     .SetHenryLawConstant(HenrysLawConstant({ .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
+                     .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 1.15e-2 * M_ATM_TO_MOL_M3_PA, .C_ = 2560.0 }))
                      .Build();
 
     auto eq_kw = DissolvedEquilibriumConstraintBuilder()

--- a/test/unit/processes/CMakeLists.txt
+++ b/test/unit/processes/CMakeLists.txt
@@ -1,4 +1,4 @@
 create_standard_test(NAME dissolved_reaction SOURCES dissolved_reaction.cpp)
 create_standard_test(NAME dissolved_reversible_reaction SOURCES dissolved_reversible_reaction.cpp)
 create_standard_test(NAME henry_law_phase_transfer SOURCES henry_law_phase_transfer.cpp)
-create_standard_test(NAME henrys_law_constant SOURCES henrys_law_constant.cpp)
+create_standard_test(NAME henry_law_constant SOURCES henry_law_constant.cpp)

--- a/test/unit/processes/henry_law_constant.cpp
+++ b/test/unit/processes/henry_law_constant.cpp
@@ -1,4 +1,4 @@
-#include <miam/processes/constants/henrys_law_constant.hpp>
+#include <miam/processes/constants/henry_law_constant.hpp>
 
 #include <micm/system/conditions.hpp>
 
@@ -8,28 +8,28 @@
 
 using namespace miam;
 
-TEST(HenrysLawConstant, DefaultParameters)
+TEST(HenryLawConstant, DefaultParameters)
 {
-  HenrysLawConstant hlc;
+  HenryLawConstant hlc;
   EXPECT_DOUBLE_EQ(hlc.parameters_.HLC_ref_, 1.0);
   EXPECT_DOUBLE_EQ(hlc.parameters_.C_, 0.0);
   EXPECT_DOUBLE_EQ(hlc.parameters_.T0_, 298.15);
 }
 
-TEST(HenrysLawConstant, CustomParameters)
+TEST(HenryLawConstant, CustomParameters)
 {
-  HenrysLawConstantParameters params{ .HLC_ref_ = 3.4e-2, .C_ = 2500.0, .T0_ = 298.15 };
-  HenrysLawConstant hlc(params);
+  HenryLawConstantParameters params{ .HLC_ref_ = 3.4e-2, .C_ = 2500.0, .T0_ = 298.15 };
+  HenryLawConstant hlc(params);
   EXPECT_DOUBLE_EQ(hlc.parameters_.HLC_ref_, 3.4e-2);
   EXPECT_DOUBLE_EQ(hlc.parameters_.C_, 2500.0);
   EXPECT_DOUBLE_EQ(hlc.parameters_.T0_, 298.15);
 }
 
-TEST(HenrysLawConstant, AtReferenceTemperature)
+TEST(HenryLawConstant, AtReferenceTemperature)
 {
   // At reference temperature, exp term should be 1, so HLC = HLC_ref
-  HenrysLawConstantParameters params{ .HLC_ref_ = 3.4e-2, .C_ = 2500.0, .T0_ = 298.15 };
-  HenrysLawConstant hlc(params);
+  HenryLawConstantParameters params{ .HLC_ref_ = 3.4e-2, .C_ = 2500.0, .T0_ = 298.15 };
+  HenryLawConstant hlc(params);
 
   EXPECT_DOUBLE_EQ(hlc.Calculate(298.15), 3.4e-2);
 
@@ -38,23 +38,23 @@ TEST(HenrysLawConstant, AtReferenceTemperature)
   EXPECT_DOUBLE_EQ(hlc.Calculate(conditions), 3.4e-2);
 }
 
-TEST(HenrysLawConstant, ZeroTemperatureDependence)
+TEST(HenryLawConstant, ZeroTemperatureDependence)
 {
   // When C = 0, HLC is constant regardless of temperature
-  HenrysLawConstantParameters params{ .HLC_ref_ = 5.0e-3, .C_ = 0.0, .T0_ = 298.15 };
-  HenrysLawConstant hlc(params);
+  HenryLawConstantParameters params{ .HLC_ref_ = 5.0e-3, .C_ = 0.0, .T0_ = 298.15 };
+  HenryLawConstant hlc(params);
 
   EXPECT_DOUBLE_EQ(hlc.Calculate(200.0), 5.0e-3);
   EXPECT_DOUBLE_EQ(hlc.Calculate(298.15), 5.0e-3);
   EXPECT_DOUBLE_EQ(hlc.Calculate(400.0), 5.0e-3);
 }
 
-TEST(HenrysLawConstant, TemperatureDependence)
+TEST(HenryLawConstant, TemperatureDependence)
 {
   // HLC(T) = HLC_ref * exp(C * (1/T - 1/T0))
   // For SO2: HLC_ref = 1.23 mol/(m³·Pa), C = 3120 K, T0 = 298.15 K
-  HenrysLawConstantParameters params{ .HLC_ref_ = 1.23, .C_ = 3120.0, .T0_ = 298.15 };
-  HenrysLawConstant hlc(params);
+  HenryLawConstantParameters params{ .HLC_ref_ = 1.23, .C_ = 3120.0, .T0_ = 298.15 };
+  HenryLawConstant hlc(params);
 
   double T = 280.0;
   double expected = 1.23 * std::exp(3120.0 * (1.0 / T - 1.0 / 298.15));
@@ -67,10 +67,10 @@ TEST(HenrysLawConstant, TemperatureDependence)
   EXPECT_LT(hlc.Calculate(320.0), hlc.Calculate(298.15));
 }
 
-TEST(HenrysLawConstant, ConditionsOverload)
+TEST(HenryLawConstant, ConditionsOverload)
 {
-  HenrysLawConstantParameters params{ .HLC_ref_ = 0.8, .C_ = 2000.0, .T0_ = 298.15 };
-  HenrysLawConstant hlc(params);
+  HenryLawConstantParameters params{ .HLC_ref_ = 0.8, .C_ = 2000.0, .T0_ = 298.15 };
+  HenryLawConstant hlc(params);
 
   micm::Conditions conditions;
   conditions.temperature_ = 310.0;
@@ -80,11 +80,11 @@ TEST(HenrysLawConstant, ConditionsOverload)
   EXPECT_DOUBLE_EQ(hlc.Calculate(conditions), hlc.Calculate(310.0));
 }
 
-TEST(HenrysLawConstant, NegativeTemperatureDependence)
+TEST(HenryLawConstant, NegativeTemperatureDependence)
 {
   // Some species have negative C (solubility increases with temperature)
-  HenrysLawConstantParameters params{ .HLC_ref_ = 2.0, .C_ = -1500.0, .T0_ = 298.15 };
-  HenrysLawConstant hlc(params);
+  HenryLawConstantParameters params{ .HLC_ref_ = 2.0, .C_ = -1500.0, .T0_ = 298.15 };
+  HenryLawConstant hlc(params);
 
   // At lower temperature, HLC should decrease (negative C)
   EXPECT_LT(hlc.Calculate(280.0), hlc.Calculate(298.15));
@@ -93,14 +93,14 @@ TEST(HenrysLawConstant, NegativeTemperatureDependence)
   EXPECT_GT(hlc.Calculate(320.0), hlc.Calculate(298.15));
 }
 
-TEST(HenrysLawConstant, KnownValues)
+TEST(HenryLawConstant, KnownValues)
 {
   // Verify against hand-calculated value
   // HLC_ref = 1.0, C = 1000.0, T0 = 300.0, T = 250.0
   // 1/T - 1/T0 = 1/250 - 1/300 = 0.004 - 0.003333... = 0.000666...
   // exp(1000 * 0.000666...) = exp(0.666...) ≈ 1.94773
-  HenrysLawConstantParameters params{ .HLC_ref_ = 1.0, .C_ = 1000.0, .T0_ = 300.0 };
-  HenrysLawConstant hlc(params);
+  HenryLawConstantParameters params{ .HLC_ref_ = 1.0, .C_ = 1000.0, .T0_ = 300.0 };
+  HenryLawConstant hlc(params);
 
   double result = hlc.Calculate(250.0);
   double expected = std::exp(1000.0 * (1.0 / 250.0 - 1.0 / 300.0));
@@ -112,23 +112,23 @@ TEST(HenrysLawConstant, KnownValues)
 // Additional tests (Phase E2)
 // ============================================================================
 
-TEST(HenrysLawConstant, TemperatureCoefficientDirectionality)
+TEST(HenryLawConstant, TemperatureCoefficientDirectionality)
 {
   // Positive C → HLC decreases with increasing temperature (typical for most gases)
-  HenrysLawConstantParameters params{ .HLC_ref_ = 1.0, .C_ = 1000.0, .T0_ = 298.15 };
-  HenrysLawConstant hlc(params);
+  HenryLawConstantParameters params{ .HLC_ref_ = 1.0, .C_ = 1000.0, .T0_ = 298.15 };
+  HenryLawConstant hlc(params);
 
   EXPECT_GT(hlc.Calculate(250.0), hlc.Calculate(298.15));
   EXPECT_GT(hlc.Calculate(298.15), hlc.Calculate(350.0));
 }
 
-TEST(HenrysLawConstant, KnownLiteratureSO2)
+TEST(HenryLawConstant, KnownLiteratureSO2)
 {
   // SO₂: HLC_ref = 1.23 mol m⁻³ Pa⁻¹, C = 3120 K, T0 = 298.15 K (Sander 2015)
   // HLC(298.15 K) = 1.23  (by definition)
   // HLC(273.15 K) = 1.23 * exp(3120 * (1/273.15 - 1/298.15))
-  HenrysLawConstantParameters params{ .HLC_ref_ = 1.23, .C_ = 3120.0, .T0_ = 298.15 };
-  HenrysLawConstant hlc(params);
+  HenryLawConstantParameters params{ .HLC_ref_ = 1.23, .C_ = 3120.0, .T0_ = 298.15 };
+  HenryLawConstant hlc(params);
 
   EXPECT_DOUBLE_EQ(hlc.Calculate(298.15), 1.23);
 

--- a/test/unit/processes/henry_law_phase_transfer.cpp
+++ b/test/unit/processes/henry_law_phase_transfer.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <miam/math/condensation_rate.hpp>
-#include <miam/processes/constants/henrys_law_constant.hpp>
+#include <miam/processes/constants/henry_law_constant.hpp>
 #include <miam/processes/henry_law_phase_transfer.hpp>
 #include <miam/processes/henry_law_phase_transfer_builder.hpp>
 
@@ -1864,18 +1864,18 @@ TEST(HenryLawPhaseTransfer, JacobianFDKitchenSink)
 
 TEST(HenryLawPhaseTransferBuilder, BuildSuccess)
 {
-  HenrysLawConstantParameters hlc_params;
+  HenryLawConstantParameters hlc_params;
   hlc_params.HLC_ref_ = HLC_ref;
   hlc_params.C_ = 2400.0;
   hlc_params.T0_ = 298.15;
-  HenrysLawConstant hlc(hlc_params);
+  HenryLawConstant hlc(hlc_params);
 
   auto process = HenryLawPhaseTransferBuilder()
                      .SetCondensedPhase(MakeAqueousPhase())
                      .SetGasSpecies(MakeGasSpecies())
                      .SetCondensedSpecies(MakeCondensedSpecies())
                      .SetSolvent(MakeSolvent())
-                     .SetHenrysLawConstant(hlc)
+                     .SetHenryLawConstant(hlc)
                      .SetDiffusionCoefficient(D_g)
                      .SetAccommodationCoefficient(alpha)
                      .Build();
@@ -1891,16 +1891,16 @@ TEST(HenryLawPhaseTransferBuilder, BuildSuccess)
 
 TEST(HenryLawPhaseTransferBuilder, MissingCondensedPhaseThrows)
 {
-  HenrysLawConstantParameters hlc_params;
+  HenryLawConstantParameters hlc_params;
   hlc_params.HLC_ref_ = HLC_ref;
-  HenrysLawConstant hlc(hlc_params);
+  HenryLawConstant hlc(hlc_params);
 
   EXPECT_THROW(
       HenryLawPhaseTransferBuilder()
           .SetGasSpecies(MakeGasSpecies())
           .SetCondensedSpecies(MakeCondensedSpecies())
           .SetSolvent(MakeSolvent())
-          .SetHenrysLawConstant(hlc)
+          .SetHenryLawConstant(hlc)
           .SetDiffusionCoefficient(D_g)
           .SetAccommodationCoefficient(alpha)
           .Build(),
@@ -1909,16 +1909,16 @@ TEST(HenryLawPhaseTransferBuilder, MissingCondensedPhaseThrows)
 
 TEST(HenryLawPhaseTransferBuilder, MissingGasSpeciesThrows)
 {
-  HenrysLawConstantParameters hlc_params;
+  HenryLawConstantParameters hlc_params;
   hlc_params.HLC_ref_ = HLC_ref;
-  HenrysLawConstant hlc(hlc_params);
+  HenryLawConstant hlc(hlc_params);
 
   EXPECT_THROW(
       HenryLawPhaseTransferBuilder()
           .SetCondensedPhase(MakeAqueousPhase())
           .SetCondensedSpecies(MakeCondensedSpecies())
           .SetSolvent(MakeSolvent())
-          .SetHenrysLawConstant(hlc)
+          .SetHenryLawConstant(hlc)
           .SetDiffusionCoefficient(D_g)
           .SetAccommodationCoefficient(alpha)
           .Build(),
@@ -1941,9 +1941,9 @@ TEST(HenryLawPhaseTransferBuilder, MissingHLCThrows)
 
 TEST(HenryLawPhaseTransferBuilder, MissingDiffusionCoefficientThrows)
 {
-  HenrysLawConstantParameters hlc_params;
+  HenryLawConstantParameters hlc_params;
   hlc_params.HLC_ref_ = HLC_ref;
-  HenrysLawConstant hlc(hlc_params);
+  HenryLawConstant hlc(hlc_params);
 
   EXPECT_THROW(
       HenryLawPhaseTransferBuilder()
@@ -1951,7 +1951,7 @@ TEST(HenryLawPhaseTransferBuilder, MissingDiffusionCoefficientThrows)
           .SetGasSpecies(MakeGasSpecies())
           .SetCondensedSpecies(MakeCondensedSpecies())
           .SetSolvent(MakeSolvent())
-          .SetHenrysLawConstant(hlc)
+          .SetHenryLawConstant(hlc)
           .SetAccommodationCoefficient(alpha)
           .Build(),
       std::runtime_error);
@@ -1959,9 +1959,9 @@ TEST(HenryLawPhaseTransferBuilder, MissingDiffusionCoefficientThrows)
 
 TEST(HenryLawPhaseTransferBuilder, MissingAccommodationCoefficientThrows)
 {
-  HenrysLawConstantParameters hlc_params;
+  HenryLawConstantParameters hlc_params;
   hlc_params.HLC_ref_ = HLC_ref;
-  HenrysLawConstant hlc(hlc_params);
+  HenryLawConstant hlc(hlc_params);
 
   EXPECT_THROW(
       HenryLawPhaseTransferBuilder()
@@ -1969,7 +1969,7 @@ TEST(HenryLawPhaseTransferBuilder, MissingAccommodationCoefficientThrows)
           .SetGasSpecies(MakeGasSpecies())
           .SetCondensedSpecies(MakeCondensedSpecies())
           .SetSolvent(MakeSolvent())
-          .SetHenrysLawConstant(hlc)
+          .SetHenryLawConstant(hlc)
           .SetDiffusionCoefficient(D_g)
           .Build(),
       std::runtime_error);
@@ -1977,18 +1977,18 @@ TEST(HenryLawPhaseTransferBuilder, MissingAccommodationCoefficientThrows)
 
 TEST(HenryLawPhaseTransferBuilder, BuiltProcessHLCWorks)
 {
-  HenrysLawConstantParameters hlc_params;
+  HenryLawConstantParameters hlc_params;
   hlc_params.HLC_ref_ = HLC_ref;
   hlc_params.C_ = 2400.0;
   hlc_params.T0_ = 298.15;
-  HenrysLawConstant hlc(hlc_params);
+  HenryLawConstant hlc(hlc_params);
 
   auto process = HenryLawPhaseTransferBuilder()
                      .SetCondensedPhase(MakeAqueousPhase())
                      .SetGasSpecies(MakeGasSpecies())
                      .SetCondensedSpecies(MakeCondensedSpecies())
                      .SetSolvent(MakeSolvent())
-                     .SetHenrysLawConstant(hlc)
+                     .SetHenryLawConstant(hlc)
                      .SetDiffusionCoefficient(D_g)
                      .SetAccommodationCoefficient(alpha)
                      .Build();


### PR DESCRIPTION
The Henry's Law implementation currently uses inconsistent naming (`Henry*` vs. `Henrys*`). This PR standardizes the naming convention to `Henry*`.

```yaml
HenrysLawConstant           -> HenryLawConstant
HenrysLawConstantParameters -> HenryLawConstantParameters
```