### PR TITLE
Specify per-representation rate constant

### DIFF
--- a/include/miam/constraints/linear_constraint.hpp
+++ b/include/miam/constraints/linear_constraint.hpp
@@ -53,8 +53,6 @@ namespace miam
       micm::Phase phase;
       micm::Species species;
       double coefficient;
-      std::string representation;  ///< Optional: restrict an instanced-phase term to this single representation
-                                   ///< prefix. Empty (default) sums over all representations holding the phase.
     };
 
     micm::Phase algebraic_phase_;        ///< Phase of the algebraic variable
@@ -122,8 +120,6 @@ namespace miam
         {
           for (const auto& prefix : phase_it->second)
           {
-            if (!term.representation.empty() && term.representation != prefix)
-              continue;  // term restricted to a single representation
             species_names.insert(prefix + "." + term.phase.name_ + "." + term.species.name_);
           }
         }
@@ -154,8 +150,6 @@ namespace miam
           {
             for (const auto& prefix : phase_it->second)
             {
-              if (!term.representation.empty() && term.representation != prefix)
-                continue;  // term restricted to a single representation
               std::size_t col = state_variable_indices.at(prefix + "." + term.phase.name_ + "." + term.species.name_);
               elements.insert({ alg_row, col });
             }
@@ -180,9 +174,8 @@ namespace miam
             auto phase_it = phase_prefixes.find(term.phase.name_);
             if (phase_it != phase_prefixes.end())
             {
-              // Same instanced phase as algebraic: use this instance, unless the term pins a representation
-              const std::string& use_prefix = term.representation.empty() ? prefix : term.representation;
-              std::size_t col = state_variable_indices.at(use_prefix + "." + term.phase.name_ + "." + term.species.name_);
+              // Same instanced phase as algebraic: use only this instance
+              std::size_t col = state_variable_indices.at(prefix + "." + term.phase.name_ + "." + term.species.name_);
               elements.insert({ alg_row, col });
             }
             else
@@ -572,8 +565,6 @@ namespace miam
         {
           for (const auto& prefix : phase_it->second)
           {
-            if (!term.representation.empty() && term.representation != prefix)
-              continue;  // term restricted to a single representation
             std::size_t idx = state_variable_indices.at(prefix + "." + term.phase.name_ + "." + term.species.name_);
             resolved.push_back({ idx, term.coefficient });
           }
@@ -604,9 +595,8 @@ namespace miam
           auto phase_it = phase_prefixes.find(term.phase.name_);
           if (phase_it != phase_prefixes.end())
           {
-            // Match the instance prefix for this term's phase, unless the term pins a specific representation
-            const std::string& use_prefix = term.representation.empty() ? alg_prefix : term.representation;
-            std::size_t idx = state_variable_indices.at(use_prefix + "." + term.phase.name_ + "." + term.species.name_);
+            // Match the instance prefix for this term's phase
+            std::size_t idx = state_variable_indices.at(alg_prefix + "." + term.phase.name_ + "." + term.species.name_);
             per_instance[i_inst].push_back({ idx, term.coefficient });
           }
           else

--- a/include/miam/constraints/linear_constraint.hpp
+++ b/include/miam/constraints/linear_constraint.hpp
@@ -53,6 +53,8 @@ namespace miam
       micm::Phase phase;
       micm::Species species;
       double coefficient;
+      std::string representation;  ///< Optional: restrict an instanced-phase term to this single representation
+                                   ///< prefix. Empty (default) sums over all representations holding the phase.
     };
 
     micm::Phase algebraic_phase_;        ///< Phase of the algebraic variable
@@ -120,6 +122,8 @@ namespace miam
         {
           for (const auto& prefix : phase_it->second)
           {
+            if (!term.representation.empty() && term.representation != prefix)
+              continue;  // term restricted to a single representation
             species_names.insert(prefix + "." + term.phase.name_ + "." + term.species.name_);
           }
         }
@@ -150,6 +154,8 @@ namespace miam
           {
             for (const auto& prefix : phase_it->second)
             {
+              if (!term.representation.empty() && term.representation != prefix)
+                continue;  // term restricted to a single representation
               std::size_t col = state_variable_indices.at(prefix + "." + term.phase.name_ + "." + term.species.name_);
               elements.insert({ alg_row, col });
             }
@@ -174,8 +180,9 @@ namespace miam
             auto phase_it = phase_prefixes.find(term.phase.name_);
             if (phase_it != phase_prefixes.end())
             {
-              // Same instanced phase as algebraic: use only this instance
-              std::size_t col = state_variable_indices.at(prefix + "." + term.phase.name_ + "." + term.species.name_);
+              // Same instanced phase as algebraic: use this instance, unless the term pins a representation
+              const std::string& use_prefix = term.representation.empty() ? prefix : term.representation;
+              std::size_t col = state_variable_indices.at(use_prefix + "." + term.phase.name_ + "." + term.species.name_);
               elements.insert({ alg_row, col });
             }
             else
@@ -565,6 +572,8 @@ namespace miam
         {
           for (const auto& prefix : phase_it->second)
           {
+            if (!term.representation.empty() && term.representation != prefix)
+              continue;  // term restricted to a single representation
             std::size_t idx = state_variable_indices.at(prefix + "." + term.phase.name_ + "." + term.species.name_);
             resolved.push_back({ idx, term.coefficient });
           }
@@ -595,8 +604,9 @@ namespace miam
           auto phase_it = phase_prefixes.find(term.phase.name_);
           if (phase_it != phase_prefixes.end())
           {
-            // Match the instance prefix for this term's phase
-            std::size_t idx = state_variable_indices.at(alg_prefix + "." + term.phase.name_ + "." + term.species.name_);
+            // Match the instance prefix for this term's phase, unless the term pins a specific representation
+            const std::string& use_prefix = term.representation.empty() ? alg_prefix : term.representation;
+            std::size_t idx = state_variable_indices.at(use_prefix + "." + term.phase.name_ + "." + term.species.name_);
             per_instance[i_inst].push_back({ idx, term.coefficient });
           }
           else

--- a/include/miam/constraints/linear_constraint_builder.hpp
+++ b/include/miam/constraints/linear_constraint_builder.hpp
@@ -27,20 +27,7 @@ namespace miam
 
     LinearConstraintBuilder& AddTerm(const micm::Phase& phase, const micm::Species& species, double coefficient)
     {
-      terms_.push_back({ phase, species, coefficient, "" });
-      return *this;
-    }
-
-    /// @brief Adds a term restricted to a single aerosol representation.
-    /// @details Only meaningful for instanced (condensed) phases. The term contributes only the named
-    ///          representation's variable instead of summing over all representations holding the phase.
-    LinearConstraintBuilder& AddTerm(
-        const micm::Phase& phase,
-        const micm::Species& species,
-        double coefficient,
-        const std::string& representation)
-    {
-      terms_.push_back({ phase, species, coefficient, representation });
+      terms_.push_back({ phase, species, coefficient });
       return *this;
     }
 

--- a/include/miam/constraints/linear_constraint_builder.hpp
+++ b/include/miam/constraints/linear_constraint_builder.hpp
@@ -27,7 +27,20 @@ namespace miam
 
     LinearConstraintBuilder& AddTerm(const micm::Phase& phase, const micm::Species& species, double coefficient)
     {
-      terms_.push_back({ phase, species, coefficient });
+      terms_.push_back({ phase, species, coefficient, "" });
+      return *this;
+    }
+
+    /// @brief Adds a term restricted to a single aerosol representation.
+    /// @details Only meaningful for instanced (condensed) phases. The term contributes only the named
+    ///          representation's variable instead of summing over all representations holding the phase.
+    LinearConstraintBuilder& AddTerm(
+        const micm::Phase& phase,
+        const micm::Species& species,
+        double coefficient,
+        const std::string& representation)
+    {
+      terms_.push_back({ phase, species, coefficient, representation });
       return *this;
     }
 

--- a/include/miam/processes/dissolved_reversible_reaction.hpp
+++ b/include/miam/processes/dissolved_reversible_reaction.hpp
@@ -43,33 +43,40 @@ namespace miam
   ///          where \f$ c_{H_2O} = 55.556 \f$ mol/L.
   ///          \f$ K_{eq} \f$ is dimensionless:
   ///          \f$ K_{eq} = K_{lit} / c_{H_2O}^{n_p - n_r} \f$.
+  ///
+  ///          The forward and reverse rate constants are stored per representation prefix, so the
+  ///          same reaction can carry different kinetics in different aerosol representations (for
+  ///          example, droplet-water-molarity-dependent rates). Every representation holding the
+  ///          reaction's phase must have a forward and reverse rate constant configured.
   class DissolvedReversibleReaction
   {
    public:
-    std::function<double(const micm::Conditions& conditions)> forward_rate_constant_;  ///< Forward rate constant function
-    std::function<double(const micm::Conditions& conditions)> reverse_rate_constant_;  ///< Reverse rate constant function
-    std::vector<micm::Species> reactants_;                                             ///< Reactant species
-    std::vector<micm::Species> products_;                                              ///< Product species
-    micm::Species solvent_;                                                            ///< Solvent species
-    micm::Phase phase_;  ///< Phase in which the reaction occurs
-    std::string uuid_;   ///< Unique identifier for the reaction
+    std::map<std::string, std::function<double(const micm::Conditions& conditions)>>
+        forward_rate_constants_;  ///< Forward rate constant functions keyed by representation prefix
+    std::map<std::string, std::function<double(const micm::Conditions& conditions)>>
+        reverse_rate_constants_;             ///< Reverse rate constant functions keyed by representation prefix
+    std::vector<micm::Species> reactants_;   ///< Reactant species
+    std::vector<micm::Species> products_;    ///< Product species
+    micm::Species solvent_;                  ///< Solvent species
+    micm::Phase phase_;                      ///< Phase in which the reaction occurs
+    std::string uuid_;                       ///< Unique identifier for the reaction
     double solvent_floor_{
       1.0e-20
     };  ///< Floor [mol m⁻³] added to [S] in ([S]+δ)^n denominator to prevent singularity as [S] → 0
 
     DissolvedReversibleReaction() = delete;
 
-    /// @brief Constructor — shared rates (all instances use the same forward and reverse rate functions)
+    /// @brief Constructor
     DissolvedReversibleReaction(
-        std::function<double(const micm::Conditions& conditions)> forward_rate_constant,
-        std::function<double(const micm::Conditions& conditions)> reverse_rate_constant,
+        std::map<std::string, std::function<double(const micm::Conditions& conditions)>> forward_rate_constants,
+        std::map<std::string, std::function<double(const micm::Conditions& conditions)>> reverse_rate_constants,
         const std::vector<micm::Species>& reactants,
         const std::vector<micm::Species>& products,
         micm::Species solvent,
         micm::Phase phase,
         double solvent_floor = 1.0e-20)
-        : forward_rate_constant_(forward_rate_constant),
-          reverse_rate_constant_(reverse_rate_constant),
+        : forward_rate_constants_(std::move(forward_rate_constants)),
+          reverse_rate_constants_(std::move(reverse_rate_constants)),
           reactants_(reactants),
           products_(products),
           solvent_(solvent),
@@ -84,7 +91,7 @@ namespace miam
     DissolvedReversibleReaction CopyWithNewUuid() const
     {
       return DissolvedReversibleReaction(
-          forward_rate_constant_, reverse_rate_constant_, reactants_, products_, solvent_, phase_, solvent_floor_);
+          forward_rate_constants_, reverse_rate_constants_, reactants_, products_, solvent_, phase_, solvent_floor_);
     }
 
     /// @brief Returns a set of unique parameter names for this process
@@ -93,11 +100,17 @@ namespace miam
     /// @return Set of unique parameter names for this process
     std::set<std::string> ProcessParameterNames(const std::map<std::string, std::set<std::string>>& phase_prefixes) const
     {
-      // The conditions are shared by the whole system, so we just need one value each for the forward and reverse rate
-      // constants. We can use the phase name and uuid to create unique parameter names.
+      // One forward and one reverse rate constant parameter per representation instance of this phase.
       std::set<std::string> parameter_names;
-      parameter_names.insert(phase_.name_ + "." + uuid_ + ".k_forward");
-      parameter_names.insert(phase_.name_ + "." + uuid_ + ".k_reverse");
+      auto it = phase_prefixes.find(phase_.name_);
+      if (it != phase_prefixes.end())
+      {
+        for (const auto& prefix : it->second)
+        {
+          parameter_names.insert(prefix + "." + phase_.name_ + "." + uuid_ + ".k_forward");
+          parameter_names.insert(prefix + "." + phase_.name_ + "." + uuid_ + ".k_reverse");
+        }
+      }
       return parameter_names;
     }
 
@@ -234,27 +247,48 @@ namespace miam
         const auto& state_parameter_indices  // acts like std::unordered_map<std::string, std::size_t>
     ) const
     {
-      // throw an error if the expected parameters don't exist
-      std::string forward_param = phase_.name_ + "." + uuid_ + ".k_forward";
-      std::string reverse_param = phase_.name_ + "." + uuid_ + ".k_reverse";
-      if (state_parameter_indices.find(forward_param) == state_parameter_indices.end())
-      {
+      // Build per-prefix parameter slots paired with the matching rate constant functions
+      std::vector<std::pair<std::size_t, std::function<double(const micm::Conditions&)>>> forward_slots;
+      std::vector<std::pair<std::size_t, std::function<double(const micm::Conditions&)>>> reverse_slots;
+      auto phase_it = phase_prefixes.find(phase_.name_);
+      if (phase_it == phase_prefixes.end())
         throw MiamException(
             MIAM_ERROR_CATEGORY_INTERNAL,
-            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-            "Internal Error: UpdateStateParametersFunction: Forward rate constant parameter " + forward_param +
-                " not found in state_parameter_indices");
-      }
-      if (state_parameter_indices.find(reverse_param) == state_parameter_indices.end())
+            MIAM_INTERNAL_MISSING_PHASE_PREFIX,
+            "Internal Error: UpdateStateParametersFunction: Phase " + phase_.name_ + " not found in phase_prefixes");
+      for (const auto& prefix : phase_it->second)
       {
-        throw MiamException(
-            MIAM_ERROR_CATEGORY_INTERNAL,
-            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-            "Internal Error: UpdateStateParametersFunction: Reverse rate constant parameter " + reverse_param +
-                " not found in state_parameter_indices");
+        std::string forward_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k_forward";
+        std::string reverse_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k_reverse";
+        if (state_parameter_indices.find(forward_param) == state_parameter_indices.end())
+          throw MiamException(
+              MIAM_ERROR_CATEGORY_INTERNAL,
+              MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+              "Internal Error: UpdateStateParametersFunction: Forward rate constant parameter " + forward_param +
+                  " not found in state_parameter_indices");
+        if (state_parameter_indices.find(reverse_param) == state_parameter_indices.end())
+          throw MiamException(
+              MIAM_ERROR_CATEGORY_INTERNAL,
+              MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+              "Internal Error: UpdateStateParametersFunction: Reverse rate constant parameter " + reverse_param +
+                  " not found in state_parameter_indices");
+        auto forward_it = forward_rate_constants_.find(prefix);
+        if (forward_it == forward_rate_constants_.end())
+          throw MiamException(
+              MIAM_ERROR_CATEGORY_CONFIGURATION,
+              MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
+              "DissolvedReversibleReaction: No forward rate constant configured for representation prefix '" + prefix +
+                  "'");
+        auto reverse_it = reverse_rate_constants_.find(prefix);
+        if (reverse_it == reverse_rate_constants_.end())
+          throw MiamException(
+              MIAM_ERROR_CATEGORY_CONFIGURATION,
+              MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
+              "DissolvedReversibleReaction: No reverse rate constant configured for representation prefix '" + prefix +
+                  "'");
+        forward_slots.push_back({ state_parameter_indices.at(forward_param), forward_it->second });
+        reverse_slots.push_back({ state_parameter_indices.at(reverse_param), reverse_it->second });
       }
-      std::size_t forward_index = state_parameter_indices.at(forward_param);
-      std::size_t reverse_index = state_parameter_indices.at(reverse_param);
 
       // Set up dummy arguments to build the function
       DenseMatrixPolicy state_parameters{ 1, state_parameter_indices.size(), 0.0 };
@@ -262,16 +296,18 @@ namespace miam
 
       // return a function that updates the forward and reverse rate constant parameters based on the current conditions
       return DenseMatrixPolicy::Function(
-          [this, forward_index, reverse_index](auto&& conditions, auto&& params)
+          [forward_slots, reverse_slots](auto&& conditions, auto&& params)
           {
-            params.ForEachRow(
-                [&](const micm::Conditions& condition, double& parameter) { parameter = forward_rate_constant_(condition); },
-                conditions,
-                params.GetColumnView(forward_index));
-            params.ForEachRow(
-                [&](const micm::Conditions& condition, double& parameter) { parameter = reverse_rate_constant_(condition); },
-                conditions,
-                params.GetColumnView(reverse_index));
+            for (const auto& [param_index, rate_fn] : forward_slots)
+              params.ForEachRow(
+                  [&](const micm::Conditions& condition, double& parameter) { parameter = rate_fn(condition); },
+                  conditions,
+                  params.GetColumnView(param_index));
+            for (const auto& [param_index, rate_fn] : reverse_slots)
+              params.ForEachRow(
+                  [&](const micm::Conditions& condition, double& parameter) { parameter = rate_fn(condition); },
+                  conditions,
+                  params.GetColumnView(param_index));
           },
           conditions_vector,
           state_parameters);
@@ -305,11 +341,11 @@ namespace miam
     ) const
     {
       StateVariableIndices variable_indices = GetStateVariableIndices(phase_prefixes, state_variable_indices);
-      auto [forward_index, reverse_index] = GetParameterIndices(state_parameter_indices);
+      auto [forward_indices, reverse_indices] = GetParameterIndices(phase_prefixes, state_parameter_indices);
       DenseMatrixPolicy dummy_state_parameters{ 1, state_parameter_indices.size(), 0.0 };
       DenseMatrixPolicy dummy_state_variables{ 1, state_variable_indices.size(), 0.0 };
       return DenseMatrixPolicy::Function(
-          [this, variable_indices, forward_index, reverse_index](
+          [this, variable_indices, forward_indices, reverse_indices](
               auto&& state_parameters, auto&& state_variables, auto&& forcing_terms)
           {
             auto forward_rate = forcing_terms.GetRowVariable();
@@ -332,8 +368,8 @@ namespace miam
                     forward_rate = forward_rate_constant * solvent / std::pow(solvent + eps, n_r);
                     reverse_rate = reverse_rate_constant * solvent / std::pow(solvent + eps, n_p);
                   },
-                  state_parameters.GetConstColumnView(forward_index),
-                  state_parameters.GetConstColumnView(reverse_index),
+                  state_parameters.GetConstColumnView(forward_indices[i_phase]),
+                  state_parameters.GetConstColumnView(reverse_indices[i_phase]),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   forward_rate,
                   reverse_rate);
@@ -407,11 +443,11 @@ namespace miam
     {
       StateVariableIndices variable_indices = GetStateVariableIndices(phase_prefixes, state_variable_indices);
       JacobianIndices jacobian_indices = GetJacobianIndices(variable_indices, jacobian);
-      auto [forward_index, reverse_index] = GetParameterIndices(state_parameter_indices);
+      auto [forward_indices, reverse_indices] = GetParameterIndices(phase_prefixes, state_parameter_indices);
       DenseMatrixPolicy dummy_state_parameters{ 1, state_parameter_indices.size(), 0.0 };
       DenseMatrixPolicy dummy_state_variables{ 1, state_variable_indices.size(), 0.0 };
       return SparseMatrixPolicy::Function(
-          [this, variable_indices, jacobian_indices, forward_index, reverse_index](
+          [this, variable_indices, jacobian_indices, forward_indices, reverse_indices](
               auto&& state_parameters, auto&& state_variables, auto&& jacobian_values)
           {
             auto d_forward_rate_d_ind = jacobian_values.GetBlockVariable();
@@ -431,7 +467,7 @@ namespace miam
                 jacobian_values.ForEachBlock(
                     [&](const double& forward_rate_constant, const double& solvent, double& partial)
                     { partial = forward_rate_constant * solvent / std::pow(solvent + eps, n_r); },
-                    state_parameters.GetConstColumnView(forward_index),
+                    state_parameters.GetConstColumnView(forward_indices[i_phase]),
                     state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                     d_forward_rate_d_ind);
                 // add contributions to the partial from the other reactants
@@ -468,7 +504,7 @@ namespace miam
                 jacobian_values.ForEachBlock(
                     [&](const double& reverse_rate_constant, const double& solvent, double& partial)
                     { partial = reverse_rate_constant * solvent / std::pow(solvent + eps, n_p); },
-                    state_parameters.GetConstColumnView(reverse_index),
+                    state_parameters.GetConstColumnView(reverse_indices[i_phase]),
                     state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                     d_reverse_rate_d_ind);
                 // add contributions to the partial from the other products
@@ -512,8 +548,8 @@ namespace miam
                     reverse_partial = reverse_rate_constant * (eps + (1.0 - static_cast<int>(n_p)) * solvent) /
                                       std::pow(solvent + eps, n_p + 1);
                   },
-                  state_parameters.GetConstColumnView(forward_index),
-                  state_parameters.GetConstColumnView(reverse_index),
+                  state_parameters.GetConstColumnView(forward_indices[i_phase]),
+                  state_parameters.GetConstColumnView(reverse_indices[i_phase]),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   d_forward_rate_d_ind,
                   d_reverse_rate_d_ind);
@@ -587,29 +623,44 @@ namespace miam
     };
 
     /// @brief Helper function to return parameter indices for the forward and reverse rate constants
-    std::pair<std::size_t, std::size_t> GetParameterIndices(
+    /// @param phase_prefixes Map of phase names to sets of state variable prefixes (prefix does not include phase or
+    /// species names)
+    /// @param state_parameter_indices Map of state parameter names to their corresponding indices in the state parameter
+    /// vector
+    /// @return Pair of (forward, reverse) parameter index vectors, one entry per phase instance in prefix-sorted order
+    std::pair<std::vector<std::size_t>, std::vector<std::size_t>> GetParameterIndices(
+        const std::map<std::string, std::set<std::string>>& phase_prefixes,
         const auto& state_parameter_indices  // acts like std::unordered_map<std::string, std::size_t>
     ) const
     {
-      std::string forward_param = phase_.name_ + "." + uuid_ + ".k_forward";
-      std::string reverse_param = phase_.name_ + "." + uuid_ + ".k_reverse";
-      if (state_parameter_indices.find(forward_param) == state_parameter_indices.end())
-      {
+      std::vector<std::size_t> forward_indices;
+      std::vector<std::size_t> reverse_indices;
+      auto phase_it = phase_prefixes.find(phase_.name_);
+      if (phase_it == phase_prefixes.end())
         throw MiamException(
             MIAM_ERROR_CATEGORY_INTERNAL,
-            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-            "Internal Error: GetParameterIndices: Forward rate constant parameter " + forward_param +
-                " not found in state_parameter_indices");
-      }
-      if (state_parameter_indices.find(reverse_param) == state_parameter_indices.end())
+            MIAM_INTERNAL_MISSING_PHASE_PREFIX,
+            "Internal Error: GetParameterIndices: Phase " + phase_.name_ + " not found in phase_prefixes");
+      for (const auto& prefix : phase_it->second)
       {
-        throw MiamException(
-            MIAM_ERROR_CATEGORY_INTERNAL,
-            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-            "Internal Error: GetParameterIndices: Reverse rate constant parameter " + reverse_param +
-                " not found in state_parameter_indices");
+        std::string forward_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k_forward";
+        std::string reverse_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k_reverse";
+        if (state_parameter_indices.find(forward_param) == state_parameter_indices.end())
+          throw MiamException(
+              MIAM_ERROR_CATEGORY_INTERNAL,
+              MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+              "Internal Error: GetParameterIndices: Forward rate constant parameter " + forward_param +
+                  " not found in state_parameter_indices");
+        if (state_parameter_indices.find(reverse_param) == state_parameter_indices.end())
+          throw MiamException(
+              MIAM_ERROR_CATEGORY_INTERNAL,
+              MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+              "Internal Error: GetParameterIndices: Reverse rate constant parameter " + reverse_param +
+                  " not found in state_parameter_indices");
+        forward_indices.push_back(state_parameter_indices.at(forward_param));
+        reverse_indices.push_back(state_parameter_indices.at(reverse_param));
       }
-      return { state_parameter_indices.at(forward_param), state_parameter_indices.at(reverse_param) };
+      return { forward_indices, reverse_indices };
     }
 
     /// @brief Helper function to return variable indices for all species involved in the reaction

--- a/include/miam/processes/dissolved_reversible_reaction_builder.hpp
+++ b/include/miam/processes/dissolved_reversible_reaction_builder.hpp
@@ -22,15 +22,12 @@ namespace miam
   /// @details Builder class for constructing DissolvedReversibleReaction objects.
   ///
   ///          Forward and reverse rate constants are configured per representation prefix (via
-  ///          AddForwardRateConstant / AddReverseRateConstant), mirroring DissolvedReactionBuilder,
-  ///          because the kinetics may differ between aerosol representations. The equilibrium
-  ///          constant, by contrast, is an intrinsic thermodynamic property and is set once for the
-  ///          whole reaction (via SetEquilibriumConstant).
+  ///          AddForwardRateConstant / AddReverseRateConstant), because the kinetics may differ 
+  ///          between aerosol representations. The equilibrium constant, by contrast, is an intrinsic
+  ///          thermodynamic property and is set once for the whole reaction (via SetEquilibriumConstant).
   ///
   ///          For each representation prefix, exactly two of {forward rate constant, reverse rate
-  ///          constant, equilibrium constant} must be determinable; the third is derived. Because
-  ///          the equilibrium constant is shared, supplying it plus either a forward or reverse rate
-  ///          constant per prefix is the common case.
+  ///          constant, equilibrium constant} must be determinable; the third is derived.
   class DissolvedReversibleReactionBuilder
   {
    public:
@@ -100,7 +97,7 @@ namespace miam
       return *this;
     }
 
-    /// @brief Sets the (shared, intrinsic) equilibrium constant function
+    /// @brief Sets the (shared) equilibrium constant function
     DissolvedReversibleReactionBuilder& SetEquilibriumConstant(const auto& equilibrium_constant)
     {
       equilibrium_constant_ = [equilibrium_constant](const micm::Conditions& conditions)
@@ -207,7 +204,7 @@ namespace miam
     std::map<std::string, std::function<double(const micm::Conditions& conditions)>>
         reverse_rate_constants_;  ///< Per-prefix reverse rate constant functions
     std::function<double(const micm::Conditions& conditions)>
-        equilibrium_constant_;         ///< Shared equilibrium constant function (intrinsic, representation-independent)
+        equilibrium_constant_;         ///< Shared equilibrium constant function (representation-independent)
     double solvent_floor_{ 1.0e-20 };  ///< Floor δ [mol m⁻³] added to [S] in ([S]+δ)^n denominator; see SetSolventFloor()
   };
 }  // namespace miam

--- a/include/miam/processes/dissolved_reversible_reaction_builder.hpp
+++ b/include/miam/processes/dissolved_reversible_reaction_builder.hpp
@@ -12,11 +12,25 @@
 #include <micm/system/conditions.hpp>
 
 #include <functional>
+#include <map>
+#include <set>
+#include <string>
 
 namespace miam
 {
   /// @brief A dissolved reversible reaction builder
   /// @details Builder class for constructing DissolvedReversibleReaction objects.
+  ///
+  ///          Forward and reverse rate constants are configured per representation prefix (via
+  ///          AddForwardRateConstant / AddReverseRateConstant), mirroring DissolvedReactionBuilder,
+  ///          because the kinetics may differ between aerosol representations. The equilibrium
+  ///          constant, by contrast, is an intrinsic thermodynamic property and is set once for the
+  ///          whole reaction (via SetEquilibriumConstant).
+  ///
+  ///          For each representation prefix, exactly two of {forward rate constant, reverse rate
+  ///          constant, equilibrium constant} must be determinable; the third is derived. Because
+  ///          the equilibrium constant is shared, supplying it plus either a forward or reverse rate
+  ///          constant per prefix is the common case.
   class DissolvedReversibleReactionBuilder
   {
    public:
@@ -60,31 +74,33 @@ namespace miam
       return *this;
     }
 
-    /// @brief Sets the forward rate constant function
-    DissolvedReversibleReactionBuilder& SetForwardRateConstant(const auto& forward_rate_constant)
+    /// @brief Adds a forward rate constant for a specific representation prefix
+    DissolvedReversibleReactionBuilder& AddForwardRateConstant(const std::string& prefix, const auto& forward_rate_constant)
     {
-      forward_rate_constant_ = [forward_rate_constant](const micm::Conditions& conditions)
+      forward_rate_constants_[prefix] = [forward_rate_constant](const micm::Conditions& conditions)
       { return forward_rate_constant.Calculate(conditions); };
       return *this;
     }
 
-    /// @brief Sets the reverse rate constant function
-    DissolvedReversibleReactionBuilder& SetReverseRateConstant(const auto& reverse_rate_constant)
+    /// @brief Adds a reverse rate constant for a specific representation prefix
+    DissolvedReversibleReactionBuilder& AddReverseRateConstant(const std::string& prefix, const auto& reverse_rate_constant)
     {
-      reverse_rate_constant_ = [reverse_rate_constant](const micm::Conditions& conditions)
+      reverse_rate_constants_[prefix] = [reverse_rate_constant](const micm::Conditions& conditions)
       { return reverse_rate_constant.Calculate(conditions); };
       return *this;
     }
 
-    /// @brief Sets the reverse rate constant from Arrhenius parameters
-    DissolvedReversibleReactionBuilder& SetReverseRateConstant(const micm::ArrheniusRateConstantParameters& params)
+    /// @brief Adds a reverse rate constant from Arrhenius parameters for a specific representation prefix
+    DissolvedReversibleReactionBuilder& AddReverseRateConstant(
+        const std::string& prefix,
+        const micm::ArrheniusRateConstantParameters& params)
     {
-      reverse_rate_constant_ = [params](const micm::Conditions& conditions)
+      reverse_rate_constants_[prefix] = [params](const micm::Conditions& conditions)
       { return micm::CalculateArrhenius(params, conditions.temperature_, conditions.pressure_); };
       return *this;
     }
 
-    /// @brief Sets the equilibrium constant function
+    /// @brief Sets the (shared, intrinsic) equilibrium constant function
     DissolvedReversibleReactionBuilder& SetEquilibriumConstant(const auto& equilibrium_constant)
     {
       equilibrium_constant_ = [equilibrium_constant](const micm::Conditions& conditions)
@@ -95,22 +111,6 @@ namespace miam
     /// @brief Builds and returns the DissolvedReversibleReaction object
     DissolvedReversibleReaction Build() const
     {
-      // Check that exactly two of the three rate constant/equilibrium constant functions are set
-      int num_set = 0;
-      if (forward_rate_constant_)
-        ++num_set;
-      if (reverse_rate_constant_)
-        ++num_set;
-      if (equilibrium_constant_)
-        ++num_set;
-      if (num_set != 2)
-      {
-        throw MiamException(
-            MIAM_ERROR_CATEGORY_CONFIGURATION,
-            MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
-            "DissolvedReversibleReactionBuilder requires exactly two of forward rate constant, reverse rate constant, or "
-            "equilibrium constant to be set.");
-      }
       if (reactants_.empty())
       {
         throw MiamException(
@@ -139,36 +139,60 @@ namespace miam
             MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
             "DissolvedReversibleReactionBuilder requires the solvent to be set.");
       }
-      // If equilibrium constant is set, compute the missing rate constant
-      if (equilibrium_constant_)
+
+      // Collect the set of representation prefixes that have at least one rate constant configured
+      std::set<std::string> prefixes;
+      for (const auto& [prefix, fn] : forward_rate_constants_)
+        prefixes.insert(prefix);
+      for (const auto& [prefix, fn] : reverse_rate_constants_)
+        prefixes.insert(prefix);
+      if (prefixes.empty())
       {
-        if (!forward_rate_constant_)
+        throw MiamException(
+            MIAM_ERROR_CATEGORY_CONFIGURATION,
+            MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
+            "DissolvedReversibleReactionBuilder requires at least one forward or reverse rate constant via "
+            "AddForwardRateConstant/AddReverseRateConstant.");
+      }
+
+      // For each prefix, require exactly two of {forward, reverse, equilibrium} and derive the third.
+      // The equilibrium constant is shared across all prefixes.
+      std::map<std::string, std::function<double(const micm::Conditions&)>> forward = forward_rate_constants_;
+      std::map<std::string, std::function<double(const micm::Conditions&)>> reverse = reverse_rate_constants_;
+      const bool has_eq = static_cast<bool>(equilibrium_constant_);
+      for (const auto& prefix : prefixes)
+      {
+        const bool has_fwd = forward.count(prefix) > 0;
+        const bool has_rev = reverse.count(prefix) > 0;
+        const int num_set = (has_fwd ? 1 : 0) + (has_rev ? 1 : 0) + (has_eq ? 1 : 0);
+        if (num_set != 2)
         {
-          // Capture the necessary functions by value to avoid dangling references
-          auto eq_const = equilibrium_constant_;
-          auto rev_const = reverse_rate_constant_;
-          forward_rate_constant_ = [eq_const, rev_const](const micm::Conditions& conditions)
-          {
-            double K_eq = eq_const(conditions);
-            double k_r = rev_const(conditions);
-            return K_eq * k_r;
-          };
+          throw MiamException(
+              MIAM_ERROR_CATEGORY_CONFIGURATION,
+              MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
+              "DissolvedReversibleReactionBuilder: for representation '" + prefix +
+                  "', exactly two of forward rate constant, reverse rate constant, or equilibrium constant must be set.");
         }
-        else if (!reverse_rate_constant_)
+        if (has_eq)
         {
-          // Capture the necessary functions by value to avoid dangling references
-          auto eq_const = equilibrium_constant_;
-          auto fwd_const = forward_rate_constant_;
-          reverse_rate_constant_ = [eq_const, fwd_const](const micm::Conditions& conditions)
+          if (!has_fwd)
           {
-            double K_eq = eq_const(conditions);
-            double k_f = fwd_const(conditions);
-            return k_f / K_eq;
-          };
+            auto eq_const = equilibrium_constant_;
+            auto rev_const = reverse.at(prefix);
+            forward[prefix] = [eq_const, rev_const](const micm::Conditions& conditions)
+            { return eq_const(conditions) * rev_const(conditions); };
+          }
+          else if (!has_rev)
+          {
+            auto eq_const = equilibrium_constant_;
+            auto fwd_const = forward.at(prefix);
+            reverse[prefix] = [eq_const, fwd_const](const micm::Conditions& conditions)
+            { return fwd_const(conditions) / eq_const(conditions); };
+          }
         }
       }
-      return DissolvedReversibleReaction(
-          forward_rate_constant_, reverse_rate_constant_, reactants_, products_, solvent_, phase_, solvent_floor_);
+
+      return DissolvedReversibleReaction(forward, reverse, reactants_, products_, solvent_, phase_, solvent_floor_);
     }
 
    private:
@@ -178,12 +202,12 @@ namespace miam
     std::vector<micm::Species> products_;   ///< Product species
     micm::Species solvent_;                 ///< Solvent species
     bool solvent_is_set_ = false;           ///< Flag to track if the solvent has been set
-    mutable std::function<double(const micm::Conditions& conditions)>
-        forward_rate_constant_;  ///< Forward rate constant function
-    mutable std::function<double(const micm::Conditions& conditions)>
-        reverse_rate_constant_;  ///< Reverse rate constant function
-    mutable std::function<double(const micm::Conditions& conditions)>
-        equilibrium_constant_;         ///< Equilibrium constant function
+    std::map<std::string, std::function<double(const micm::Conditions& conditions)>>
+        forward_rate_constants_;  ///< Per-prefix forward rate constant functions
+    std::map<std::string, std::function<double(const micm::Conditions& conditions)>>
+        reverse_rate_constants_;  ///< Per-prefix reverse rate constant functions
+    std::function<double(const micm::Conditions& conditions)>
+        equilibrium_constant_;         ///< Shared equilibrium constant function (intrinsic, representation-independent)
     double solvent_floor_{ 1.0e-20 };  ///< Floor δ [mol m⁻³] added to [S] in ([S]+δ)^n denominator; see SetSolventFloor()
   };
 }  // namespace miam

--- a/test/integration/configs/cam_cloud_chemistry.json
+++ b/test/integration/configs/cam_cloud_chemistry.json
@@ -1,0 +1,238 @@
+{
+  "version": "1.0.0",
+  "name": "CAM Cloud Chemistry",
+
+  "species": [
+    { "name": "SO2",    "molecular weight [kg mol-1]": 0.06407 },
+    { "name": "H2O2",   "molecular weight [kg mol-1]": 0.03401 },
+    { "name": "O3",     "molecular weight [kg mol-1]": 0.04800 },
+    { "name": "Hp",     "molecular weight [kg mol-1]": 0.00101 },
+    { "name": "OHm",    "molecular weight [kg mol-1]": 0.01701 },
+    { "name": "HSO3m",  "molecular weight [kg mol-1]": 0.08107 },
+    { "name": "SO3mm",  "molecular weight [kg mol-1]": 0.08007 },
+    { "name": "SO4mm",  "molecular weight [kg mol-1]": 0.09607 },
+    { "name": "SO2OOHm", "molecular weight [kg mol-1]": 0.11307 },
+    { "name": "H2O",    "molecular weight [kg mol-1]": 0.01801 }
+  ],
+
+  "phases": [
+    {
+      "name": "gas",
+      "species": [
+        { "name": "SO2",  "diffusion coefficient [m2 s-1]": 1.28e-5 },
+        { "name": "H2O2", "diffusion coefficient [m2 s-1]": 1.46e-5 },
+        { "name": "O3",   "diffusion coefficient [m2 s-1]": 1.48e-5 }
+      ]
+    },
+    {
+      "name": "AQUEOUS",
+      "species": [
+        "SO2", "H2O2", "O3", "Hp", "OHm", "HSO3m", "SO3mm", "SO4mm", "SO2OOHm",
+        { "name": "H2O", "density [kg m-3]": 997.0 }
+      ]
+    }
+  ],
+
+  "reactions": [],
+
+  "aerosol representations": [
+    {
+      "type": "UNIFORM_SECTION",
+      "name": "CLOUD",
+      "phases": ["AQUEOUS"],
+      "minimum radius [m]": 1.0e-6,
+      "maximum radius [m]": 1.0e-5
+    }
+  ],
+
+  "aerosol processes": [
+    {
+      "__comment": "Henry's Law Equilibrium: SO2(g) <-> SO2(aq)",
+      "type": "HENRY_LAW_EQUILIBRIUM",
+      "gas phase": "gas",
+      "gas-phase species": "SO2",
+      "condensed phase": "AQUEOUS",
+      "condensed-phase species": "SO2",
+      "solvent": "H2O",
+      "Henry's law constant": {
+        "HLC_ref [mol m-3 Pa-1]": 1.214e-2,
+        "C [K]": 3120.0
+      }
+    },
+    {
+      "__comment": "Henry's Law Equilibrium: H2O2(g) <-> H2O2(aq)",
+      "type": "HENRY_LAW_EQUILIBRIUM",
+      "gas phase": "gas",
+      "gas-phase species": "H2O2",
+      "condensed phase": "AQUEOUS",
+      "condensed-phase species": "H2O2",
+      "solvent": "H2O",
+      "Henry's law constant": {
+        "HLC_ref [mol m-3 Pa-1]": 7.306e2,
+        "C [K]": 6621.0
+      }
+    },
+    {
+      "__comment": "Henry's Law Equilibrium: O3(g) <-> O3(aq)",
+      "type": "HENRY_LAW_EQUILIBRIUM",
+      "gas phase": "gas",
+      "gas-phase species": "O3",
+      "condensed phase": "AQUEOUS",
+      "condensed-phase species": "O3",
+      "solvent": "H2O",
+      "Henry's law constant": {
+        "HLC_ref [mol m-3 Pa-1]": 1.135e-4,
+        "C [K]": 2560.0
+      }
+    },
+    {
+      "__comment": "R1a: HSO3- + H2O2_aq <-> SO2OOH- + H2O (reversible, Keq=1725)",
+      "__note": "k_fwd = c_H2O_M * 7.45e7/13 = 3.184e8; Keq=1725 (Lind & Kok 1986 / revised MIAM)",
+      "type": "DISSOLVED_REVERSIBLE_REACTION",
+      "condensed phase": "AQUEOUS",
+      "solvent": "H2O",
+      "reactants": [
+        { "species name": "HSO3m", "coefficient": 1 },
+        { "species name": "H2O2",  "coefficient": 1 }
+      ],
+      "products": [
+        { "species name": "SO2OOHm", "coefficient": 1 },
+        { "species name": "H2O",     "coefficient": 1 }
+      ],
+      "forward rate constant": {
+        "A": 3.184e8,
+        "C": 4430.0
+      },
+      "equilibrium constant": {
+        "A": 1725.0
+      }
+    },
+    {
+      "__comment": "R1b: SO2OOH- + H+ -> SO4-- (irreversible)",
+      "__note": "k = c_H2O_M * 2.4e6 = 1.333e8; Ea/R = 4430 K",
+      "type": "DISSOLVED_REACTION",
+      "condensed phase": "AQUEOUS",
+      "solvent": "H2O",
+      "reactants": [
+        { "species name": "SO2OOHm", "coefficient": 1 },
+        { "species name": "Hp",      "coefficient": 1 }
+      ],
+      "products": [
+        { "species name": "SO4mm", "coefficient": 1 }
+      ],
+      "rate constant": {
+        "A": 1.333e8,
+        "C": 4430.0
+      }
+    },
+    {
+      "__comment": "Kw: 2 H2O <-> H+ + OH-",
+      "type": "DISSOLVED_EQUILIBRIUM",
+      "condensed phase": "AQUEOUS",
+      "solvent": "H2O",
+      "reactants": [
+        { "species name": "H2O", "coefficient": 2 }
+      ],
+      "products": [
+        { "species name": "Hp",  "coefficient": 1 },
+        { "species name": "OHm", "coefficient": 1 }
+      ],
+      "algebraic species": "OHm",
+      "equilibrium constant": {
+        "A": 3.24e-18,
+        "C": 0.0
+      }
+    },
+    {
+      "__comment": "Ka1: SO2(aq) <-> H+ + HSO3-",
+      "type": "DISSOLVED_EQUILIBRIUM",
+      "condensed phase": "AQUEOUS",
+      "solvent": "H2O",
+      "reactants": [
+        { "species name": "SO2", "coefficient": 1 }
+      ],
+      "products": [
+        { "species name": "Hp",    "coefficient": 1 },
+        { "species name": "HSO3m", "coefficient": 1 }
+      ],
+      "algebraic species": "HSO3m",
+      "equilibrium constant": {
+        "A": 3.06e-4,
+        "C": 2090.0
+      }
+    },
+    {
+      "__comment": "Ka2: HSO3- <-> H+ + SO3--",
+      "type": "DISSOLVED_EQUILIBRIUM",
+      "condensed phase": "AQUEOUS",
+      "solvent": "H2O",
+      "reactants": [
+        { "species name": "HSO3m", "coefficient": 1 }
+      ],
+      "products": [
+        { "species name": "Hp",    "coefficient": 1 },
+        { "species name": "SO3mm", "coefficient": 1 }
+      ],
+      "algebraic species": "SO3mm",
+      "equilibrium constant": {
+        "A": 1.08e-9,
+        "C": 1120.0
+      }
+    },
+    {
+      "__comment": "Mass conservation: total S in reversible pool (includes SO2OOH-)",
+      "type": "LINEAR_CONSTRAINT",
+      "name": "sulfur conservation",
+      "algebraic phase": "gas",
+      "algebraic species": "SO2",
+      "diagnose from state": true,
+      "terms": [
+        { "phase": "gas",     "species": "SO2",      "coefficient": 1.0 },
+        { "phase": "AQUEOUS", "species": "SO2",      "coefficient": 1.0 },
+        { "phase": "AQUEOUS", "species": "HSO3m",    "coefficient": 1.0 },
+        { "phase": "AQUEOUS", "species": "SO3mm",    "coefficient": 1.0 },
+        { "phase": "AQUEOUS", "species": "SO2OOHm",  "coefficient": 1.0 }
+      ]
+    },
+    {
+      "__comment": "Mass conservation: total H2O2",
+      "type": "LINEAR_CONSTRAINT",
+      "name": "H2O2 conservation",
+      "algebraic phase": "gas",
+      "algebraic species": "H2O2",
+      "diagnose from state": true,
+      "terms": [
+        { "phase": "gas",     "species": "H2O2", "coefficient": 1.0 },
+        { "phase": "AQUEOUS", "species": "H2O2", "coefficient": 1.0 }
+      ]
+    },
+    {
+      "__comment": "Mass conservation: total O3",
+      "type": "LINEAR_CONSTRAINT",
+      "name": "O3 conservation",
+      "algebraic phase": "gas",
+      "algebraic species": "O3",
+      "diagnose from state": true,
+      "terms": [
+        { "phase": "gas",     "species": "O3", "coefficient": 1.0 },
+        { "phase": "AQUEOUS", "species": "O3", "coefficient": 1.0 }
+      ]
+    },
+    {
+      "__comment": "Charge balance: H+ = OH- + HSO3- + 2 SO3-- + 2 SO4-- + SO2OOH-",
+      "type": "LINEAR_CONSTRAINT",
+      "name": "charge balance",
+      "algebraic phase": "AQUEOUS",
+      "algebraic species": "Hp",
+      "constant [mol m-3]": 0.0,
+      "terms": [
+        { "phase": "AQUEOUS", "species": "Hp",       "coefficient":  1.0 },
+        { "phase": "AQUEOUS", "species": "OHm",      "coefficient": -1.0 },
+        { "phase": "AQUEOUS", "species": "HSO3m",    "coefficient": -1.0 },
+        { "phase": "AQUEOUS", "species": "SO3mm",    "coefficient": -2.0 },
+        { "phase": "AQUEOUS", "species": "SO4mm",    "coefficient": -2.0 },
+        { "phase": "AQUEOUS", "species": "SO2OOHm",  "coefficient": -1.0 }
+      ]
+    }
+  ]
+}

--- a/test/integration/configs/cam_cloud_chemistry.json
+++ b/test/integration/configs/cam_cloud_chemistry.json
@@ -99,9 +99,8 @@
         { "species name": "SO2OOHm", "coefficient": 1 },
         { "species name": "H2O",     "coefficient": 1 }
       ],
-      "forward rate constant": {
-        "A": 3.184e8,
-        "C": 4430.0
+      "forward rate constants": {
+        "CLOUD": { "A": 3.184e8, "C": 4430.0 }
       },
       "equilibrium constant": {
         "A": 1725.0
@@ -120,9 +119,8 @@
       "products": [
         { "species name": "SO4mm", "coefficient": 1 }
       ],
-      "rate constant": {
-        "A": 1.333e8,
-        "C": 4430.0
+      "rate constants": {
+        "CLOUD": { "A": 1.333e8, "C": 4430.0 }
       }
     },
     {

--- a/test/integration/test_aqueous_carbonic_acid.cpp
+++ b/test/integration/test_aqueous_carbonic_acid.cpp
@@ -123,8 +123,8 @@ namespace
     auto droplet = SingleMomentMode{ "DROPLET", { aqueous_phase }, 5.0e-6, 1.2 };
 
     // CO2(aq) + H2O <-> H+ + HCO3-  (same rate constants in both tests)
-    auto rxn1 = DissolvedReversibleReaction{ [](const Conditions&) { return k1_f; },
-                                             [](const Conditions&) { return k1_r; },
+    auto rxn1 = DissolvedReversibleReaction{ { { "DROPLET", [](const Conditions&) { return k1_f; } } },
+                                             { { "DROPLET", [](const Conditions&) { return k1_r; } } },
                                              { CO2_aq },
                                              { Hp, HCO3m },
                                              H2O,
@@ -250,16 +250,16 @@ TEST(AqueousCarbonicAcid, KineticODE)
                       .Build();
 
   // HCO3- <-> H+ + CO3--  (full stiff rate; stable for pure-ODE Rosenbrock)
-  auto rxn2 = DissolvedReversibleReaction{ [](const Conditions&) { return k2_f; },
-                                           [](const Conditions&) { return k2_r; },
+  auto rxn2 = DissolvedReversibleReaction{ { { "DROPLET", [](const Conditions&) { return k2_f; } } },
+                                           { { "DROPLET", [](const Conditions&) { return k2_r; } } },
                                            { sys.HCO3m },
                                            { sys.Hp, sys.CO3mm },
                                            sys.H2O,
                                            sys.aqueous_phase };
 
   // H2O <-> H+ + OH-  (H2O as reactant AND solvent gives correct Kw_miam)
-  auto rxn_w = DissolvedReversibleReaction{ [](const Conditions&) { return kw_f; },
-                                            [](const Conditions&) { return kw_r; },
+  auto rxn_w = DissolvedReversibleReaction{ { { "DROPLET", [](const Conditions&) { return kw_f; } } },
+                                            { { "DROPLET", [](const Conditions&) { return kw_r; } } },
                                             { sys.H2O },
                                             { sys.Hp, sys.OHm },
                                             sys.H2O,

--- a/test/integration/test_cam_cloud_chemistry.cpp
+++ b/test/integration/test_cam_cloud_chemistry.cpp
@@ -1287,7 +1287,7 @@ TEST(CamCloudChemistry, Step4_FullSystemWithKinetics)
                    .SetReactants({ hso3m, h2o2_aq })
                    .SetProducts({ so2oohm, h2o })
                    .SetSolvent(h2o)
-                   .SetForwardRateConstant(EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
+                   .AddForwardRateConstant("CLOUD", EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
                    .SetEquilibriumConstant(EquilibriumConstant({ .A_ = 1725.0 }))
                    .Build();
 
@@ -1615,7 +1615,7 @@ TEST(CamCloudChemistry, Step4b_NaiveInitialConditions)
                    .SetReactants({ hso3m, h2o2_aq })
                    .SetProducts({ so2oohm, h2o })
                    .SetSolvent(h2o)
-                   .SetForwardRateConstant(EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
+                   .AddForwardRateConstant("CLOUD", EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
                    .SetEquilibriumConstant(EquilibriumConstant({ .A_ = 1725.0 }))
                    .Build();
 
@@ -1888,7 +1888,7 @@ TEST(CamCloudChemistry, Step5_JacobianVerification)
                    .SetReactants({ hso3m, h2o2_aq })
                    .SetProducts({ so2oohm, h2o })
                    .SetSolvent(h2o)
-                   .SetForwardRateConstant(EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
+                   .AddForwardRateConstant("CLOUD", EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
                    .SetEquilibriumConstant(EquilibriumConstant({ .A_ = 1725.0 }))
                    .Build();
 

--- a/test/integration/test_dissolved_reversible_reaction.cpp
+++ b/test/integration/test_dissolved_reversible_reaction.cpp
@@ -57,8 +57,8 @@ TEST(DissolvedReversibleReactionIntegration, SimpleAtoB)
   auto reverse_rate = [k_reverse](const Conditions& conditions) { return k_reverse; };
 
   // Create reversible reaction: A <-> B with solvent C
-  auto reaction = DissolvedReversibleReaction{ forward_rate,
-                                               reverse_rate,
+  auto reaction = DissolvedReversibleReaction{ { { "DROPLET", forward_rate } },
+                                               { { "DROPLET", reverse_rate } },
                                                { A },  // reactants
                                                { B },  // products
                                                C,      // solvent
@@ -179,8 +179,8 @@ TEST(DissolvedReversibleReactionIntegration, SolventAsReactant)
   auto reverse_rate = [k_reverse](const Conditions& conditions) { return k_reverse; };
 
   // Create reversible reaction: A + C <-> B with solvent C
-  auto reaction = DissolvedReversibleReaction{ forward_rate,
-                                               reverse_rate,
+  auto reaction = DissolvedReversibleReaction{ { { "DROPLET", forward_rate } },
+                                               { { "DROPLET", reverse_rate } },
                                                { A, C },  // reactants: A + C
                                                { B },     // products: B
                                                C,         // solvent
@@ -309,8 +309,8 @@ TEST(DissolvedReversibleReactionIntegration, SolventAsProduct)
   // Create reversible reaction: A ⇌ B + C with solvent C
   // Forward: k_f/[C]^0 × [A] = k_f × [A] (no solvent dependence)
   // Reverse: k_r/[C]^1 × [B] × [C] = k_r × [B] (C cancels)
-  auto reaction = DissolvedReversibleReaction{ forward_rate,
-                                               reverse_rate,
+  auto reaction = DissolvedReversibleReaction{ { { "DROPLET", forward_rate } },
+                                               { { "DROPLET", reverse_rate } },
                                                { A },     // reactants: A
                                                { B, C },  // products: B + C
                                                C,         // solvent
@@ -440,8 +440,8 @@ TEST(DissolvedReversibleReactionIntegration, MultiPhaseInstances)
   auto reverse_rate_small = [k_reverse_small](const Conditions& conditions) { return k_reverse_small; };
 
   // Create reaction for small droplets: A ⇌ B
-  auto reaction_small = DissolvedReversibleReaction{ forward_rate_small,
-                                                     reverse_rate_small,
+  auto reaction_small = DissolvedReversibleReaction{ { { "DROPLET_SMALL", forward_rate_small } },
+                                                     { { "DROPLET_SMALL", reverse_rate_small } },
                                                      { A },  // reactants
                                                      { B },  // products
                                                      C,      // solvent
@@ -455,8 +455,8 @@ TEST(DissolvedReversibleReactionIntegration, MultiPhaseInstances)
   auto reverse_rate_large = [k_reverse_large](const Conditions& conditions) { return k_reverse_large; };
 
   // Create reaction for large droplets: A ⇌ B
-  auto reaction_large = DissolvedReversibleReaction{ forward_rate_large,
-                                                     reverse_rate_large,
+  auto reaction_large = DissolvedReversibleReaction{ { { "DROPLET_LARGE", forward_rate_large } },
+                                                     { { "DROPLET_LARGE", reverse_rate_large } },
                                                      { A },  // reactants
                                                      { B },  // products
                                                      C,      // solvent

--- a/test/integration/test_jacobian_verification.cpp
+++ b/test/integration/test_jacobian_verification.cpp
@@ -237,7 +237,9 @@ TEST(JacobianVerification, DissolvedReversibleReactionProcess)
   double k_f = 0.1, k_r = 0.05;
   auto forward_rate = [k_f](const Conditions&) { return k_f; };
   auto reverse_rate = [k_r](const Conditions&) { return k_r; };
-  auto reaction = DissolvedReversibleReaction{ forward_rate, reverse_rate, { A }, { B }, C, aqueous_phase };
+  auto reaction = DissolvedReversibleReaction{
+    { { "DROPLET", forward_rate } }, { { "DROPLET", reverse_rate } }, { A }, { B }, C, aqueous_phase
+  };
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
   model.AddProcesses({ reaction });
@@ -394,9 +396,12 @@ TEST(JacobianVerification, MultipleProcessesCombined)
                        .Build();
 
   // C ⇌ D (reversible)
-  auto reaction2 = DissolvedReversibleReaction{
-    [](const Conditions&) { return 0.2; }, [](const Conditions&) { return 0.05; }, { C }, { D }, S, aqueous_phase
-  };
+  auto reaction2 = DissolvedReversibleReaction{ { { "DROPLET", [](const Conditions&) { return 0.2; } } },
+                                                { { "DROPLET", [](const Conditions&) { return 0.05; } } },
+                                                { C },
+                                                { D },
+                                                S,
+                                                aqueous_phase };
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
   model.AddProcesses(reaction1, reaction2);
@@ -799,7 +804,9 @@ TEST(JacobianVerification, DissolvedReversibleReactionDampingRange)
   double k_f = 0.1, k_r = 0.05;
   auto forward_rate = [k_f](const Conditions&) { return k_f; };
   auto reverse_rate = [k_r](const Conditions&) { return k_r; };
-  auto reaction = DissolvedReversibleReaction{ forward_rate, reverse_rate, { A }, { B }, C, aqueous_phase };
+  auto reaction = DissolvedReversibleReaction{
+    { { "DROPLET", forward_rate } }, { { "DROPLET", reverse_rate } }, { A }, { B }, C, aqueous_phase
+  };
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
   model.AddProcesses({ reaction });

--- a/test/integration/test_kinetic_vs_constrained.cpp
+++ b/test/integration/test_kinetic_vs_constrained.cpp
@@ -43,7 +43,9 @@ namespace
 
     auto forward_rate = [k_f](const Conditions& conditions) { return k_f; };
     auto reverse_rate = [k_r](const Conditions& conditions) { return k_r; };
-    auto reversible = DissolvedReversibleReaction{ forward_rate, reverse_rate, { B }, { C }, S, aqueous_phase };
+    auto reversible = DissolvedReversibleReaction{
+      { { "DROPLET", forward_rate } }, { { "DROPLET", reverse_rate } }, { B }, { C }, S, aqueous_phase
+    };
 
     auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
     model.AddProcesses({ reaction });
@@ -133,7 +135,9 @@ TEST(KineticVsConstrained, DissolvedReversibleVsEquilibriumConstraint)
 
     auto forward_rate = [k_f](const Conditions& conditions) { return k_f; };
     auto reverse_rate = [k_r](const Conditions& conditions) { return k_r; };
-    auto reversible = DissolvedReversibleReaction{ forward_rate, reverse_rate, { B }, { C }, S, aqueous_phase };
+    auto reversible = DissolvedReversibleReaction{
+      { { "DROPLET", forward_rate } }, { { "DROPLET", reverse_rate } }, { B }, { C }, S, aqueous_phase
+    };
 
     auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
     model.AddProcesses({ reaction });

--- a/test/integration/test_miam_api.cpp
+++ b/test/integration/test_miam_api.cpp
@@ -136,7 +136,10 @@ TEST(MIAM, ApiExample)
                               .SetSolvent(h2o)
                               .SetEquilibriumConstant(EquilibriumConstant(
                                   EquilibriumConstantParameters{ .A_ = 1.14e-2, .C_ = 2300.0, .T0_ = 298.15 }))
-                              .SetReverseRateConstant(ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
+                              .AddReverseRateConstant("SMALL_DROP", ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
+                              .AddReverseRateConstant("LARGE_DROP", ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
+                              .AddReverseRateConstant("AITKEN", ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
+                              .AddReverseRateConstant("ACCUMULATION", ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
                               .Build();
 
   // Condensed phase reversible reaction: CO2 hydration
@@ -150,7 +153,10 @@ TEST(MIAM, ApiExample)
                            .SetSolvent(h2o)
                            .SetEquilibriumConstant(EquilibriumConstant(
                                EquilibriumConstantParameters{ .A_ = 1.70e3, .C_ = 2400.0, .T0_ = 298.15 }))
-                           .SetReverseRateConstant(ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
+                           .AddReverseRateConstant("SMALL_DROP", ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
+                           .AddReverseRateConstant("LARGE_DROP", ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
+                           .AddReverseRateConstant("AITKEN", ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
+                           .AddReverseRateConstant("ACCUMULATION", ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
                            .Build();
 
   // Condensed phase reversible reaction: H2CO3 dissociation
@@ -164,7 +170,10 @@ TEST(MIAM, ApiExample)
                                 .SetSolvent(h2o)
                                 .SetEquilibriumConstant(EquilibriumConstant(
                                     EquilibriumConstantParameters{ .A_ = 4.27e2, .C_ = 2300.0, .T0_ = 298.15 }))
-                                .SetReverseRateConstant(ArrheniusRateConstantParameters{ .A_ = 2.5e10, .C_ = 4.0e4 })
+                                .AddReverseRateConstant("SMALL_DROP", ArrheniusRateConstantParameters{ .A_ = 2.5e10, .C_ = 4.0e4 })
+                                .AddReverseRateConstant("LARGE_DROP", ArrheniusRateConstantParameters{ .A_ = 2.5e10, .C_ = 4.0e4 })
+                                .AddReverseRateConstant("AITKEN", ArrheniusRateConstantParameters{ .A_ = 2.5e10, .C_ = 4.0e4 })
+                                .AddReverseRateConstant("ACCUMULATION", ArrheniusRateConstantParameters{ .A_ = 2.5e10, .C_ = 4.0e4 })
                                 .Build();
 
   // Condensed phase reversible reaction: HCO3- dissociation
@@ -178,7 +187,10 @@ TEST(MIAM, ApiExample)
                                 .SetSolvent(h2o)
                                 .SetEquilibriumConstant(EquilibriumConstant(
                                     EquilibriumConstantParameters{ .A_ = 1.70e1, .C_ = 2300.0, .T0_ = 298.15 }))
-                                .SetReverseRateConstant(ArrheniusRateConstantParameters{ .A_ = 6.4e9, .C_ = 3.1e4 })
+                                .AddReverseRateConstant("SMALL_DROP", ArrheniusRateConstantParameters{ .A_ = 6.4e9, .C_ = 3.1e4 })
+                                .AddReverseRateConstant("LARGE_DROP", ArrheniusRateConstantParameters{ .A_ = 6.4e9, .C_ = 3.1e4 })
+                                .AddReverseRateConstant("AITKEN", ArrheniusRateConstantParameters{ .A_ = 6.4e9, .C_ = 3.1e4 })
+                                .AddReverseRateConstant("ACCUMULATION", ArrheniusRateConstantParameters{ .A_ = 6.4e9, .C_ = 3.1e4 })
                                 .Build();
 
   std::vector<DissolvedReversibleReaction> reactions{ //    co2_photo,

--- a/test/integration/test_solvent_robustness.cpp
+++ b/test/integration/test_solvent_robustness.cpp
@@ -255,7 +255,7 @@ namespace
                      .SetReactants({ sp.hso3m, sp.h2o2_aq })
                      .SetProducts({ sp.so2oohm, sp.h2o })
                      .SetSolvent(sp.h2o)
-                     .SetForwardRateConstant(EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
+                     .AddForwardRateConstant("CLOUD", EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
                      .SetEquilibriumConstant(EquilibriumConstant({ .A_ = 1725.0 }))
                      .Build();
 
@@ -415,7 +415,7 @@ TEST(SolventRobustness, A2_DissolvedReversibleReaction_SolventSweep)
                    .SetReactants({ hso3m, h2o2_aq })
                    .SetProducts({ so2oohm, h2o })
                    .SetSolvent(h2o)
-                   .SetForwardRateConstant(EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
+                   .AddForwardRateConstant("CLOUD", EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
                    .SetEquilibriumConstant(EquilibriumConstant({ .A_ = 1725.0 }))
                    .Build();
 

--- a/test/unit/constraints/linear_constraint.cpp
+++ b/test/unit/constraints/linear_constraint.cpp
@@ -131,47 +131,6 @@ TEST(LinearConstraint, ResidualGlobal)
   EXPECT_NEAR(residual[0][0], 10.0, 1.0e-12);
 }
 
-// ── Representation-qualified term: instanced term restricted to a single representation ──
-
-TEST(LinearConstraint, RepresentationQualifiedTermGlobal)
-{
-  // G = [A_g] + [A_aq @ LARGE only] - C   (SMALL's A_aq is deliberately excluded)
-  LinearConstraint constraint(
-      gas_phase, A_g, { { gas_phase, A_g, 1.0 }, { aqueous_phase, A_aq, 1.0, "LARGE" } }, 80.0);
-
-  std::map<std::string, std::set<std::string>> phase_prefixes;
-  phase_prefixes["AQUEOUS"].insert("LARGE");
-  phase_prefixes["AQUEOUS"].insert("SMALL");
-
-  // Dependencies and Jacobian sparsity must exclude SMALL
-  auto deps = constraint.ConstraintSpeciesDependencies(phase_prefixes);
-  EXPECT_EQ(deps.size(), 2);
-  EXPECT_TRUE(deps.count("A_g"));
-  EXPECT_TRUE(deps.count("LARGE.AQUEOUS.A_aq"));
-  EXPECT_FALSE(deps.count("SMALL.AQUEOUS.A_aq"));
-
-  std::unordered_map<std::string, std::size_t> state_indices;
-  state_indices["A_g"] = 0;
-  state_indices["LARGE.AQUEOUS.A_aq"] = 1;
-  state_indices["SMALL.AQUEOUS.A_aq"] = 2;
-
-  auto elements = constraint.NonZeroConstraintJacobianElements(phase_prefixes, state_indices);
-  EXPECT_EQ(elements.size(), 2);
-  EXPECT_TRUE(elements.count({ 0, 0 }));
-  EXPECT_TRUE(elements.count({ 0, 1 }));
-  EXPECT_FALSE(elements.count({ 0, 2 }));  // SMALL excluded
-
-  auto residual_fn = constraint.ConstraintResidualFunction<DMP>(phase_prefixes, param_indices, state_indices);
-  DMP state_variables{ 1, 3, 0.0 };
-  state_variables[0][0] = 50.0;   // [A_g]
-  state_variables[0][1] = 30.0;   // LARGE [A_aq]
-  state_variables[0][2] = 999.0;  // SMALL [A_aq] — must NOT contribute
-  DMP residual{ 1, 3, 0.0 };
-  residual_fn(state_variables, no_params, residual);
-  // G = 50 + 30 - 80 = 0; SMALL's 999 is ignored
-  EXPECT_NEAR(residual[0][0], 0.0, 1.0e-12);
-}
-
 TEST(LinearConstraint, JacobianGlobal)
 {
   LinearConstraint constraint(gas_phase, A_g, { { gas_phase, A_g, 1.0 }, { aqueous_phase, A_aq, 1.0 } }, 100.0);

--- a/test/unit/constraints/linear_constraint.cpp
+++ b/test/unit/constraints/linear_constraint.cpp
@@ -131,6 +131,47 @@ TEST(LinearConstraint, ResidualGlobal)
   EXPECT_NEAR(residual[0][0], 10.0, 1.0e-12);
 }
 
+// ── Representation-qualified term: instanced term restricted to a single representation ──
+
+TEST(LinearConstraint, RepresentationQualifiedTermGlobal)
+{
+  // G = [A_g] + [A_aq @ LARGE only] - C   (SMALL's A_aq is deliberately excluded)
+  LinearConstraint constraint(
+      gas_phase, A_g, { { gas_phase, A_g, 1.0 }, { aqueous_phase, A_aq, 1.0, "LARGE" } }, 80.0);
+
+  std::map<std::string, std::set<std::string>> phase_prefixes;
+  phase_prefixes["AQUEOUS"].insert("LARGE");
+  phase_prefixes["AQUEOUS"].insert("SMALL");
+
+  // Dependencies and Jacobian sparsity must exclude SMALL
+  auto deps = constraint.ConstraintSpeciesDependencies(phase_prefixes);
+  EXPECT_EQ(deps.size(), 2);
+  EXPECT_TRUE(deps.count("A_g"));
+  EXPECT_TRUE(deps.count("LARGE.AQUEOUS.A_aq"));
+  EXPECT_FALSE(deps.count("SMALL.AQUEOUS.A_aq"));
+
+  std::unordered_map<std::string, std::size_t> state_indices;
+  state_indices["A_g"] = 0;
+  state_indices["LARGE.AQUEOUS.A_aq"] = 1;
+  state_indices["SMALL.AQUEOUS.A_aq"] = 2;
+
+  auto elements = constraint.NonZeroConstraintJacobianElements(phase_prefixes, state_indices);
+  EXPECT_EQ(elements.size(), 2);
+  EXPECT_TRUE(elements.count({ 0, 0 }));
+  EXPECT_TRUE(elements.count({ 0, 1 }));
+  EXPECT_FALSE(elements.count({ 0, 2 }));  // SMALL excluded
+
+  auto residual_fn = constraint.ConstraintResidualFunction<DMP>(phase_prefixes, param_indices, state_indices);
+  DMP state_variables{ 1, 3, 0.0 };
+  state_variables[0][0] = 50.0;   // [A_g]
+  state_variables[0][1] = 30.0;   // LARGE [A_aq]
+  state_variables[0][2] = 999.0;  // SMALL [A_aq] — must NOT contribute
+  DMP residual{ 1, 3, 0.0 };
+  residual_fn(state_variables, no_params, residual);
+  // G = 50 + 30 - 80 = 0; SMALL's 999 is ignored
+  EXPECT_NEAR(residual[0][0], 0.0, 1.0e-12);
+}
+
 TEST(LinearConstraint, JacobianGlobal)
 {
   LinearConstraint constraint(gas_phase, A_g, { { gas_phase, A_g, 1.0 }, { aqueous_phase, A_aq, 1.0 } }, 100.0);

--- a/test/unit/model.cpp
+++ b/test/unit/model.cpp
@@ -47,9 +47,11 @@ TEST(Model, SpeciesUsedWithSingleRepresentationAndProcess)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-14; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { h2o },  // reactants
-                                        { hp, ohm },                          // products
-                                        h2o,                                  // solvent
+  DissolvedReversibleReaction reaction{ { { "SMALL_DROP", forward_rate } },
+                                        { { "SMALL_DROP", reverse_rate } },
+                                        { h2o },      // reactants
+                                        { hp, ohm },  // products
+                                        h2o,          // solvent
                                         aqueous_phase };
 
   Model model;
@@ -80,9 +82,11 @@ TEST(Model, SpeciesUsedWithMultipleRepresentations)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-14; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { h2o },  // reactants
-                                        { hp, ohm },                          // products
-                                        h2o,                                  // solvent
+  DissolvedReversibleReaction reaction{ { { "SMALL_DROP", forward_rate }, { "LARGE_DROP", forward_rate } },
+                                        { { "SMALL_DROP", reverse_rate }, { "LARGE_DROP", reverse_rate } },
+                                        { h2o },      // reactants
+                                        { hp, ohm },  // products
+                                        h2o,          // solvent
                                         aqueous_phase };
 
   Model model;
@@ -122,12 +126,22 @@ TEST(Model, SpeciesUsedWithMultipleProcesses)
   auto h2o_forward = [](const micm::Conditions& conditions) { return 1.0e-14; };
   auto h2o_reverse = [](const micm::Conditions& conditions) { return 1.0e11; };
 
-  DissolvedReversibleReaction h2o_dissociation{ h2o_forward, h2o_reverse, { h2o }, { hp, ohm }, h2o, aqueous_phase };
+  DissolvedReversibleReaction h2o_dissociation{ { { "AITKEN", h2o_forward } },
+                                                { { "AITKEN", h2o_reverse } },
+                                                { h2o },
+                                                { hp, ohm },
+                                                h2o,
+                                                aqueous_phase };
 
   auto co2_forward = [](const micm::Conditions& conditions) { return 1.0e-3; };
   auto co2_reverse = [](const micm::Conditions& conditions) { return 1.0e2; };
 
-  DissolvedReversibleReaction co2_hydration{ co2_forward, co2_reverse, { co2, h2o }, { h2co3 }, h2o, aqueous_phase };
+  DissolvedReversibleReaction co2_hydration{ { { "AITKEN", co2_forward } },
+                                             { { "AITKEN", co2_reverse } },
+                                             { co2, h2o },
+                                             { h2co3 },
+                                             h2o,
+                                             aqueous_phase };
 
   Model model;
   model.name_ = "TEST_MODEL";
@@ -161,7 +175,14 @@ TEST(Model, SpeciesUsedMixedRepresentationTypes)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-3; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e2; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { co2, h2o }, { h2co3 }, h2o, aqueous_phase };
+  DissolvedReversibleReaction reaction{
+    { { "MODE1", forward_rate }, { "MODE2", forward_rate }, { "BIN_01", forward_rate } },
+    { { "MODE1", reverse_rate }, { "MODE2", reverse_rate }, { "BIN_01", reverse_rate } },
+    { co2, h2o },
+    { h2co3 },
+    h2o,
+    aqueous_phase
+  };
 
   Model model;
   model.name_ = "TEST_MODEL";
@@ -197,9 +218,13 @@ TEST(Model, AddProcesses)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-14; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
-  DissolvedReversibleReaction reaction1{ forward_rate, reverse_rate, { h2o }, { hp, ohm }, h2o, aqueous_phase };
+  DissolvedReversibleReaction reaction1{
+    { { "MODE1", forward_rate } }, { { "MODE1", reverse_rate } }, { h2o }, { hp, ohm }, h2o, aqueous_phase
+  };
 
-  DissolvedReversibleReaction reaction2{ reverse_rate, forward_rate, { hp, ohm }, { h2o }, h2o, aqueous_phase };
+  DissolvedReversibleReaction reaction2{
+    { { "MODE1", reverse_rate } }, { { "MODE1", forward_rate } }, { hp, ohm }, { h2o }, h2o, aqueous_phase
+  };
 
   Model model;
   model.name_ = "TEST_MODEL";
@@ -247,7 +272,9 @@ TEST(Model, SpeciesUsedWithDifferentPhasesInReactions)
   auto reverse_rate = [](const micm::Conditions& conditions) { return 2.0; };
 
   // Reaction only in aqueous phase
-  DissolvedReversibleReaction aqueous_reaction{ forward_rate, reverse_rate, { h2o }, { hp }, h2o, aqueous_phase };
+  DissolvedReversibleReaction aqueous_reaction{
+    { { "DROPLET", forward_rate } }, { { "DROPLET", reverse_rate } }, { h2o }, { hp }, h2o, aqueous_phase
+  };
 
   Model model;
   model.name_ = "TEST_MODEL";
@@ -303,7 +330,9 @@ TEST(Model, NonZeroJacobianElementsWithSingleProcess)
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
   // H2O <-> H+ + OH-
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { h2o }, { hp, ohm }, h2o, aqueous_phase };
+  DissolvedReversibleReaction reaction{
+    { { "SMALL_DROP", forward_rate } }, { { "SMALL_DROP", reverse_rate } }, { h2o }, { hp, ohm }, h2o, aqueous_phase
+  };
 
   Model model;
   model.name_ = "TEST_MODEL";
@@ -345,12 +374,22 @@ TEST(Model, NonZeroJacobianElementsWithMultipleProcesses)
   auto h2o_forward = [](const micm::Conditions& conditions) { return 1.0e-14; };
   auto h2o_reverse = [](const micm::Conditions& conditions) { return 1.0e11; };
 
-  DissolvedReversibleReaction h2o_dissociation{ h2o_forward, h2o_reverse, { h2o }, { hp, ohm }, h2o, aqueous_phase };
+  DissolvedReversibleReaction h2o_dissociation{ { { "AITKEN", h2o_forward } },
+                                                { { "AITKEN", h2o_reverse } },
+                                                { h2o },
+                                                { hp, ohm },
+                                                h2o,
+                                                aqueous_phase };
 
   auto co2_forward = [](const micm::Conditions& conditions) { return 1.0e-3; };
   auto co2_reverse = [](const micm::Conditions& conditions) { return 1.0e2; };
 
-  DissolvedReversibleReaction co2_hydration{ co2_forward, co2_reverse, { co2, h2o }, { h2co3 }, h2o, aqueous_phase };
+  DissolvedReversibleReaction co2_hydration{ { { "AITKEN", co2_forward } },
+                                             { { "AITKEN", co2_reverse } },
+                                             { co2, h2o },
+                                             { h2co3 },
+                                             h2o,
+                                             aqueous_phase };
 
   Model model;
   model.name_ = "TEST_MODEL";
@@ -395,7 +434,14 @@ TEST(Model, NonZeroJacobianElementsWithMultipleRepresentations)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-14; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { h2o }, { hp, ohm }, h2o, aqueous_phase };
+  DissolvedReversibleReaction reaction{
+    { { "SMALL_DROP", forward_rate }, { "LARGE_DROP", forward_rate } },
+    { { "SMALL_DROP", reverse_rate }, { "LARGE_DROP", reverse_rate } },
+    { h2o },
+    { hp, ohm },
+    h2o,
+    aqueous_phase
+  };
 
   Model model;
   model.name_ = "TEST_MODEL";
@@ -437,7 +483,14 @@ TEST(Model, NonZeroJacobianElementsMixedTypes)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-3; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e2; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { co2, h2o }, { h2co3 }, h2o, aqueous_phase };
+  DissolvedReversibleReaction reaction{
+    { { "MODE1", forward_rate }, { "MODE2", forward_rate } },
+    { { "MODE1", reverse_rate }, { "MODE2", reverse_rate } },
+    { co2, h2o },
+    { h2co3 },
+    h2o,
+    aqueous_phase
+  };
 
   Model model;
   model.name_ = "TEST_MODEL";

--- a/test/unit/process_set.cpp
+++ b/test/unit/process_set.cpp
@@ -32,8 +32,8 @@ namespace
 
     DissolvedReversibleReaction MakeReaction() const
     {
-      return DissolvedReversibleReaction{ [kf = k_forward](const micm::Conditions&) { return kf; },
-                                          [kr = k_reverse](const micm::Conditions&) { return kr; },
+      return DissolvedReversibleReaction{ { { "DROP", [kf = k_forward](const micm::Conditions&) { return kf; } } },
+                                          { { "DROP", [kr = k_reverse](const micm::Conditions&) { return kr; } } },
                                           { a },
                                           { b },
                                           solvent,
@@ -80,10 +80,10 @@ TEST(MiamProcessSet, ProcessParameterNames)
 
   // Should have 2 parameter names (k_forward and k_reverse) for the single phase instance
   EXPECT_EQ(names.size(), 2);
-  // Names follow the pattern AQUEOUS.<uuid>.k_forward / k_reverse — just check count
+  // Names follow the pattern DROP.AQUEOUS.<uuid>.k_forward / k_reverse — just check count
   for (const auto& name : names)
   {
-    EXPECT_TRUE(name.find("AQUEOUS.") == 0);
+    EXPECT_TRUE(name.find("DROP.AQUEOUS.") == 0);
   }
 }
 

--- a/test/unit/processes/dissolved_reversible_reaction.cpp
+++ b/test/unit/processes/dissolved_reversible_reaction.cpp
@@ -81,9 +81,11 @@ TEST(DissolvedReversibleReaction, SpeciesUsedWithSinglePrefix)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-14; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { h2o },  // reactants
-                                        { hp, ohm },                          // products
-                                        h2o,                                  // solvent
+  DissolvedReversibleReaction reaction{ { { "SMALL_DROP", forward_rate } },
+                                        { { "SMALL_DROP", reverse_rate } },
+                                        { h2o },      // reactants
+                                        { hp, ohm },  // products
+                                        h2o,          // solvent
                                         aqueous_phase };
 
   // Create phase prefixes map - single representation with one prefix
@@ -110,9 +112,11 @@ TEST(DissolvedReversibleReaction, SpeciesUsedWithMultiplePrefixes)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-3; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e2; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { co2, h2o },  // reactants
-                                        { h2co3 },                                 // products
-                                        h2o,                                       // solvent
+  DissolvedReversibleReaction reaction{ { { "SMALL_DROP", forward_rate }, { "LARGE_DROP", forward_rate } },
+                                        { { "SMALL_DROP", reverse_rate }, { "LARGE_DROP", reverse_rate } },
+                                        { co2, h2o },  // reactants
+                                        { h2co3 },     // products
+                                        h2o,           // solvent
                                         aqueous_phase };
 
   // Create phase prefixes map - multiple representations with different prefixes
@@ -147,9 +151,11 @@ TEST(DissolvedReversibleReaction, SpeciesUsedWithNoMatchingPhase)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-3; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e2; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { co2, h2o },  // reactants
-                                        { h2co3 },                                 // products
-                                        h2o,                                       // solvent
+  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
+                                        { { "MODE1", reverse_rate } },
+                                        { co2, h2o },  // reactants
+                                        { h2co3 },     // products
+                                        h2o,           // solvent
                                         aqueous_phase };
 
   // Create phase prefixes map without the AQUEOUS phase
@@ -171,9 +177,11 @@ TEST(DissolvedReversibleReaction, SpeciesUsedDuplicateHandling)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-10; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
-  DissolvedReversibleReaction reaction{ forward_rate,  reverse_rate, { hco3m },  // reactants
-                                        { hp, co32m },                           // products
-                                        hco3m,                                   // solvent (same as reactant)
+  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
+                                        { { "MODE1", reverse_rate } },
+                                        { hco3m },      // reactants
+                                        { hp, co32m },  // products
+                                        hco3m,          // solvent (same as reactant)
                                         aqueous_phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -202,9 +210,14 @@ TEST(DissolvedReversibleReaction, SpeciesUsedComplexReaction)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 2.0; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { a, b },  // 2 reactants
-                                        { c, d },                              // 2 products
-                                        solvent,      phase };
+  DissolvedReversibleReaction reaction{
+    { { "REP1", forward_rate }, { "REP2", forward_rate }, { "REP3", forward_rate } },
+    { { "REP1", reverse_rate }, { "REP2", reverse_rate }, { "REP3", reverse_rate } },
+    { a, b },  // 2 reactants
+    { c, d },  // 2 products
+    solvent,
+    phase
+  };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["LIQUID"].insert("REP1");
@@ -239,9 +252,11 @@ TEST(DissolvedReversibleReaction, NonZeroJacobianElementsBasic)
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
   // H2O <-> H+ + OH-
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { h2o },  // reactants
-                                        { hp, ohm },                          // products
-                                        h2o,                                  // solvent
+  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
+                                        { { "MODE1", reverse_rate } },
+                                        { h2o },      // reactants
+                                        { hp, ohm },  // products
+                                        h2o,          // solvent
                                         aqueous_phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -285,9 +300,11 @@ TEST(DissolvedReversibleReaction, NonZeroJacobianElementsMultipleReactants)
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e2; };
 
   // CO2 + H2O <-> H2CO3
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { co2, h2o },  // 2 reactants
-                                        { h2co3 },                                 // 1 product
-                                        h2o,                                       // solvent
+  DissolvedReversibleReaction reaction{ { { "DROP", forward_rate } },
+                                        { { "DROP", reverse_rate } },
+                                        { co2, h2o },  // 2 reactants
+                                        { h2co3 },     // 1 product
+                                        h2o,           // solvent
                                         aqueous_phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -319,7 +336,12 @@ TEST(DissolvedReversibleReaction, NonZeroJacobianElementsMultiplePrefixes)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-14; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { h2o }, { hp, ohm }, h2o, aqueous_phase };
+  DissolvedReversibleReaction reaction{ { { "SMALL_DROP", forward_rate }, { "LARGE_DROP", forward_rate } },
+                                        { { "SMALL_DROP", reverse_rate }, { "LARGE_DROP", reverse_rate } },
+                                        { h2o },
+                                        { hp, ohm },
+                                        h2o,
+                                        aqueous_phase };
 
   // Two representations of the same phase
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -359,7 +381,8 @@ TEST(DissolvedReversibleReaction, NonZeroJacobianElementsComplexReaction)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-10; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { hco3m }, { hp, co32m }, h2o, aqueous_phase };
+  DissolvedReversibleReaction reaction{ { { "MODE", forward_rate } }, { { "MODE", reverse_rate } }, { hco3m },
+                                        { hp, co32m },                h2o,                          aqueous_phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE");
@@ -404,13 +427,18 @@ TEST(DissolvedReversibleReaction, UpdateStateParametersFunctionBasic)
   auto forward_rate = [k_forward](const micm::Conditions& conditions) { return k_forward; };
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { h2o }, { hp, ohm }, h2o, aqueous_phase };
+  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
+                                        { { "MODE1", reverse_rate } },
+                                        { h2o },
+                                        { hp, ohm },
+                                        h2o,
+                                        aqueous_phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -454,13 +482,18 @@ TEST(DissolvedReversibleReaction, UpdateStateParametersFunctionTemperatureDepend
   auto reverse_rate = [](const micm::Conditions& conditions)
   { return 1.0e11 * std::exp(-2000.0 / conditions.temperature_); };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { h2o }, { hp, ohm }, h2o, aqueous_phase };
+  DissolvedReversibleReaction reaction{ { { "DROPLET", forward_rate } },
+                                        { { "DROPLET", reverse_rate } },
+                                        { h2o },
+                                        { hp, ohm },
+                                        h2o,
+                                        aqueous_phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROPLET");
 
-  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = "DROPLET." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = "DROPLET." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -511,13 +544,18 @@ TEST(DissolvedReversibleReaction, UpdateStateParametersFunctionMissingParameter)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-14; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { h2o }, { hp, ohm }, h2o, aqueous_phase };
+  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
+                                        { { "MODE1", reverse_rate } },
+                                        { h2o },
+                                        { hp, ohm },
+                                        h2o,
+                                        aqueous_phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
   // Only include forward parameter, not reverse
-  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string forward_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -543,13 +581,18 @@ TEST(DissolvedReversibleReaction, UpdateStateParametersFunctionMultipleCells)
   };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e2; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { co2, h2o }, { h2co3 }, h2o, aqueous_phase };
+  DissolvedReversibleReaction reaction{ { { "CLOUD", forward_rate } },
+                                        { { "CLOUD", reverse_rate } },
+                                        { co2, h2o },
+                                        { h2co3 },
+                                        h2o,
+                                        aqueous_phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("CLOUD");
 
-  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = "CLOUD." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = "CLOUD." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -601,16 +644,18 @@ TEST(DissolvedReversibleReaction, ForcingFunctionBasicRates)
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
   // H2O <-> H+ + OH-
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { h2o },  // reactants
-                                        { hp, ohm },                          // products
-                                        h2o,                                  // solvent
+  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
+                                        { { "MODE1", reverse_rate } },
+                                        { h2o },      // reactants
+                                        { hp, ohm },  // products
+                                        h2o,          // solvent
                                         aqueous_phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -672,16 +717,18 @@ TEST(DissolvedReversibleReaction, ForcingFunctionSolventNormalization)
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
   // CO2 + H2O <-> H2CO3
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { co2, h2o },  // 2 reactants
-                                        { h2co3 },                                 // 1 product
-                                        h2o,                                       // solvent
+  DissolvedReversibleReaction reaction{ { { "DROP", forward_rate } },
+                                        { { "DROP", reverse_rate } },
+                                        { co2, h2o },  // 2 reactants
+                                        { h2co3 },     // 1 product
+                                        h2o,           // solvent
                                         aqueous_phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = "DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = "DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -740,15 +787,18 @@ TEST(DissolvedReversibleReaction, ForcingFunctionMultipleReactantsProducts)
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
   // A + B <-> C + D
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { a, b },  // 2 reactants
-                                        { c, d },                              // 2 products
-                                        solvent,      phase };
+  DissolvedReversibleReaction reaction{ { { "REP1", forward_rate } },
+                                        { { "REP1", reverse_rate } },
+                                        { a, b },  // 2 reactants
+                                        { c, d },  // 2 products
+                                        solvent,
+                                        phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["LIQUID"].insert("REP1");
 
-  std::string forward_param = phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = "REP1." + phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = "REP1." + phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -810,13 +860,18 @@ TEST(DissolvedReversibleReaction, ForcingFunctionMultipleCells)
   auto forward_rate = [k_forward](const micm::Conditions& conditions) { return k_forward; };
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { h2o }, { hp, ohm }, h2o, aqueous_phase };
+  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
+                                        { { "MODE1", reverse_rate } },
+                                        { h2o },
+                                        { hp, ohm },
+                                        h2o,
+                                        aqueous_phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -879,19 +934,24 @@ TEST(DissolvedReversibleReaction, ForcingFunctionMultiplePhaseInstances)
   auto forward_rate = [k_forward](const micm::Conditions& conditions) { return k_forward; };
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { h2o }, { hp, ohm }, h2o, aqueous_phase };
+  DissolvedReversibleReaction reaction{ { { "SMALL_DROP", forward_rate }, { "LARGE_DROP", forward_rate } },
+                                        { { "SMALL_DROP", reverse_rate }, { "LARGE_DROP", reverse_rate } },
+                                        { h2o },
+                                        { hp, ohm },
+                                        h2o,
+                                        aqueous_phase };
 
   // Two phase instances (e.g., small and large drops)
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("SMALL_DROP");
   phase_prefixes["AQUEOUS"].insert("LARGE_DROP");
 
-  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
-
+  // Each representation has its own rate-constant columns in the parameters matrix
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
-  state_parameter_indices[forward_param] = 0;
-  state_parameter_indices[reverse_param] = 1;
+  state_parameter_indices["SMALL_DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  state_parameter_indices["SMALL_DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  state_parameter_indices["LARGE_DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 2;
+  state_parameter_indices["LARGE_DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 3;
 
   std::unordered_map<std::string, std::size_t> state_variable_indices;
   state_variable_indices["SMALL_DROP.AQUEOUS.H2O"] = 0;
@@ -904,9 +964,11 @@ TEST(DissolvedReversibleReaction, ForcingFunctionMultiplePhaseInstances)
   auto forcing_func =
       reaction.ForcingFunction<MatrixPolicy>(phase_prefixes, state_parameter_indices, state_variable_indices);
 
-  MatrixPolicy state_parameters(1, 2);
+  MatrixPolicy state_parameters(1, 4);
   state_parameters[0][0] = k_forward;
   state_parameters[0][1] = k_reverse;
+  state_parameters[0][2] = k_forward;
+  state_parameters[0][3] = k_reverse;
 
   MatrixPolicy state_variables(1, 6);
   // Small drop
@@ -959,16 +1021,18 @@ TEST(DissolvedReversibleReaction, JacobianFunctionBasicPartials)
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
   // H2O <-> H+ + OH-
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { h2o },  // 1 reactant
-                                        { hp, ohm },                          // 2 products
-                                        h2o,                                  // solvent
+  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
+                                        { { "MODE1", reverse_rate } },
+                                        { h2o },      // 1 reactant
+                                        { hp, ohm },  // 2 products
+                                        h2o,          // solvent
                                         aqueous_phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -1055,16 +1119,18 @@ TEST(DissolvedReversibleReaction, JacobianFunctionMultipleReactantsProducts)
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
   // CO2 + H2O <-> H2CO3
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { co2, h2o },  // 2 reactants
-                                        { h2co3 },                                 // 1 product
-                                        h2o,                                       // solvent
+  DissolvedReversibleReaction reaction{ { { "DROP", forward_rate } },
+                                        { { "DROP", reverse_rate } },
+                                        { co2, h2o },  // 2 reactants
+                                        { h2co3 },     // 1 product
+                                        h2o,           // solvent
                                         aqueous_phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = "DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = "DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -1157,16 +1223,18 @@ TEST(DissolvedReversibleReaction, JacobianFunctionSigns)
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
   // HCO3- <-> H+ + CO32-
-  DissolvedReversibleReaction reaction{ forward_rate,  reverse_rate, { hco3m },  // 1 reactant
-                                        { hp, co32m },                           // 2 products
-                                        h2o,                                     // solvent
+  DissolvedReversibleReaction reaction{ { { "MODE", forward_rate } },
+                                        { { "MODE", reverse_rate } },
+                                        { hco3m },      // 1 reactant
+                                        { hp, co32m },  // 2 products
+                                        h2o,            // solvent
                                         aqueous_phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE");
 
-  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = "MODE." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = "MODE." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -1247,13 +1315,18 @@ TEST(DissolvedReversibleReaction, JacobianFunctionMultipleCells)
   auto forward_rate = [k_forward](const micm::Conditions& conditions) { return k_forward; };
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { h2o }, { hp, ohm }, h2o, aqueous_phase };
+  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
+                                        { { "MODE1", reverse_rate } },
+                                        { h2o },
+                                        { hp, ohm },
+                                        h2o,
+                                        aqueous_phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -1327,19 +1400,24 @@ TEST(DissolvedReversibleReaction, JacobianFunctionMultiplePhaseInstances)
   auto forward_rate = [k_forward](const micm::Conditions& conditions) { return k_forward; };
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { h2o }, { hp, ohm }, h2o, aqueous_phase };
+  DissolvedReversibleReaction reaction{ { { "SMALL_DROP", forward_rate }, { "LARGE_DROP", forward_rate } },
+                                        { { "SMALL_DROP", reverse_rate }, { "LARGE_DROP", reverse_rate } },
+                                        { h2o },
+                                        { hp, ohm },
+                                        h2o,
+                                        aqueous_phase };
 
   // Two phase instances
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("SMALL_DROP");
   phase_prefixes["AQUEOUS"].insert("LARGE_DROP");
 
-  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
-
+  // Both representations share the same rate-constant columns in the parameters matrix
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
-  state_parameter_indices[forward_param] = 0;
-  state_parameter_indices[reverse_param] = 1;
+  state_parameter_indices["SMALL_DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  state_parameter_indices["SMALL_DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  state_parameter_indices["LARGE_DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 2;
+  state_parameter_indices["LARGE_DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 3;
 
   std::unordered_map<std::string, std::size_t> state_variable_indices;
   state_variable_indices["SMALL_DROP.AQUEOUS.H2O"] = 0;
@@ -1361,9 +1439,11 @@ TEST(DissolvedReversibleReaction, JacobianFunctionMultiplePhaseInstances)
   auto jacobian_func = reaction.JacobianFunction<MatrixPolicy, SparseMatrixPolicy>(
       phase_prefixes, state_parameter_indices, state_variable_indices, jacobian);
 
-  MatrixPolicy state_parameters(1, 2);
+  MatrixPolicy state_parameters(1, 4);
   state_parameters[0][0] = k_forward;
   state_parameters[0][1] = k_reverse;
+  state_parameters[0][2] = k_forward;
+  state_parameters[0][3] = k_reverse;
 
   MatrixPolicy state_variables(1, 6);
   // Small drop (indices 0-2)
@@ -1408,16 +1488,18 @@ TEST(DissolvedReversibleReaction, JacobianFunctionSimpleDistinctSpecies)
 
   // foo <-> bar (with solvent baz)
   // With 1 reactant and 1 product, there's no solvent concentration dependence
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { foo },  // 1 reactant
-                                        { bar },                              // 1 product
-                                        baz,                                  // solvent
+  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
+                                        { { "MODE1", reverse_rate } },
+                                        { foo },  // 1 reactant
+                                        { bar },  // 1 product
+                                        baz,      // solvent
                                         aqueous_phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -1504,16 +1586,18 @@ TEST(DissolvedReversibleReaction, JacobianFunctionTwoReactantsWithSolventDepende
 
   // foo + qux <-> bar (with solvent baz)
   // With 2 reactants, forward rate has solvent dependence: k_f / [baz]^1
-  DissolvedReversibleReaction reaction{ forward_rate, reverse_rate, { foo, qux },  // 2 reactants
-                                        { bar },                                   // 1 product
-                                        baz,                                       // solvent
+  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
+                                        { { "MODE1", reverse_rate } },
+                                        { foo, qux },  // 2 reactants
+                                        { bar },       // 1 product
+                                        baz,           // solvent
                                         aqueous_phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -1594,8 +1678,8 @@ TEST(DissolvedReversibleReaction, JacobianFDForwardOnly)
 
   double k_forward = 1.0e-14;
   double k_reverse = 0.0;
-  auto reaction = DissolvedReversibleReaction{ [k_forward](const micm::Conditions&) { return k_forward; },
-                                               [k_reverse](const micm::Conditions&) { return k_reverse; },
+  auto reaction = DissolvedReversibleReaction{ { { "MODE1", [k_forward](const micm::Conditions&) { return k_forward; } } },
+                                               { { "MODE1", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
                                                { h2o },
                                                { hp, ohm },
                                                h2o,
@@ -1605,8 +1689,8 @@ TEST(DissolvedReversibleReaction, JacobianFDForwardOnly)
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["MODE1.AQUEOUS.H2O"] = 0;
@@ -1633,8 +1717,8 @@ TEST(DissolvedReversibleReaction, JacobianFDReverseOnly)
 
   double k_forward = 0.0;
   double k_reverse = 1.0e11;
-  auto reaction = DissolvedReversibleReaction{ [k_forward](const micm::Conditions&) { return k_forward; },
-                                               [k_reverse](const micm::Conditions&) { return k_reverse; },
+  auto reaction = DissolvedReversibleReaction{ { { "MODE1", [k_forward](const micm::Conditions&) { return k_forward; } } },
+                                               { { "MODE1", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
                                                { h2o },
                                                { hp, ohm },
                                                h2o,
@@ -1644,8 +1728,8 @@ TEST(DissolvedReversibleReaction, JacobianFDReverseOnly)
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["MODE1.AQUEOUS.H2O"] = 0;
@@ -1672,8 +1756,8 @@ TEST(DissolvedReversibleReaction, JacobianFDBidirectional)
 
   double k_forward = 1.0e-14;
   double k_reverse = 1.0e11;
-  auto reaction = DissolvedReversibleReaction{ [k_forward](const micm::Conditions&) { return k_forward; },
-                                               [k_reverse](const micm::Conditions&) { return k_reverse; },
+  auto reaction = DissolvedReversibleReaction{ { { "MODE1", [k_forward](const micm::Conditions&) { return k_forward; } } },
+                                               { { "MODE1", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
                                                { h2o },
                                                { hp, ohm },
                                                h2o,
@@ -1683,8 +1767,8 @@ TEST(DissolvedReversibleReaction, JacobianFDBidirectional)
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["MODE1.AQUEOUS.H2O"] = 0;
@@ -1711,8 +1795,8 @@ TEST(DissolvedReversibleReaction, JacobianFDMultiCell)
 
   double k_forward = 1.0e-14;
   double k_reverse = 1.0e11;
-  auto reaction = DissolvedReversibleReaction{ [k_forward](const micm::Conditions&) { return k_forward; },
-                                               [k_reverse](const micm::Conditions&) { return k_reverse; },
+  auto reaction = DissolvedReversibleReaction{ { { "MODE1", [k_forward](const micm::Conditions&) { return k_forward; } } },
+                                               { { "MODE1", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
                                                { h2o },
                                                { hp, ohm },
                                                h2o,
@@ -1722,8 +1806,8 @@ TEST(DissolvedReversibleReaction, JacobianFDMultiCell)
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["MODE1.AQUEOUS.H2O"] = 0;
@@ -1763,8 +1847,8 @@ TEST(DissolvedReversibleReaction, JacobianFDMultipleReactantsProducts)
 
   double k_forward = 0.05;
   double k_reverse = 0.02;
-  auto reaction = DissolvedReversibleReaction{ [k_forward](const micm::Conditions&) { return k_forward; },
-                                               [k_reverse](const micm::Conditions&) { return k_reverse; },
+  auto reaction = DissolvedReversibleReaction{ { { "DROP", [k_forward](const micm::Conditions&) { return k_forward; } } },
+                                               { { "DROP", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
                                                { a, b },
                                                { c, d },
                                                h2o,
@@ -1774,8 +1858,8 @@ TEST(DissolvedReversibleReaction, JacobianFDMultipleReactantsProducts)
   phase_prefixes["AQUEOUS"].insert("DROP");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi["DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi["DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["DROP.AQUEOUS.H2O"] = 0;
@@ -1806,8 +1890,8 @@ TEST(DissolvedReversibleReaction, JacobianFDMultipleInstances)
 
   double k_forward = 1.0e-14;
   double k_reverse = 1.0e11;
-  auto reaction = DissolvedReversibleReaction{ [k_forward](const micm::Conditions&) { return k_forward; },
-                                               [k_reverse](const micm::Conditions&) { return k_reverse; },
+  auto reaction = DissolvedReversibleReaction{ { { "LARGE", [k_forward](const micm::Conditions&) { return k_forward; } }, { "SMALL", [k_forward](const micm::Conditions&) { return k_forward; } } },
+                                               { { "LARGE", [k_reverse](const micm::Conditions&) { return k_reverse; } }, { "SMALL", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
                                                { h2o },
                                                { hp, ohm },
                                                h2o,
@@ -1818,8 +1902,10 @@ TEST(DissolvedReversibleReaction, JacobianFDMultipleInstances)
   phase_prefixes["AQUEOUS"].insert("SMALL");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi["LARGE." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi["LARGE." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi["SMALL." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 2;
+  spi["SMALL." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 3;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["LARGE.AQUEOUS.H2O"] = 0;
@@ -1829,9 +1915,11 @@ TEST(DissolvedReversibleReaction, JacobianFDMultipleInstances)
   svi["SMALL.AQUEOUS.H+"] = 4;
   svi["SMALL.AQUEOUS.OH-"] = 5;
 
-  MatrixPolicy params(1, 2, 0.0);
+  MatrixPolicy params(1, 4, 0.0);
   params[0][0] = k_forward;
   params[0][1] = k_reverse;
+  params[0][2] = k_forward;
+  params[0][3] = k_reverse;
   MatrixPolicy vars(1, 6, 0.0);
   vars[0][0] = 55.0;
   vars[0][1] = 1.0e-7;
@@ -1853,8 +1941,8 @@ TEST(DissolvedReversibleReaction, JacobianFDSolventIsReactant)
 
   double k_forward = 1.0e-14;
   double k_reverse = 1.0e11;
-  auto reaction = DissolvedReversibleReaction{ [k_forward](const micm::Conditions&) { return k_forward; },
-                                               [k_reverse](const micm::Conditions&) { return k_reverse; },
+  auto reaction = DissolvedReversibleReaction{ { { "BULK", [k_forward](const micm::Conditions&) { return k_forward; } } },
+                                               { { "BULK", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
                                                { h2o },
                                                { hp, ohm },
                                                h2o,
@@ -1864,8 +1952,8 @@ TEST(DissolvedReversibleReaction, JacobianFDSolventIsReactant)
   phase_prefixes["AQUEOUS"].insert("BULK");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi["BULK." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi["BULK." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["BULK.AQUEOUS.H2O"] = 0;
@@ -1899,8 +1987,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionZeroReactant)
 
   double k_forward = 1.0e-14;
   double k_reverse = 1.0e11;
-  auto reaction = DissolvedReversibleReaction{ [k_forward](const micm::Conditions&) { return k_forward; },
-                                               [k_reverse](const micm::Conditions&) { return k_reverse; },
+  auto reaction = DissolvedReversibleReaction{ { { "MODE1", [k_forward](const micm::Conditions&) { return k_forward; } } },
+                                               { { "MODE1", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
                                                { h2o },
                                                { hp, ohm },
                                                h2o,
@@ -1910,8 +1998,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionZeroReactant)
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["MODE1.AQUEOUS.H2O"] = 0;
@@ -1950,8 +2038,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionZeroProduct)
 
   double k_forward = 0.1;
   double k_reverse = 0.2;
-  auto reaction = DissolvedReversibleReaction{ [k_forward](const micm::Conditions&) { return k_forward; },
-                                               [k_reverse](const micm::Conditions&) { return k_reverse; },
+  auto reaction = DissolvedReversibleReaction{ { { "MODE1", [k_forward](const micm::Conditions&) { return k_forward; } } },
+                                               { { "MODE1", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
                                                { a },
                                                { b },
                                                solvent,
@@ -1961,8 +2049,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionZeroProduct)
   phase_prefixes["AQ"].insert("MODE1");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi[phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi[phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi["MODE1." + phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi["MODE1." + phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["MODE1.AQ.SOLVENT"] = 0;
@@ -2002,8 +2090,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionAtEquilibrium)
 
   double k_forward = 0.1;
   double k_reverse = 0.3;
-  auto reaction = DissolvedReversibleReaction{ [k_forward](const micm::Conditions&) { return k_forward; },
-                                               [k_reverse](const micm::Conditions&) { return k_reverse; },
+  auto reaction = DissolvedReversibleReaction{ { { "MODE1", [k_forward](const micm::Conditions&) { return k_forward; } } },
+                                               { { "MODE1", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
                                                { a },
                                                { b },
                                                solvent,
@@ -2013,8 +2101,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionAtEquilibrium)
   phase_prefixes["AQ"].insert("MODE1");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi[phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi[phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi["MODE1." + phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi["MODE1." + phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["MODE1.AQ.SOLVENT"] = 0;
@@ -2056,8 +2144,8 @@ TEST(DissolvedReversibleReaction, JacobianFDZeroSolvent)
 
   double k_forward = 0.1;
   double k_reverse = 0.05;
-  auto reaction = DissolvedReversibleReaction{ [k_forward](const micm::Conditions&) { return k_forward; },
-                                               [k_reverse](const micm::Conditions&) { return k_reverse; },
+  auto reaction = DissolvedReversibleReaction{ { { "MODE1", [k_forward](const micm::Conditions&) { return k_forward; } } },
+                                               { { "MODE1", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
                                                { a },
                                                { b },
                                                solvent,
@@ -2067,8 +2155,8 @@ TEST(DissolvedReversibleReaction, JacobianFDZeroSolvent)
   phase_prefixes["AQ"].insert("MODE1");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi[phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi[phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi["MODE1." + phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi["MODE1." + phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["MODE1.AQ.SOLVENT"] = 0;


### PR DESCRIPTION


`DissolvedReaction` specifies rate constant per-representation, but the `cam_cloud_chemistry.config` currently has no way to express them.

This PR adds support for specifying a rate constant for each representation in the configuration. The configuration is copied from MUSICA. The MUSICA configuration will be updated in a later change.

No tests are included in this PR because a parser for this configuration has not yet been implemented.

```JSON
    {
      "__comment": "R1b: SO2OOH- + H+ -> SO4-- (irreversible)",
      "__note": "k = c_H2O_M * 2.4e6 = 1.333e8; Ea/R = 4430 K",
      "type": "DISSOLVED_REACTION"

      # Current
      "rate constant": {
        "A": 1.333e8,
        "C": 4430.0
      }

      # This PR
      "rate constants": {
        "CLOUD": { "A": 1.333e8, "C": 4430.0 }
      }
    },
```
Additionally, `DissolvedReversibleReaction` needs to support per-representation rate constant because it absorbs droplet-specific state (water molarity). Currently rate constant is shared by all representations. 

Below, ` "__note"` describes the rate as k = c_H2O_M * <molar value>, which is scaled by droplet water molarity. The rate constant can differ per representation for dissolved reversible reaction.

```JSON
    {
      "__comment": "R1a: HSO3- + H2O2_aq <-> SO2OOH- + H2O (reversible, Keq=1725)",
      "__note": "k_fwd = c_H2O_M * 7.45e7/13 = 3.184e8; Keq=1725 (Lind & Kok 1986 / revised MIAM)",   <-- here
      "type": "DISSOLVED_REVERSIBLE_REACTION",
      "condensed phase": "AQUEOUS",
      "solvent": "H2O",
      "reactants": [
       ...
      ],
      "products": [
       ...
      ],
      "forward rate constants": {
        "CLOUD": { "A": 3.184e8, "C": 4430.0 }   <-- here
      },
      "equilibrium constant": {      <-- this is shared, because it depends on the temperature only. 
        "A": 1725.0
      }
    },
```

- Adds cam cloud chemistry configuration supporting per-representation rata constant for both dissolved reaction and dissolved reversible reaction
- Updates implementation and test to allow dissolved reversible reaction to support per-representation rata constant
