### PR TITLE
Improve the precision of solvent concentration and incorporate feedback into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,15 @@ of **mol m⁻³ of air**. This includes the solvent (e.g. cloud liquid water).
 
 ### Dissolved-phase rate expression
 
-For a dissolved reaction with *n*_r reactants, MIAM computes the rate as:
+MIAM computes the rate of a dissolved reaction as:
 
 > *r* = *k* / [S]^(*n*_r − 1) × ∏[R_i]
+
+where:
+- *n*_r is the **number of reactants** in the reaction
+- *n*_p is the **number of products** in the reaction (used in the
+  equilibrium-constant conversion below)
+- [S] is the solvent concentration and [R_i] are the reactant concentrations
 
 The solvent-normalization factor [S]^(*n*_r − 1) absorbs the concentration
 dimensions, so *k* is always in units of s⁻¹ regardless of reaction order.

--- a/README.md
+++ b/README.md
@@ -72,15 +72,15 @@ molar (mol L⁻¹) units. To convert to MIAM's *k* and *K*_eq:
 >
 > *K*_eq,MIAM = *K*_lit / *c*_H₂O^(*n*_p − *n*_r)
 
-where *c*_H₂O = 55.556 mol L⁻¹ is the molar concentration of pure liquid
-water (a **fixed** unit-conversion constant, not the cloud water state
-variable), and *K*_lit includes all species — including water — in molar
-concentration units.
+where *c*_H₂O = 55.51 mol L⁻¹ is the molar concentration of pure liquid
+water (1000 g L⁻¹ ÷ 18.015 g mol⁻¹ — a **fixed** unit-conversion constant,
+not the cloud water state variable), and *K*_lit includes all species —
+including water — in molar concentration units.
 
 Examples:
 - Unimolecular (*n*_r = 1): *k*_MIAM = *k*_lit
-- Bimolecular (*n*_r = 2): *k*_MIAM = *k*_lit × 55.556
-- Dissociation A → B + C (*n*_r = 1, *n*_p = 2): *K*_eq = *K*_lit / 55.556
+- Bimolecular (*n*_r = 2): *k*_MIAM = *k*_lit × 55.51
+- Dissociation A → B + C (*n*_r = 1, *n*_p = 2): *K*_eq = *K*_lit / 55.51
 
 # Getting Started
 

--- a/include/miam/processes/constants/equilibrium_constant.hpp
+++ b/include/miam/processes/constants/equilibrium_constant.hpp
@@ -15,7 +15,8 @@ namespace miam
   /// @details The pre-exponential factor A_ is the equilibrium constant at the
   ///          reference temperature T0_ in MIAM's solvent-normalized units.
   ///          To convert from a literature value K_lit in molar units:
-  ///          A_ = K_lit / c_H2O^(n_p - n_r), where c_H2O = 55.556 mol/L.
+  ///          A_ = K_lit / c_H2O^(n_p - n_r), where c_H2O = 55.51 mol/L
+  ///          (1000 g/L ÷ 18.015 g/mol).
   ///          After this conversion, A_ is always dimensionless.
   struct EquilibriumConstantParameters
   {

--- a/include/miam/processes/dissolved_reaction.hpp
+++ b/include/miam/processes/dissolved_reaction.hpp
@@ -47,7 +47,7 @@ namespace miam
   ///          so \f$ k \f$ always has units of s⁻¹. To convert from a literature
   ///          rate constant \f$ k_{lit} \f$ in molar units:
   ///          \f$ k = k_{lit} \times c_{H_2O}^{n_r - 1} \f$
-  ///          where \f$ c_{H_2O} = 55.556 \f$ mol/L.
+  ///          where \f$ c_{H_2O} = 55.51 \f$ mol/L (1000 g/L ÷ 18.015 g/mol).
   ///
   ///          Partial derivatives used in the Jacobian:
   ///          \f[

--- a/include/miam/processes/dissolved_reversible_reaction.hpp
+++ b/include/miam/processes/dissolved_reversible_reaction.hpp
@@ -40,7 +40,7 @@ namespace miam
   ///          solvent-normalization conversion from literature molar units:
   ///          \f$ k_f = k_{f,lit} \times c_{H_2O}^{n_r - 1} \f$,
   ///          \f$ k_r = k_{r,lit} \times c_{H_2O}^{n_p - 1} \f$
-  ///          where \f$ c_{H_2O} = 55.556 \f$ mol/L.
+  ///          where \f$ c_{H_2O} = 55.51 \f$ mol/L (1000 g/L ÷ 18.015 g/mol).
   ///          \f$ K_{eq} \f$ is dimensionless:
   ///          \f$ K_{eq} = K_{lit} / c_{H_2O}^{n_p - n_r} \f$.
   ///

--- a/test/integration/test_aqueous_carbonic_acid.cpp
+++ b/test/integration/test_aqueous_carbonic_acid.cpp
@@ -28,7 +28,7 @@
 // UNIT CONVENTIONS (mol m-3 air, same as test_cam_cloud_chemistry.cpp):
 //   C_H2O = 0.017 mol m-3 air  (cloud LWC ~0.3 g m-3)
 //   f_v   = C_H2O * Mw/rho     (volume fraction of liquid water ~3.06e-7)
-//   K_miam = K_lit[M] / c_H2O^(n_p - n_r),  c_H2O = 55.556 mol/L
+//   K_miam = K_lit[M] / c_H2O^(n_p - n_r),  c_H2O = 55.51 mol/L
 //   K_miam_water = Kw_lit / c_H2O^2  (H2O appears as explicit reactant AND solvent)
 
 #include <miam/miam.hpp>
@@ -59,7 +59,7 @@ namespace
 
   // -- Cloud liquid water content ----------------------------------------------
   constexpr double C_H2O = 0.017;     // mol m-3 air (LWC ~0.3 g m-3)
-  constexpr double c_H2O_M = 55.556;  // mol/L (pure-water molar conc.)
+  constexpr double c_H2O_M = 55.51;  // mol/L (pure-water molar conc., 1000 g/L / 18.015 g/mol)
 
   // -- Henry's Law constant (CO2) -----------------------------------------------
   // K_H = 3.4e-2 M/atm = 3.4e-2 * 1000/101325 mol m-3_liq Pa-1

--- a/test/integration/test_cam_cloud_chemistry.cpp
+++ b/test/integration/test_cam_cloud_chemistry.cpp
@@ -42,7 +42,7 @@ namespace
   constexpr double M_ATM_TO_MOL_M3_PA = 1000.0 / 101325.0;
 
   // Pure water molar concentration (unit conversion constant, NOT the state variable)
-  constexpr double c_H2O_M = 55.556;  // mol/L (molar conc. of pure liquid water)
+  constexpr double c_H2O_M = 55.51;  // mol/L (molar conc. of pure liquid water, 1000 g/L / 18.015 g/mol)
 
   // Realistic cloud liquid water content
   constexpr double C_H2O = 0.017;                                         // mol/m³ air (cloud LWC ~ 0.3 g m⁻³)

--- a/test/integration/test_solvent_robustness.cpp
+++ b/test/integration/test_solvent_robustness.cpp
@@ -37,7 +37,7 @@ using DenseMatrix = micm::Matrix<double>;
 namespace
 {
   constexpr double M_ATM_TO_MOL_M3_PA = 1000.0 / 101325.0;
-  constexpr double c_H2O_M = 55.556;
+  constexpr double c_H2O_M = 55.51;  // mol/L (1000 g/L / 18.015 g/mol)
   constexpr double water_molecular_weight = 0.018;
   constexpr double water_density = 1000.0;
   constexpr double T0 = 298.15;


### PR DESCRIPTION
This PR:
- Improves the precision of water molar concentration .
```yaml
c_H2O_M = 55.556 -> 55.51 (1000/18.015)
```
- Adds the definition for `n_r` and `n_p`, representing  number of reactants and number of products, respectively in README.