### PR TITLE
Fix application of processes to multiple phase instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ transfer:
 
 ```c++
 #include <miam/miam.hpp>
-#include <miam/processes/constants/henrys_law_constant.hpp>
+#include <miam/processes/constants/henry_law_constant.hpp>
 #include <micm/CPU.hpp>
 
 #include <iomanip>
@@ -152,30 +152,37 @@ int main()
   Phase gas_phase{ "GAS", { { co2 } } };
   Phase aqueous_phase{ "AQUEOUS", { { co2 }, { h2o } } };
 
-  // Cloud droplets with a single-moment log-normal distribution
-  auto cloud = SingleMomentMode{
-    "CLOUD",
+  // Small cloud droplets with a single-moment log-normal distribution
+  auto cloud_small = SingleMomentMode{
+    "CLOUD_SMALL",
+    { aqueous_phase },
+    5.0e-7,  // geometric mean radius [m]
+    1.4      // geometric standard deviation
+  };
+  auto cloud_large = SingleMomentMode{
+    "CLOUD_LARGE",
     { aqueous_phase },
     5.0e-6,  // geometric mean radius [m]
     1.2      // geometric standard deviation
   };
 
   // Henry's Law phase transfer: CO2(g) <-> CO2(aq)
+  // (gets applied to both aqueous phase instances (in small and large droplets)
   auto co2_transfer = HenryLawPhaseTransferBuilder()
     .SetCondensedPhase(aqueous_phase)
     .SetGasSpecies(co2)
     .SetCondensedSpecies(co2)
     .SetSolvent(h2o)
-    .SetHenrysLawConstant(HenrysLawConstant(
+    .SetHenryLawConstant(HenryLawConstant(
         { .HLC_ref_ = 3.4e-2 }))       // mol m-3 Pa-1 at 298 K
     .SetDiffusionCoefficient(1.5e-5)    // m2 s-1
-    .SetAccommodationCoefficient(5.0e-6)
+    .SetAccommodationCoefficient(5.0e-6) // Set artificially low to see transfer over 10 time steps
     .Build();
 
   // Create model and add processes
   auto cloud_model = Model{
     .name_ = "CLOUD",
-    .representations_ = { cloud }
+    .representations_ = { cloud_small, cloud_large }
   };
   cloud_model.AddProcesses({ co2_transfer });
 
@@ -195,16 +202,17 @@ int main()
   state.conditions_[0].pressure_ = 101325.0;    // Pa
   state.conditions_[0].CalculateIdealAirDensity();
 
-  state[co2] = 1.0e-3;                                  // mol m-3 air
-  state[cloud.Species(aqueous_phase, h2o)] = 0.017;      // mol m-3 air (cloud LWC ~ 0.3 g m-3)
-  cloud.SetDefaultParameters(state);
+  state[co2] = 1.0e-3;                                     // mol m-3 air
+  state[cloud_small.Species(aqueous_phase, h2o)] = 0.017;  // mol m-3 air (cloud LWC ~ 0.3 g m-3)
+  state[cloud_large.Species(aqueous_phase, h2o)] = 0.023;  // mol m-3 air (cloud LWC ~ 0.4 g m-3)
+  cloud_small.SetDefaultParameters(state);
+  cloud_large.SetDefaultParameters(state);
 
-  // Integrate
   state.PrintHeader();
   state.PrintState(0);
   for (int i = 1; i <= 10; ++i)
   {
-    solver.CalculateRateConstants(state);
+    solver.UpdateStateParameters(state);
     auto result = solver.Solve(0.1, state);  // 100 ms steps
     state.PrintState(i * 100);
   }
@@ -223,10 +231,18 @@ Henry's Law equilibrium. With realistic cloud liquid water content
 (~0.017 mol m⁻³), only a trace fraction of the gas dissolves:
 
 ```
-  time,                CO2,  CLOUD.AQUEOUS.CO2,  CLOUD.AQUEOUS.H2O
-     0,           1.00e-03,           0.00e+00,           1.70e-02
-   ...
-  1000,           ~1.00e-03,          ~1.0e-08,           1.70e-02
+  time,  CLOUD_LARGE.AQUEOUS.CO2,  CLOUD_LARGE.AQUEOUS.H2O,                      CO2,  CLOUD_SMALL.AQUEOUS.CO2,  CLOUD_SMALL.AQUEOUS.H2O
+     0,                 0.00e+00,                 2.30e-02,                 1.00e-03,                 0.00e+00,                 1.70e-02
+   100,                 1.01e-08,                 2.30e-02,                 1.00e-03,                 2.54e-08,                 1.70e-02
+   200,                 1.73e-08,                 2.30e-02,                 1.00e-03,                 2.58e-08,                 1.70e-02
+   300,                 2.24e-08,                 2.30e-02,                 1.00e-03,                 2.58e-08,                 1.70e-02
+   400,                 2.60e-08,                 2.30e-02,                 1.00e-03,                 2.58e-08,                 1.70e-02
+   500,                 2.86e-08,                 2.30e-02,                 1.00e-03,                 2.58e-08,                 1.70e-02
+   600,                 3.04e-08,                 2.30e-02,                 1.00e-03,                 2.58e-08,                 1.70e-02
+   700,                 3.17e-08,                 2.30e-02,                 1.00e-03,                 2.58e-08,                 1.70e-02
+   800,                 3.26e-08,                 2.30e-02,                 1.00e-03,                 2.58e-08,                 1.70e-02
+   900,                 3.33e-08,                 2.30e-02,                 1.00e-03,                 2.58e-08,                 1.70e-02
+  1000,                 3.38e-08,                 2.30e-02,                 1.00e-03,                 2.58e-08,                 1.70e-02
 ```
 
 See the [MIAM documentation](https://miam.readthedocs.io/) for the full API

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ int main()
   };
 
   // Henry's Law phase transfer: CO2(g) <-> CO2(aq)
-  // (gets applied to both aqueous phase instances (in small and large droplets)
+  // (gets applied to both aqueous phase instances (in small and large droplets))
   auto co2_transfer = HenryLawPhaseTransferBuilder()
     .SetCondensedPhase(aqueous_phase)
     .SetGasSpecies(co2)

--- a/include/miam/model/model.hpp
+++ b/include/miam/model/model.hpp
@@ -607,7 +607,9 @@ namespace miam
             throw MiamException(
                 MIAM_ERROR_CATEGORY_INTERNAL,
                 MIAM_INTERNAL_DUPLICATE_STATE_PREFIX,
-                "Internal Error: PhaseStatePrefixes: Non-unique state variable prefixes detected for phase " + phase_name);
+                "PhaseStatePrefixes: Non-unique state variable prefixes detected for phase " + phase_name +
+                ". Check your aerosol representation and phase names for duplicates."
+              );
           }
         }
       }

--- a/include/miam/processes/dissolved_reaction.hpp
+++ b/include/miam/processes/dissolved_reaction.hpp
@@ -773,7 +773,7 @@ namespace miam
       {
         throw MiamException(
             MIAM_ERROR_CATEGORY_INTERNAL,
-            MIAM_INTERNAL_MISSING_PHASE_PREFIX,
+            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
             "Internal Error: GetParameterIndex: Rate constant parameter " + k_param +
             " not found in state_parameter_indices");
       }

--- a/include/miam/processes/dissolved_reaction.hpp
+++ b/include/miam/processes/dissolved_reaction.hpp
@@ -61,8 +61,8 @@ namespace miam
   class DissolvedReaction
   {
    public:
-    std::map<std::string, std::function<double(const micm::Conditions& conditions)>>
-        rate_constants_;                    ///< Rate constant functions keyed by representation prefix
+    std::function<double(const micm::Conditions& conditions)>
+        rate_constant_;                     ///< Rate constant function
     std::vector<micm::Species> reactants_;  ///< Reactant species
     std::vector<micm::Species> products_;   ///< Product species
     micm::Species solvent_;                 ///< Solvent species
@@ -79,14 +79,14 @@ namespace miam
 
     /// @brief Constructor
     DissolvedReaction(
-        std::map<std::string, std::function<double(const micm::Conditions& conditions)>> rate_constants,
+        std::function<double(const micm::Conditions& conditions)> rate_constant,
         const std::vector<micm::Species>& reactants,
         const std::vector<micm::Species>& products,
         micm::Species solvent,
         micm::Phase phase,
         double solvent_floor = 1.0e-20,
         double min_halflife = 0.0)
-        : rate_constants_(std::move(rate_constants)),
+        : rate_constant_(rate_constant),
           reactants_(reactants),
           products_(products),
           solvent_(solvent),
@@ -101,7 +101,7 @@ namespace miam
     /// @return A new DissolvedReaction with the same properties but a unique UUID
     DissolvedReaction CopyWithNewUuid() const
     {
-      return DissolvedReaction(rate_constants_, reactants_, products_, solvent_, phase_, solvent_floor_, min_halflife_);
+      return DissolvedReaction(rate_constant_, reactants_, products_, solvent_, phase_, solvent_floor_, min_halflife_);
     }
 
     /// @brief Returns a set of unique parameter names for this process
@@ -110,12 +110,11 @@ namespace miam
     /// @return Set of unique parameter names for this process
     std::set<std::string> ProcessParameterNames(const std::map<std::string, std::set<std::string>>& phase_prefixes) const
     {
-      std::set<std::string> names;
-      auto it = phase_prefixes.find(phase_.name_);
-      if (it != phase_prefixes.end())
-        for (const auto& prefix : it->second)
-          names.insert(prefix + "." + phase_.name_ + "." + uuid_ + ".k");
-      return names;
+        std::set<std::string> parameter_names;
+        // The conditions are shared by the whole system, so we just need one value for the rate
+        // constant. We can use the phase name and uuid to create a unique parameter name.
+        parameter_names.insert(phase_.name_ + "." + uuid_ + ".k");
+        return parameter_names;
     }
 
     /// @brief Returns participating species' unique state names
@@ -237,39 +236,33 @@ namespace miam
         const auto& state_parameter_indices  // acts like std::unordered_map<std::string, std::size_t>
     ) const
     {
-      std::vector<std::pair<std::size_t, std::function<double(const micm::Conditions&)>>> k_slots;
-      auto phase_it = phase_prefixes.find(phase_.name_);
-      for (const auto& prefix : phase_it->second)
-      {
-        std::string k_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k";
+        std::string k_param = phase_.name_ + "." + uuid_ + ".k";
         if (state_parameter_indices.find(k_param) == state_parameter_indices.end())
+        {
           throw MiamException(
               MIAM_ERROR_CATEGORY_INTERNAL,
               MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-              "Internal Error: UpdateStateParametersFunction: Parameter " + k_param + " not found");
-        auto rate_it = rate_constants_.find(prefix);
-        if (rate_it == rate_constants_.end())
-          throw MiamException(
-              MIAM_ERROR_CATEGORY_CONFIGURATION,
-              MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
-              "DissolvedReaction: No rate constant configured for representation prefix '" + prefix + "'");
-        k_slots.push_back({ state_parameter_indices.at(k_param), rate_it->second });
-      }
+              "Internal Error: UpdateStateParametersFunction: Rate constant parameter " + k_param +
+              " not found in state_parameter_indices");
+        }
+        std::size_t k_index = state_parameter_indices.at(k_param);
 
-      DenseMatrixPolicy state_parameters{ 1, state_parameter_indices.size(), 0.0 };
-      std::vector<micm::Conditions> conditions_vector;
+        // Set up dummy arguments to build the function
+        DenseMatrixPolicy state_parameters{ 1, state_parameter_indices.size(), 0.0 };
+        std::vector<micm::Conditions> conditions_vector;
 
-      return DenseMatrixPolicy::Function(
-          [k_slots](auto&& conditions, auto&& params)
-          {
-            for (const auto& [k_idx, rate_fn] : k_slots)
+        // return a function that updates the rate constant parameter based on the current conditions
+        return DenseMatrixPolicy::Function(
+            [this, k_index](auto&& conditions, auto&& params)
+            {
               params.ForEachRow(
-                  [&](const micm::Conditions& cond, double& param) { param = rate_fn(cond); },
+                  [&](const micm::Conditions& condition, double& parameter)
+                  { parameter = rate_constant_(condition); },
                   conditions,
-                  params.GetColumnView(k_idx));
-          },
-          conditions_vector,
-          state_parameters);
+                  params.GetColumnView(k_index));
+            },
+            conditions_vector,
+            state_parameters);
     }
 
     /// @brief Returns a function that calculates the forcing terms for this process
@@ -300,18 +293,18 @@ namespace miam
     ) const
     {
       StateVariableIndices variable_indices = GetStateVariableIndices(phase_prefixes, state_variable_indices);
-      std::vector<std::size_t> k_indices = GetParameterIndices(phase_prefixes, state_parameter_indices);
+      std::size_t k_index = GetParameterIndex(state_parameter_indices);
       DenseMatrixPolicy dummy_state_parameters{ 1, state_parameter_indices.size(), 0.0 };
       DenseMatrixPolicy dummy_state_variables{ 1, state_variable_indices.size(), 0.0 };
 
       if (min_halflife_ > 0.0)
       {
         return ForcingFunctionCapped<DenseMatrixPolicy>(
-            variable_indices, k_indices, dummy_state_parameters, dummy_state_variables);
+            variable_indices, k_index, dummy_state_parameters, dummy_state_variables);
       }
 
       return DenseMatrixPolicy::Function(
-          [this, variable_indices, k_indices](auto&& state_parameters, auto&& state_variables, auto&& forcing_terms)
+          [this, variable_indices, k_index](auto&& state_parameters, auto&& state_variables, auto&& forcing_terms)
           {
             auto rate = forcing_terms.GetRowVariable();
             const double eps = solvent_floor_;
@@ -324,7 +317,7 @@ namespace miam
               state_parameters.ForEachRow(
                   [&](const double& rate_constant, const double& solvent, double& rate)
                   { rate = rate_constant * solvent / std::pow(solvent + eps, n_r); },
-                  state_parameters.GetConstColumnView(k_indices[i_phase]),
+                  state_parameters.GetConstColumnView(k_index),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   rate);
               for (std::size_t r = 0; r < reactants_.size(); ++r)
@@ -380,18 +373,18 @@ namespace miam
     {
       StateVariableIndices variable_indices = GetStateVariableIndices(phase_prefixes, state_variable_indices);
       JacobianIndices jacobian_indices = GetJacobianIndices(variable_indices, jacobian);
-      std::vector<std::size_t> k_indices = GetParameterIndices(phase_prefixes, state_parameter_indices);
+      std::size_t k_index = GetParameterIndex(state_parameter_indices);
       DenseMatrixPolicy dummy_state_parameters{ 1, state_parameter_indices.size(), 0.0 };
       DenseMatrixPolicy dummy_state_variables{ 1, state_variable_indices.size(), 0.0 };
 
       if (min_halflife_ > 0.0)
       {
         return JacobianFunctionCapped<DenseMatrixPolicy, SparseMatrixPolicy>(
-            variable_indices, jacobian_indices, k_indices, dummy_state_parameters, dummy_state_variables, jacobian);
+            variable_indices, jacobian_indices, k_index, dummy_state_parameters, dummy_state_variables, jacobian);
       }
 
       return SparseMatrixPolicy::Function(
-          [this, variable_indices, jacobian_indices, k_indices](
+          [this, variable_indices, jacobian_indices, k_index](
               auto&& state_parameters, auto&& state_variables, auto&& jacobian_values)
           {
             auto d_rate_d_ind = jacobian_values.GetBlockVariable();
@@ -409,7 +402,7 @@ namespace miam
                 jacobian_values.ForEachBlock(
                     [&](const double& rate_constant, const double& solvent, double& partial)
                     { partial = rate_constant * solvent / std::pow(solvent + eps, n_r); },
-                    state_parameters.GetConstColumnView(k_indices[i_phase]),
+                    state_parameters.GetConstColumnView(k_index),
                     state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                     d_rate_d_ind);
                 // add contributions to the partial from the other reactants
@@ -446,7 +439,7 @@ namespace miam
                     partial =
                         rate_constant * (eps + (1.0 - static_cast<int>(n_r)) * solvent) / std::pow(solvent + eps, n_r + 1);
                   },
-                  state_parameters.GetConstColumnView(k_indices[i_phase]),
+                  state_parameters.GetConstColumnView(k_index),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   d_rate_d_ind);
               // add contributions to the partial from the reactants
@@ -511,12 +504,12 @@ namespace miam
     template<typename DenseMatrixPolicy>
     auto ForcingFunctionCapped(
         const StateVariableIndices& variable_indices,
-        const std::vector<std::size_t>& k_indices,
+        const std::size_t k_index,
         DenseMatrixPolicy& dummy_state_parameters,
         DenseMatrixPolicy& dummy_state_variables) const
     {
       return DenseMatrixPolicy::Function(
-          [this, variable_indices, k_indices](auto&& state_parameters, auto&& state_variables, auto&& forcing_terms)
+          [this, variable_indices, k_index](auto&& state_parameters, auto&& state_variables, auto&& forcing_terms)
           {
             auto rate = forcing_terms.GetRowVariable();
             auto accum = forcing_terms.GetRowVariable();
@@ -530,7 +523,7 @@ namespace miam
               state_parameters.ForEachRow(
                   [&](const double& rate_constant, const double& solvent, double& rate)
                   { rate = rate_constant * solvent / std::pow(solvent + eps, n_r); },
-                  state_parameters.GetConstColumnView(k_indices[i_phase]),
+                  state_parameters.GetConstColumnView(k_index),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   rate);
               for (std::size_t r = 0; r < n_r; ++r)
@@ -601,13 +594,13 @@ namespace miam
     auto JacobianFunctionCapped(
         const StateVariableIndices& variable_indices,
         const JacobianIndices& jacobian_indices,
-        const std::vector<std::size_t>& k_indices,
+        const std::size_t k_index,
         DenseMatrixPolicy& dummy_state_parameters,
         DenseMatrixPolicy& dummy_state_variables,
         const SparseMatrixPolicy& jacobian) const
     {
       return SparseMatrixPolicy::Function(
-          [this, variable_indices, jacobian_indices, k_indices](
+          [this, variable_indices, jacobian_indices, k_index](
               auto&& state_parameters, auto&& state_variables, auto&& jacobian_values)
           {
             auto d_rate_d_ind = jacobian_values.GetBlockVariable();
@@ -626,7 +619,7 @@ namespace miam
               jacobian_values.ForEachBlock(
                   [&](const double& rate_constant, const double& solvent, double& rr)
                   { rr = rate_constant * solvent / std::pow(solvent + eps, n_r); },
-                  state_parameters.GetConstColumnView(k_indices[i_phase]),
+                  state_parameters.GetConstColumnView(k_index),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   raw_rate);
               for (std::size_t r = 0; r < n_r; ++r)
@@ -681,7 +674,7 @@ namespace miam
                 jacobian_values.ForEachBlock(
                     [&](const double& rate_constant, const double& solvent, double& partial)
                     { partial = rate_constant * solvent / std::pow(solvent + eps, n_r); },
-                    state_parameters.GetConstColumnView(k_indices[i_phase]),
+                    state_parameters.GetConstColumnView(k_index),
                     state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                     d_rate_d_ind);
                 for (std::size_t r = 0; r < n_r; ++r)
@@ -732,7 +725,7 @@ namespace miam
                     partial =
                         rate_constant * (eps + (1.0 - static_cast<int>(n_r)) * solvent) / std::pow(solvent + eps, n_r + 1);
                   },
-                  state_parameters.GetConstColumnView(k_indices[i_phase]),
+                  state_parameters.GetConstColumnView(k_index),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   d_rate_d_ind);
               for (std::size_t r = 0; r < n_r; ++r)
@@ -770,30 +763,21 @@ namespace miam
           jacobian);
     }
 
-    /// @brief Returns one parameter index per phase instance, in the same prefix-sorted order as GetStateVariableIndices
-    std::vector<std::size_t> GetParameterIndices(
-        const std::map<std::string, std::set<std::string>>& phase_prefixes,
+    /// @brief Helper function to return parameter index for the rate constant
+    std::size_t GetParameterIndex(
         const auto& state_parameter_indices  // acts like std::unordered_map<std::string, std::size_t>
     ) const
     {
-      std::vector<std::size_t> indices;
-      auto phase_it = phase_prefixes.find(phase_.name_);
-      if (phase_it == phase_prefixes.end())
+      std::string k_param = phase_.name_ + "." + uuid_ + ".k";
+      if (state_parameter_indices.find(k_param) == state_parameter_indices.end())
+      {
         throw MiamException(
             MIAM_ERROR_CATEGORY_INTERNAL,
             MIAM_INTERNAL_MISSING_PHASE_PREFIX,
-            "Internal Error: GetParameterIndices: Phase " + phase_.name_ + " not found in phase_prefixes");
-      for (const auto& prefix : phase_it->second)
-      {
-        std::string k_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k";
-        if (state_parameter_indices.find(k_param) == state_parameter_indices.end())
-          throw MiamException(
-              MIAM_ERROR_CATEGORY_INTERNAL,
-              MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-              "Internal Error: GetParameterIndices: Parameter " + k_param + " not found in state_parameter_indices");
-        indices.push_back(state_parameter_indices.at(k_param));
+            "Internal Error: GetParameterIndex: Rate constant parameter " + k_param +
+            " not found in state_parameter_indices");
       }
-      return indices;
+      return state_parameter_indices.at(k_param);
     }
 
     /// @brief Helper function to return variable indices for all species involved in the reaction

--- a/include/miam/processes/dissolved_reaction_builder.hpp
+++ b/include/miam/processes/dissolved_reaction_builder.hpp
@@ -72,19 +72,18 @@ namespace miam
       return *this;
     }
 
-    /// @brief Adds a rate constant for a specific representation prefix
-    DissolvedReactionBuilder& AddRateConstant(
-        const std::string& prefix,
+    /// @brief Sets the rate constant function
+    DissolvedReactionBuilder& SetRateConstant(
         std::function<double(const micm::Conditions&)> rate_constant)
     {
-      rate_constants_[prefix] = std::move(rate_constant);
+      rate_constant_ = std::move(rate_constant);
       return *this;
     }
 
-    /// @brief Adds an Arrhenius rate constant for a specific representation prefix
-    DissolvedReactionBuilder& AddRateConstant(const std::string& prefix, const micm::ArrheniusRateConstantParameters& params)
+    /// @brief Sets the rate constant from Arrhenius rate constant parameters
+    DissolvedReactionBuilder& SetRateConstant(const micm::ArrheniusRateConstantParameters& params)
     {
-      rate_constants_[prefix] = [params](const micm::Conditions& conditions)
+      rate_constant_ = [params](const micm::Conditions& conditions)
       { return micm::CalculateArrhenius(params, conditions.temperature_, conditions.pressure_); };
       return *this;
     }
@@ -92,12 +91,12 @@ namespace miam
     /// @brief Builds and returns the DissolvedReaction object
     DissolvedReaction Build() const
     {
-      if (rate_constants_.empty())
+      if (!rate_constant_)
       {
         throw MiamException(
             MIAM_ERROR_CATEGORY_CONFIGURATION,
             MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
-            "DissolvedReactionBuilder requires at least one rate constant via AddRateConstant.");
+            "DissolvedReactionBuilder requires a rate constant via SetRateConstant.");
       }
       if (reactants_.empty())
       {
@@ -127,7 +126,7 @@ namespace miam
             MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
             "DissolvedReactionBuilder requires the solvent to be set.");
       }
-      return DissolvedReaction(rate_constants_, reactants_, products_, solvent_, phase_, solvent_floor_, min_halflife_);
+      return DissolvedReaction(rate_constant_, reactants_, products_, solvent_, phase_, solvent_floor_, min_halflife_);
     }
 
    private:
@@ -137,8 +136,8 @@ namespace miam
     std::vector<micm::Species> products_;   ///< Product species
     micm::Species solvent_;                 ///< Solvent species
     bool solvent_is_set_ = false;           ///< Flag to track if the solvent has been set
-    std::map<std::string, std::function<double(const micm::Conditions& conditions)>>
-        rate_constants_;               ///< Per-prefix rate constants
+    std::function<double(const micm::Conditions& conditions)>
+        rate_constant_;                     ///< Rate constant
     double solvent_floor_{ 1.0e-20 };  ///< Floor δ [mol m⁻³] added to [S] in ([S]+δ)^n denominator; see SetSolventFloor()
     double min_halflife_{ 0.0 };       ///< Minimum half-life for rate capping [s]
   };

--- a/include/miam/processes/dissolved_reversible_reaction.hpp
+++ b/include/miam/processes/dissolved_reversible_reaction.hpp
@@ -248,7 +248,7 @@ namespace miam
         {
           throw MiamException(
             MIAM_ERROR_CATEGORY_INTERNAL,
-            MIAM_INTERNAL_MISSING_PHASE_PREFIX,
+            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
               "Internal Error: UpdateStateParametersFunction: Forward rate constant parameter " + forward_param +
               " not found in state_parameter_indices");
         }
@@ -256,7 +256,7 @@ namespace miam
         {
           throw MiamException(
             MIAM_ERROR_CATEGORY_INTERNAL,
-            MIAM_INTERNAL_MISSING_PHASE_PREFIX,
+            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
               "Internal Error: UpdateStateParametersFunction: Reverse rate constant parameter " + reverse_param +
               " not found in state_parameter_indices");
         }
@@ -606,7 +606,7 @@ namespace miam
       {
         throw MiamException(
             MIAM_ERROR_CATEGORY_INTERNAL,
-            MIAM_INTERNAL_MISSING_PHASE_PREFIX,
+            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
             "Internal Error: GetParameterIndices: Forward rate constant parameter " + forward_param +
             " not found in state_parameter_indices");
       }
@@ -614,7 +614,7 @@ namespace miam
       {
         throw MiamException(
             MIAM_ERROR_CATEGORY_INTERNAL,
-            MIAM_INTERNAL_MISSING_PHASE_PREFIX,
+            MIAM_INTERNAL_MISSING_STATE_PARAMETER,
             "Internal Error: GetParameterIndices: Reverse rate constant parameter " + reverse_param +
             " not found in state_parameter_indices");
       }

--- a/include/miam/processes/dissolved_reversible_reaction.hpp
+++ b/include/miam/processes/dissolved_reversible_reaction.hpp
@@ -51,10 +51,10 @@ namespace miam
   class DissolvedReversibleReaction
   {
    public:
-    std::map<std::string, std::function<double(const micm::Conditions& conditions)>>
-        forward_rate_constants_;  ///< Forward rate constant functions keyed by representation prefix
-    std::map<std::string, std::function<double(const micm::Conditions& conditions)>>
-        reverse_rate_constants_;            ///< Reverse rate constant functions keyed by representation prefix
+    std::function<double(const micm::Conditions& conditions)>
+        forward_rate_constant_;             ///< Forward rate constant function
+    std::function<double(const micm::Conditions& conditions)>
+        reverse_rate_constant_;             ///< Reverse rate constant function
     std::vector<micm::Species> reactants_;  ///< Reactant species
     std::vector<micm::Species> products_;   ///< Product species
     micm::Species solvent_;                 ///< Solvent species
@@ -68,15 +68,15 @@ namespace miam
 
     /// @brief Constructor
     DissolvedReversibleReaction(
-        std::map<std::string, std::function<double(const micm::Conditions& conditions)>> forward_rate_constants,
-        std::map<std::string, std::function<double(const micm::Conditions& conditions)>> reverse_rate_constants,
+        std::function<double(const micm::Conditions& conditions)> forward_rate_constant,
+        std::function<double(const micm::Conditions& conditions)> reverse_rate_constant,
         const std::vector<micm::Species>& reactants,
         const std::vector<micm::Species>& products,
         micm::Species solvent,
         micm::Phase phase,
         double solvent_floor = 1.0e-20)
-        : forward_rate_constants_(std::move(forward_rate_constants)),
-          reverse_rate_constants_(std::move(reverse_rate_constants)),
+        : forward_rate_constant_(forward_rate_constant),
+          reverse_rate_constant_(reverse_rate_constant),
           reactants_(reactants),
           products_(products),
           solvent_(solvent),
@@ -91,7 +91,7 @@ namespace miam
     DissolvedReversibleReaction CopyWithNewUuid() const
     {
       return DissolvedReversibleReaction(
-          forward_rate_constants_, reverse_rate_constants_, reactants_, products_, solvent_, phase_, solvent_floor_);
+          forward_rate_constant_, reverse_rate_constant_, reactants_, products_, solvent_, phase_, solvent_floor_);
     }
 
     /// @brief Returns a set of unique parameter names for this process
@@ -100,18 +100,12 @@ namespace miam
     /// @return Set of unique parameter names for this process
     std::set<std::string> ProcessParameterNames(const std::map<std::string, std::set<std::string>>& phase_prefixes) const
     {
-      // One forward and one reverse rate constant parameter per representation instance of this phase.
-      std::set<std::string> parameter_names;
-      auto it = phase_prefixes.find(phase_.name_);
-      if (it != phase_prefixes.end())
-      {
-        for (const auto& prefix : it->second)
-        {
-          parameter_names.insert(prefix + "." + phase_.name_ + "." + uuid_ + ".k_forward");
-          parameter_names.insert(prefix + "." + phase_.name_ + "." + uuid_ + ".k_reverse");
-        }
-      }
-      return parameter_names;
+        // The conditions are shared by the whole system, so we just need one value each for the forward and reverse rate
+        // constants. We can use the phase name and uuid to create unique parameter names.
+        std::set<std::string> parameter_names;
+        parameter_names.insert(phase_.name_ + "." + uuid_ + ".k_forward");
+        parameter_names.insert(phase_.name_ + "." + uuid_ + ".k_reverse");
+        return parameter_names;
     }
 
     /// @brief Returns participating species' unique state names
@@ -247,68 +241,49 @@ namespace miam
         const auto& state_parameter_indices  // acts like std::unordered_map<std::string, std::size_t>
     ) const
     {
-      // Build per-prefix parameter slots paired with the matching rate constant functions
-      std::vector<std::pair<std::size_t, std::function<double(const micm::Conditions&)>>> forward_slots;
-      std::vector<std::pair<std::size_t, std::function<double(const micm::Conditions&)>>> reverse_slots;
-      auto phase_it = phase_prefixes.find(phase_.name_);
-      if (phase_it == phase_prefixes.end())
-        throw MiamException(
+        // throw an error if the expected parameters don't exist
+        std::string forward_param = phase_.name_ + "." + uuid_ + ".k_forward";
+        std::string reverse_param = phase_.name_ + "." + uuid_ + ".k_reverse";
+        if (state_parameter_indices.find(forward_param) == state_parameter_indices.end())
+        {
+          throw MiamException(
             MIAM_ERROR_CATEGORY_INTERNAL,
             MIAM_INTERNAL_MISSING_PHASE_PREFIX,
-            "Internal Error: UpdateStateParametersFunction: Phase " + phase_.name_ + " not found in phase_prefixes");
-      for (const auto& prefix : phase_it->second)
-      {
-        std::string forward_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k_forward";
-        std::string reverse_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k_reverse";
-        if (state_parameter_indices.find(forward_param) == state_parameter_indices.end())
-          throw MiamException(
-              MIAM_ERROR_CATEGORY_INTERNAL,
-              MIAM_INTERNAL_MISSING_STATE_PARAMETER,
               "Internal Error: UpdateStateParametersFunction: Forward rate constant parameter " + forward_param +
-                  " not found in state_parameter_indices");
+              " not found in state_parameter_indices");
+        }
         if (state_parameter_indices.find(reverse_param) == state_parameter_indices.end())
+        {
           throw MiamException(
-              MIAM_ERROR_CATEGORY_INTERNAL,
-              MIAM_INTERNAL_MISSING_STATE_PARAMETER,
+            MIAM_ERROR_CATEGORY_INTERNAL,
+            MIAM_INTERNAL_MISSING_PHASE_PREFIX,
               "Internal Error: UpdateStateParametersFunction: Reverse rate constant parameter " + reverse_param +
-                  " not found in state_parameter_indices");
-        auto forward_it = forward_rate_constants_.find(prefix);
-        if (forward_it == forward_rate_constants_.end())
-          throw MiamException(
-              MIAM_ERROR_CATEGORY_CONFIGURATION,
-              MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
-              "DissolvedReversibleReaction: No forward rate constant configured for representation prefix '" + prefix + "'");
-        auto reverse_it = reverse_rate_constants_.find(prefix);
-        if (reverse_it == reverse_rate_constants_.end())
-          throw MiamException(
-              MIAM_ERROR_CATEGORY_CONFIGURATION,
-              MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
-              "DissolvedReversibleReaction: No reverse rate constant configured for representation prefix '" + prefix + "'");
-        forward_slots.push_back({ state_parameter_indices.at(forward_param), forward_it->second });
-        reverse_slots.push_back({ state_parameter_indices.at(reverse_param), reverse_it->second });
-      }
+              " not found in state_parameter_indices");
+        }
+        std::size_t forward_index = state_parameter_indices.at(forward_param);
+        std::size_t reverse_index = state_parameter_indices.at(reverse_param);
 
-      // Set up dummy arguments to build the function
-      DenseMatrixPolicy state_parameters{ 1, state_parameter_indices.size(), 0.0 };
-      std::vector<micm::Conditions> conditions_vector;
+        // Set up dummy arguments to build the function
+        DenseMatrixPolicy state_parameters{ 1, state_parameter_indices.size(), 0.0 };
+        std::vector<micm::Conditions> conditions_vector;
 
-      // return a function that updates the forward and reverse rate constant parameters based on the current conditions
-      return DenseMatrixPolicy::Function(
-          [forward_slots, reverse_slots](auto&& conditions, auto&& params)
-          {
-            for (const auto& [param_index, rate_fn] : forward_slots)
+        // return a function that updates the forward and reverse rate constant parameters based on the current conditions
+        return DenseMatrixPolicy::Function(
+            [this, forward_index, reverse_index](auto&& conditions, auto&& params)
+            {
               params.ForEachRow(
-                  [&](const micm::Conditions& condition, double& parameter) { parameter = rate_fn(condition); },
+                  [&](const micm::Conditions& condition, double& parameter)
+                  { parameter = forward_rate_constant_(condition); },
                   conditions,
-                  params.GetColumnView(param_index));
-            for (const auto& [param_index, rate_fn] : reverse_slots)
+                  params.GetColumnView(forward_index));
               params.ForEachRow(
-                  [&](const micm::Conditions& condition, double& parameter) { parameter = rate_fn(condition); },
+                  [&](const micm::Conditions& condition, double& parameter)
+                  { parameter = reverse_rate_constant_(condition); },
                   conditions,
-                  params.GetColumnView(param_index));
-          },
-          conditions_vector,
-          state_parameters);
+                  params.GetColumnView(reverse_index));
+            },
+            conditions_vector,
+            state_parameters);
     }
 
     /// @brief Returns a function that calculates the forcing terms for this process
@@ -339,11 +314,11 @@ namespace miam
     ) const
     {
       StateVariableIndices variable_indices = GetStateVariableIndices(phase_prefixes, state_variable_indices);
-      auto [forward_indices, reverse_indices] = GetParameterIndices(phase_prefixes, state_parameter_indices);
+      auto [forward_index, reverse_index] = GetParameterIndices(state_parameter_indices);
       DenseMatrixPolicy dummy_state_parameters{ 1, state_parameter_indices.size(), 0.0 };
       DenseMatrixPolicy dummy_state_variables{ 1, state_variable_indices.size(), 0.0 };
       return DenseMatrixPolicy::Function(
-          [this, variable_indices, forward_indices, reverse_indices](
+          [this, variable_indices, forward_index, reverse_index](
               auto&& state_parameters, auto&& state_variables, auto&& forcing_terms)
           {
             auto forward_rate = forcing_terms.GetRowVariable();
@@ -366,8 +341,8 @@ namespace miam
                     forward_rate = forward_rate_constant * solvent / std::pow(solvent + eps, n_r);
                     reverse_rate = reverse_rate_constant * solvent / std::pow(solvent + eps, n_p);
                   },
-                  state_parameters.GetConstColumnView(forward_indices[i_phase]),
-                  state_parameters.GetConstColumnView(reverse_indices[i_phase]),
+                  state_parameters.GetConstColumnView(forward_index),
+                  state_parameters.GetConstColumnView(reverse_index),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   forward_rate,
                   reverse_rate);
@@ -441,11 +416,11 @@ namespace miam
     {
       StateVariableIndices variable_indices = GetStateVariableIndices(phase_prefixes, state_variable_indices);
       JacobianIndices jacobian_indices = GetJacobianIndices(variable_indices, jacobian);
-      auto [forward_indices, reverse_indices] = GetParameterIndices(phase_prefixes, state_parameter_indices);
+      auto [forward_index, reverse_index] = GetParameterIndices(state_parameter_indices);
       DenseMatrixPolicy dummy_state_parameters{ 1, state_parameter_indices.size(), 0.0 };
       DenseMatrixPolicy dummy_state_variables{ 1, state_variable_indices.size(), 0.0 };
       return SparseMatrixPolicy::Function(
-          [this, variable_indices, jacobian_indices, forward_indices, reverse_indices](
+          [this, variable_indices, jacobian_indices, forward_index, reverse_index](
               auto&& state_parameters, auto&& state_variables, auto&& jacobian_values)
           {
             auto d_forward_rate_d_ind = jacobian_values.GetBlockVariable();
@@ -465,7 +440,7 @@ namespace miam
                 jacobian_values.ForEachBlock(
                     [&](const double& forward_rate_constant, const double& solvent, double& partial)
                     { partial = forward_rate_constant * solvent / std::pow(solvent + eps, n_r); },
-                    state_parameters.GetConstColumnView(forward_indices[i_phase]),
+                    state_parameters.GetConstColumnView(forward_index),
                     state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                     d_forward_rate_d_ind);
                 // add contributions to the partial from the other reactants
@@ -502,7 +477,7 @@ namespace miam
                 jacobian_values.ForEachBlock(
                     [&](const double& reverse_rate_constant, const double& solvent, double& partial)
                     { partial = reverse_rate_constant * solvent / std::pow(solvent + eps, n_p); },
-                    state_parameters.GetConstColumnView(reverse_indices[i_phase]),
+                    state_parameters.GetConstColumnView(reverse_index),
                     state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                     d_reverse_rate_d_ind);
                 // add contributions to the partial from the other products
@@ -546,8 +521,8 @@ namespace miam
                     reverse_partial = reverse_rate_constant * (eps + (1.0 - static_cast<int>(n_p)) * solvent) /
                                       std::pow(solvent + eps, n_p + 1);
                   },
-                  state_parameters.GetConstColumnView(forward_indices[i_phase]),
-                  state_parameters.GetConstColumnView(reverse_indices[i_phase]),
+                  state_parameters.GetConstColumnView(forward_index),
+                  state_parameters.GetConstColumnView(reverse_index),
                   state_variables.GetConstColumnView(variable_indices.solvent_indices_[i_phase]),
                   d_forward_rate_d_ind,
                   d_reverse_rate_d_ind);
@@ -621,44 +596,29 @@ namespace miam
     };
 
     /// @brief Helper function to return parameter indices for the forward and reverse rate constants
-    /// @param phase_prefixes Map of phase names to sets of state variable prefixes (prefix does not include phase or
-    /// species names)
-    /// @param state_parameter_indices Map of state parameter names to their corresponding indices in the state parameter
-    /// vector
-    /// @return Pair of (forward, reverse) parameter index vectors, one entry per phase instance in prefix-sorted order
-    std::pair<std::vector<std::size_t>, std::vector<std::size_t>> GetParameterIndices(
-        const std::map<std::string, std::set<std::string>>& phase_prefixes,
+    std::pair<std::size_t, std::size_t> GetParameterIndices(
         const auto& state_parameter_indices  // acts like std::unordered_map<std::string, std::size_t>
     ) const
     {
-      std::vector<std::size_t> forward_indices;
-      std::vector<std::size_t> reverse_indices;
-      auto phase_it = phase_prefixes.find(phase_.name_);
-      if (phase_it == phase_prefixes.end())
+      std::string forward_param = phase_.name_ + "." + uuid_ + ".k_forward";
+      std::string reverse_param = phase_.name_ + "." + uuid_ + ".k_reverse";
+      if (state_parameter_indices.find(forward_param) == state_parameter_indices.end())
+      {
         throw MiamException(
             MIAM_ERROR_CATEGORY_INTERNAL,
             MIAM_INTERNAL_MISSING_PHASE_PREFIX,
-            "Internal Error: GetParameterIndices: Phase " + phase_.name_ + " not found in phase_prefixes");
-      for (const auto& prefix : phase_it->second)
-      {
-        std::string forward_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k_forward";
-        std::string reverse_param = prefix + "." + phase_.name_ + "." + uuid_ + ".k_reverse";
-        if (state_parameter_indices.find(forward_param) == state_parameter_indices.end())
-          throw MiamException(
-              MIAM_ERROR_CATEGORY_INTERNAL,
-              MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-              "Internal Error: GetParameterIndices: Forward rate constant parameter " + forward_param +
-                  " not found in state_parameter_indices");
-        if (state_parameter_indices.find(reverse_param) == state_parameter_indices.end())
-          throw MiamException(
-              MIAM_ERROR_CATEGORY_INTERNAL,
-              MIAM_INTERNAL_MISSING_STATE_PARAMETER,
-              "Internal Error: GetParameterIndices: Reverse rate constant parameter " + reverse_param +
-                  " not found in state_parameter_indices");
-        forward_indices.push_back(state_parameter_indices.at(forward_param));
-        reverse_indices.push_back(state_parameter_indices.at(reverse_param));
+            "Internal Error: GetParameterIndices: Forward rate constant parameter " + forward_param +
+            " not found in state_parameter_indices");
       }
-      return { forward_indices, reverse_indices };
+      if (state_parameter_indices.find(reverse_param) == state_parameter_indices.end())
+      {
+        throw MiamException(
+            MIAM_ERROR_CATEGORY_INTERNAL,
+            MIAM_INTERNAL_MISSING_PHASE_PREFIX,
+            "Internal Error: GetParameterIndices: Reverse rate constant parameter " + reverse_param +
+            " not found in state_parameter_indices");
+      }
+      return { state_parameter_indices.at(forward_param), state_parameter_indices.at(reverse_param) };
     }
 
     /// @brief Helper function to return variable indices for all species involved in the reaction

--- a/include/miam/processes/dissolved_reversible_reaction_builder.hpp
+++ b/include/miam/processes/dissolved_reversible_reaction_builder.hpp
@@ -21,12 +21,7 @@ namespace miam
   /// @brief A dissolved reversible reaction builder
   /// @details Builder class for constructing DissolvedReversibleReaction objects.
   ///
-  ///          Forward and reverse rate constants are configured per representation prefix (via
-  ///          AddForwardRateConstant / AddReverseRateConstant), because the kinetics may differ
-  ///          between aerosol representations. The equilibrium constant, by contrast, is an intrinsic
-  ///          thermodynamic property and is set once for the whole reaction (via SetEquilibriumConstant).
-  ///
-  ///          For each representation prefix, exactly two of {forward rate constant, reverse rate
+  ///          Exactly two of {forward rate constant, reverse rate
   ///          constant, equilibrium constant} must be determinable; the third is derived.
   class DissolvedReversibleReactionBuilder
   {
@@ -71,43 +66,41 @@ namespace miam
       return *this;
     }
 
-    /// @brief Adds a forward rate constant for a specific representation prefix
-    DissolvedReversibleReactionBuilder& AddForwardRateConstant(const std::string& prefix, const auto& forward_rate_constant)
+    /// @brief Sets the forward rate constant function
+    DissolvedReversibleReactionBuilder& SetForwardRateConstant(const auto& forward_rate_constant)
     {
-      forward_rate_constants_[prefix] = [forward_rate_constant](const micm::Conditions& conditions)
+      forward_rate_constant_ = [forward_rate_constant](const micm::Conditions& conditions)
       { return forward_rate_constant.Calculate(conditions); };
       return *this;
     }
 
-    /// @brief Adds a forward rate constant from Arrhenius parameters for a specific representation prefix
-    DissolvedReversibleReactionBuilder& AddForwardRateConstant(
-        const std::string& prefix,
-        const micm::ArrheniusRateConstantParameters& params)
+    /// @brief Sets the forward rate constant from Arrhenius parameters
+    DissolvedReversibleReactionBuilder& SetForwardRateConstant(
+      const micm::ArrheniusRateConstantParameters& params)
     {
-      forward_rate_constants_[prefix] = [params](const micm::Conditions& conditions)
+      forward_rate_constant_ = [params](const micm::Conditions& conditions)
       { return micm::CalculateArrhenius(params, conditions.temperature_, conditions.pressure_); };
       return *this;
     }
 
-    /// @brief Adds a reverse rate constant for a specific representation prefix
-    DissolvedReversibleReactionBuilder& AddReverseRateConstant(const std::string& prefix, const auto& reverse_rate_constant)
+    /// @brief Sets the reverse rate constant function
+    DissolvedReversibleReactionBuilder& SetReverseRateConstant(const auto& reverse_rate_constant)
     {
-      reverse_rate_constants_[prefix] = [reverse_rate_constant](const micm::Conditions& conditions)
+      reverse_rate_constant_ = [reverse_rate_constant](const micm::Conditions& conditions)
       { return reverse_rate_constant.Calculate(conditions); };
       return *this;
     }
 
-    /// @brief Adds a reverse rate constant from Arrhenius parameters for a specific representation prefix
-    DissolvedReversibleReactionBuilder& AddReverseRateConstant(
-        const std::string& prefix,
+    /// @brief Sets the reverse rate constant from Arrhenius parameters
+    DissolvedReversibleReactionBuilder& SetReverseRateConstant(
         const micm::ArrheniusRateConstantParameters& params)
     {
-      reverse_rate_constants_[prefix] = [params](const micm::Conditions& conditions)
+      reverse_rate_constant_ = [params](const micm::Conditions& conditions)
       { return micm::CalculateArrhenius(params, conditions.temperature_, conditions.pressure_); };
       return *this;
     }
 
-    /// @brief Sets the (shared) equilibrium constant function
+    /// @brief Sets the equilibrium constant function
     DissolvedReversibleReactionBuilder& SetEquilibriumConstant(const auto& equilibrium_constant)
     {
       equilibrium_constant_ = [equilibrium_constant](const micm::Conditions& conditions)
@@ -147,59 +140,51 @@ namespace miam
             "DissolvedReversibleReactionBuilder requires the solvent to be set.");
       }
 
-      // Collect the set of representation prefixes that have at least one rate constant configured
-      std::set<std::string> prefixes;
-      for (const auto& [prefix, fn] : forward_rate_constants_)
-        prefixes.insert(prefix);
-      for (const auto& [prefix, fn] : reverse_rate_constants_)
-        prefixes.insert(prefix);
-      if (prefixes.empty())
+      int num_set = 0;
+      if (forward_rate_constant_)
+        ++num_set;
+      if (reverse_rate_constant_)
+        ++num_set;
+      if (equilibrium_constant_)
+        ++num_set;
+      if (num_set != 2)
       {
         throw MiamException(
             MIAM_ERROR_CATEGORY_CONFIGURATION,
             MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
-            "DissolvedReversibleReactionBuilder requires at least one forward or reverse rate constant via "
-            "AddForwardRateConstant/AddReverseRateConstant.");
+            "DissolvedReversibleReactionBuilder: exactly two of forward rate constant, reverse rate constant, or equilibrium constant must be set.");
       }
-
-      // For each prefix, require exactly two of {forward, reverse, equilibrium} and derive the third.
-      // The equilibrium constant is shared across all prefixes.
-      std::map<std::string, std::function<double(const micm::Conditions&)>> forward = forward_rate_constants_;
-      std::map<std::string, std::function<double(const micm::Conditions&)>> reverse = reverse_rate_constants_;
-      const bool has_eq = static_cast<bool>(equilibrium_constant_);
-      for (const auto& prefix : prefixes)
-      {
-        const bool has_fwd = forward.count(prefix) > 0;
-        const bool has_rev = reverse.count(prefix) > 0;
-        const int num_set = (has_fwd ? 1 : 0) + (has_rev ? 1 : 0) + (has_eq ? 1 : 0);
-        if (num_set != 2)
+            
+        // If equilibrium constant is set, compute the missing rate constant
+        if (equilibrium_constant_)
         {
-          throw MiamException(
-              MIAM_ERROR_CATEGORY_CONFIGURATION,
-              MIAM_CONFIGURATION_MISSING_REQUIRED_PARAMETER,
-              "DissolvedReversibleReactionBuilder: for representation '" + prefix +
-                  "', exactly two of forward rate constant, reverse rate constant, or equilibrium constant must be set.");
-        }
-        if (has_eq)
-        {
-          if (!has_fwd)
+          if (!forward_rate_constant_)
           {
+            // Capture the necessary functions by value to avoid dangling references
             auto eq_const = equilibrium_constant_;
-            auto rev_const = reverse.at(prefix);
-            forward[prefix] = [eq_const, rev_const](const micm::Conditions& conditions)
-            { return eq_const(conditions) * rev_const(conditions); };
+            auto rev_const = reverse_rate_constant_;
+            forward_rate_constant_ = [eq_const, rev_const](const micm::Conditions& conditions)
+            {
+              double K_eq = eq_const(conditions);
+              double k_r = rev_const(conditions);
+              return K_eq * k_r;
+            };
           }
-          else if (!has_rev)
+          else if (!reverse_rate_constant_)
           {
+            // Capture the necessary functions by value to avoid dangling references
             auto eq_const = equilibrium_constant_;
-            auto fwd_const = forward.at(prefix);
-            reverse[prefix] = [eq_const, fwd_const](const micm::Conditions& conditions)
-            { return fwd_const(conditions) / eq_const(conditions); };
+            auto fwd_const = forward_rate_constant_;
+            reverse_rate_constant_ = [eq_const, fwd_const](const micm::Conditions& conditions)
+            {
+              double K_eq = eq_const(conditions);
+              double k_f = fwd_const(conditions);
+              return k_f / K_eq;
+            };
           }
         }
-      }
-
-      return DissolvedReversibleReaction(forward, reverse, reactants_, products_, solvent_, phase_, solvent_floor_);
+        return DissolvedReversibleReaction(
+            forward_rate_constant_, reverse_rate_constant_, reactants_, products_, solvent_, phase_, solvent_floor_);
     }
 
    private:
@@ -209,12 +194,12 @@ namespace miam
     std::vector<micm::Species> products_;   ///< Product species
     micm::Species solvent_;                 ///< Solvent species
     bool solvent_is_set_ = false;           ///< Flag to track if the solvent has been set
-    std::map<std::string, std::function<double(const micm::Conditions& conditions)>>
-        forward_rate_constants_;  ///< Per-prefix forward rate constant functions
-    std::map<std::string, std::function<double(const micm::Conditions& conditions)>>
-        reverse_rate_constants_;  ///< Per-prefix reverse rate constant functions
-    std::function<double(const micm::Conditions& conditions)>
-        equilibrium_constant_;         ///< Shared equilibrium constant function (representation-independent)
-    double solvent_floor_{ 1.0e-20 };  ///< Floor δ [mol m⁻³] added to [S] in ([S]+δ)^n denominator; see SetSolventFloor()
+    mutable std::function<double(const micm::Conditions& conditions)>
+        forward_rate_constant_;             ///< Forward rate constant function
+    mutable std::function<double(const micm::Conditions& conditions)>
+        reverse_rate_constant_;            ///< Reverse rate constant function
+    mutable std::function<double(const micm::Conditions& conditions)>
+        equilibrium_constant_;              ///< Equilibrium constant function
+    double solvent_floor_{ 1.0e-20 };       ///< Floor δ [mol m⁻³] added to [S] in ([S]+δ)^n denominator; see SetSolventFloor()
   };
 }  // namespace miam

--- a/include/miam/processes/dissolved_reversible_reaction_builder.hpp
+++ b/include/miam/processes/dissolved_reversible_reaction_builder.hpp
@@ -156,6 +156,8 @@ namespace miam
       }
             
         // If equilibrium constant is set, compute the missing rate constant
+        auto fwd_rc = forward_rate_constant_;
+        auto rev_rc = reverse_rate_constant_;
         if (equilibrium_constant_)
         {
           if (!forward_rate_constant_)
@@ -163,7 +165,7 @@ namespace miam
             // Capture the necessary functions by value to avoid dangling references
             auto eq_const = equilibrium_constant_;
             auto rev_const = reverse_rate_constant_;
-            forward_rate_constant_ = [eq_const, rev_const](const micm::Conditions& conditions)
+            fwd_rc = [eq_const, rev_const](const micm::Conditions& conditions)
             {
               double K_eq = eq_const(conditions);
               double k_r = rev_const(conditions);
@@ -175,7 +177,7 @@ namespace miam
             // Capture the necessary functions by value to avoid dangling references
             auto eq_const = equilibrium_constant_;
             auto fwd_const = forward_rate_constant_;
-            reverse_rate_constant_ = [eq_const, fwd_const](const micm::Conditions& conditions)
+            rev_rc = [eq_const, fwd_const](const micm::Conditions& conditions)
             {
               double K_eq = eq_const(conditions);
               double k_f = fwd_const(conditions);
@@ -184,7 +186,7 @@ namespace miam
           }
         }
         return DissolvedReversibleReaction(
-            forward_rate_constant_, reverse_rate_constant_, reactants_, products_, solvent_, phase_, solvent_floor_);
+            fwd_rc, rev_rc, reactants_, products_, solvent_, phase_, solvent_floor_);
     }
 
    private:
@@ -194,11 +196,11 @@ namespace miam
     std::vector<micm::Species> products_;   ///< Product species
     micm::Species solvent_;                 ///< Solvent species
     bool solvent_is_set_ = false;           ///< Flag to track if the solvent has been set
-    mutable std::function<double(const micm::Conditions& conditions)>
+    std::function<double(const micm::Conditions& conditions)>
         forward_rate_constant_;             ///< Forward rate constant function
-    mutable std::function<double(const micm::Conditions& conditions)>
+    std::function<double(const micm::Conditions& conditions)>
         reverse_rate_constant_;            ///< Reverse rate constant function
-    mutable std::function<double(const micm::Conditions& conditions)>
+    std::function<double(const micm::Conditions& conditions)>
         equilibrium_constant_;              ///< Equilibrium constant function
     double solvent_floor_{ 1.0e-20 };       ///< Floor δ [mol m⁻³] added to [S] in ([S]+δ)^n denominator; see SetSolventFloor()
   };

--- a/test/integration/test_aqueous_carbonic_acid.cpp
+++ b/test/integration/test_aqueous_carbonic_acid.cpp
@@ -123,8 +123,8 @@ namespace
     auto droplet = SingleMomentMode{ "DROPLET", { aqueous_phase }, 5.0e-6, 1.2 };
 
     // CO2(aq) + H2O <-> H+ + HCO3-  (same rate constants in both tests)
-    auto rxn1 = DissolvedReversibleReaction{ { { "DROPLET", [](const Conditions&) { return k1_f; } } },
-                                             { { "DROPLET", [](const Conditions&) { return k1_r; } } },
+    auto rxn1 = DissolvedReversibleReaction{ { [](const Conditions&) { return k1_f; } },
+                                             { [](const Conditions&) { return k1_r; } },
                                              { CO2_aq },
                                              { Hp, HCO3m },
                                              H2O,
@@ -250,16 +250,16 @@ TEST(AqueousCarbonicAcid, KineticODE)
                       .Build();
 
   // HCO3- <-> H+ + CO3--  (full stiff rate; stable for pure-ODE Rosenbrock)
-  auto rxn2 = DissolvedReversibleReaction{ { { "DROPLET", [](const Conditions&) { return k2_f; } } },
-                                           { { "DROPLET", [](const Conditions&) { return k2_r; } } },
+  auto rxn2 = DissolvedReversibleReaction{ { [](const Conditions&) { return k2_f; } },
+                                           { [](const Conditions&) { return k2_r; } },
                                            { sys.HCO3m },
                                            { sys.Hp, sys.CO3mm },
                                            sys.H2O,
                                            sys.aqueous_phase };
 
   // H2O <-> H+ + OH-  (H2O as reactant AND solvent gives correct Kw_miam)
-  auto rxn_w = DissolvedReversibleReaction{ { { "DROPLET", [](const Conditions&) { return kw_f; } } },
-                                            { { "DROPLET", [](const Conditions&) { return kw_r; } } },
+  auto rxn_w = DissolvedReversibleReaction{ { [](const Conditions&) { return kw_f; } },
+                                            { [](const Conditions&) { return kw_r; } },
                                             { sys.H2O },
                                             { sys.Hp, sys.OHm },
                                             sys.H2O,

--- a/test/integration/test_cam_cloud_chemistry.cpp
+++ b/test/integration/test_cam_cloud_chemistry.cpp
@@ -1287,7 +1287,7 @@ TEST(CamCloudChemistry, Step4_FullSystemWithKinetics)
                    .SetReactants({ hso3m, h2o2_aq })
                    .SetProducts({ so2oohm, h2o })
                    .SetSolvent(h2o)
-                   .AddForwardRateConstant("CLOUD", EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
+                   .SetForwardRateConstant(EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
                    .SetEquilibriumConstant(EquilibriumConstant({ .A_ = 1725.0 }))
                    .Build();
 
@@ -1296,8 +1296,7 @@ TEST(CamCloudChemistry, Step4_FullSystemWithKinetics)
                    .SetReactants({ so2oohm, hp })
                    .SetProducts({ so4mm })
                    .SetSolvent(h2o)
-                   .AddRateConstant(
-                       "CLOUD",
+                   .SetRateConstant(
                        [](const Conditions& c) -> double
                        { return c_H2O_M * 2.4e6 * std::exp(-4430.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                    .Build();
@@ -1308,8 +1307,7 @@ TEST(CamCloudChemistry, Step4_FullSystemWithKinetics)
                   .SetReactants({ hso3m, o3_aq })
                   .SetProducts({ so4mm, hp })
                   .SetSolvent(h2o)
-                  .AddRateConstant(
-                      "CLOUD",
+                  .SetRateConstant(
                       [](const Conditions& c) -> double
                       { return c_H2O_M * 3.75e5 * std::exp(-5530.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                   .Build();
@@ -1320,8 +1318,7 @@ TEST(CamCloudChemistry, Step4_FullSystemWithKinetics)
                   .SetReactants({ so3mm, o3_aq })
                   .SetProducts({ so4mm })
                   .SetSolvent(h2o)
-                  .AddRateConstant(
-                      "CLOUD",
+                  .SetRateConstant(
                       [](const Conditions& c) -> double
                       { return c_H2O_M * 1.59e9 * std::exp(-5280.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                   .Build();
@@ -1615,7 +1612,7 @@ TEST(CamCloudChemistry, Step4b_NaiveInitialConditions)
                    .SetReactants({ hso3m, h2o2_aq })
                    .SetProducts({ so2oohm, h2o })
                    .SetSolvent(h2o)
-                   .AddForwardRateConstant("CLOUD", EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
+                   .SetForwardRateConstant(EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
                    .SetEquilibriumConstant(EquilibriumConstant({ .A_ = 1725.0 }))
                    .Build();
 
@@ -1624,8 +1621,7 @@ TEST(CamCloudChemistry, Step4b_NaiveInitialConditions)
                    .SetReactants({ so2oohm, hp })
                    .SetProducts({ so4mm })
                    .SetSolvent(h2o)
-                   .AddRateConstant(
-                       "CLOUD",
+                   .SetRateConstant(
                        [](const Conditions& c) -> double
                        { return c_H2O_M * 2.4e6 * std::exp(-4430.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                    .Build();
@@ -1635,8 +1631,7 @@ TEST(CamCloudChemistry, Step4b_NaiveInitialConditions)
                   .SetReactants({ hso3m, o3_aq })
                   .SetProducts({ so4mm, hp })
                   .SetSolvent(h2o)
-                  .AddRateConstant(
-                      "CLOUD",
+                  .SetRateConstant(
                       [](const Conditions& c) -> double
                       { return c_H2O_M * 3.75e5 * std::exp(-5530.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                   .Build();
@@ -1646,8 +1641,7 @@ TEST(CamCloudChemistry, Step4b_NaiveInitialConditions)
                   .SetReactants({ so3mm, o3_aq })
                   .SetProducts({ so4mm })
                   .SetSolvent(h2o)
-                  .AddRateConstant(
-                      "CLOUD",
+                  .SetRateConstant(
                       [](const Conditions& c) -> double
                       { return c_H2O_M * 1.59e9 * std::exp(-5280.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                   .Build();
@@ -1888,7 +1882,7 @@ TEST(CamCloudChemistry, Step5_JacobianVerification)
                    .SetReactants({ hso3m, h2o2_aq })
                    .SetProducts({ so2oohm, h2o })
                    .SetSolvent(h2o)
-                   .AddForwardRateConstant("CLOUD", EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
+                   .SetForwardRateConstant(EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
                    .SetEquilibriumConstant(EquilibriumConstant({ .A_ = 1725.0 }))
                    .Build();
 
@@ -1897,8 +1891,7 @@ TEST(CamCloudChemistry, Step5_JacobianVerification)
                    .SetReactants({ so2oohm, hp })
                    .SetProducts({ so4mm })
                    .SetSolvent(h2o)
-                   .AddRateConstant(
-                       "CLOUD",
+                   .SetRateConstant(
                        [](const Conditions& c) -> double
                        { return c_H2O_M * 2.4e6 * std::exp(-4430.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                    .Build();
@@ -1908,8 +1901,7 @@ TEST(CamCloudChemistry, Step5_JacobianVerification)
                   .SetReactants({ hso3m, o3_aq })
                   .SetProducts({ so4mm, hp })
                   .SetSolvent(h2o)
-                  .AddRateConstant(
-                      "CLOUD",
+                  .SetRateConstant(
                       [](const Conditions& c) -> double
                       { return c_H2O_M * 3.75e5 * std::exp(-5530.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                   .Build();
@@ -1919,8 +1911,7 @@ TEST(CamCloudChemistry, Step5_JacobianVerification)
                   .SetReactants({ so3mm, o3_aq })
                   .SetProducts({ so4mm })
                   .SetSolvent(h2o)
-                  .AddRateConstant(
-                      "CLOUD",
+                  .SetRateConstant(
                       [](const Conditions& c) -> double
                       { return c_H2O_M * 1.59e9 * std::exp(-5280.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                   .Build();

--- a/test/integration/test_dissolved_reaction.cpp
+++ b/test/integration/test_dissolved_reaction.cpp
@@ -421,7 +421,7 @@ TEST(DissolvedReactionIntegration, MultiPhaseInstances)
   // Large droplets should decay at the same rate
   double A_final_small = state.variables_[0][i_A_small];
   double A_final_large = state.variables_[0][i_A_large];
-  EXPECT_NEAR(A_final_large / A0_large, A_final_small / A0_small, A0_large * 1.0e-5)
+  EXPECT_NEAR(A_final_large / A0_large, A_final_small / A0_small, 1.0e-5)
     << "Large and small droplet species concetrations should change at the same rate";
 }
 

--- a/test/integration/test_dissolved_reaction.cpp
+++ b/test/integration/test_dissolved_reaction.cpp
@@ -36,7 +36,7 @@ TEST(DissolvedReactionIntegration, SimpleFirstOrderDecay)
                       .SetReactants({ A })
                       .SetProducts({ B })
                       .SetSolvent(C)
-                      .AddRateConstant("DROPLET", rate)
+                      .SetRateConstant(rate)
                       .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
@@ -47,10 +47,10 @@ TEST(DissolvedReactionIntegration, SimpleFirstOrderDecay)
 
   auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(system)
-                    .AddExternalModel(model)
-                    .SetIgnoreUnusedSpecies(true)
-                    .Build();
+                  .SetSystem(system)
+                  .AddExternalModel(model)
+                  .SetIgnoreUnusedSpecies(true)
+                  .Build();
 
   State state = solver.GetState();
 
@@ -131,7 +131,7 @@ TEST(DissolvedReactionIntegration, SolventAsReactant)
                       .SetReactants({ A, C })
                       .SetProducts({ B })
                       .SetSolvent(C)
-                      .AddRateConstant("DROPLET", rate)
+                      .SetRateConstant(rate)
                       .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
@@ -144,10 +144,10 @@ TEST(DissolvedReactionIntegration, SolventAsReactant)
 
   auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(system)
-                    .AddExternalModel(model)
-                    .SetIgnoreUnusedSpecies(true)
-                    .Build();
+                  .SetSystem(system)
+                  .AddExternalModel(model)
+                  .SetIgnoreUnusedSpecies(true)
+                  .Build();
 
   State state = solver.GetState();
 
@@ -227,7 +227,7 @@ TEST(DissolvedReactionIntegration, SolventAsProduct)
                       .SetReactants({ A })
                       .SetProducts({ B, C })
                       .SetSolvent(C)
-                      .AddRateConstant("DROPLET", rate)
+                      .SetRateConstant(rate)
                       .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
@@ -241,10 +241,10 @@ TEST(DissolvedReactionIntegration, SolventAsProduct)
 
   auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(system)
-                    .AddExternalModel(model)
-                    .SetIgnoreUnusedSpecies(true)
-                    .Build();
+                  .SetSystem(system)
+                  .AddExternalModel(model)
+                  .SetIgnoreUnusedSpecies(true)
+                  .Build();
 
   State state = solver.GetState();
 
@@ -302,7 +302,7 @@ TEST(DissolvedReactionIntegration, SolventAsProduct)
 }
 
 // ============================================================================
-// Test 4: Multi-Phase Instances (two droplet populations, different rates)
+// Test 4: Multi-Phase Instances (two droplet populations)
 // ============================================================================
 TEST(DissolvedReactionIntegration, MultiPhaseInstances)
 {
@@ -310,27 +310,34 @@ TEST(DissolvedReactionIntegration, MultiPhaseInstances)
   auto B = Species{ "B" };
   auto C = Species{ "C" };  // solvent
 
-  auto aqueous_phase = Phase{ "AQUEOUS", { { A }, { B }, { C } } };
+  auto aqueous = Phase{ "AQUEOUS", { { A }, { B }, { C } } };
 
-  auto small_droplet = UniformSection{ "DROPLET_SMALL", { aqueous_phase } };
-  auto large_droplet = UniformSection{ "DROPLET_LARGE", { aqueous_phase } };
+  auto small_droplet = UniformSection{
+    "DROPLET_SMALL",
+    { aqueous }
+  };
+  auto large_droplet = UniformSection{
+    "DROPLET_LARGE",
+    { aqueous }
+  };
 
-  double k_small = 0.1;
-  double k_large = 0.2;
 
-  auto rate_small = [k_small](const Conditions& conditions) { return k_small; };
-  auto rate_large = [k_large](const Conditions& conditions) { return k_large; };
-
+  double k = 0.1;
+  
+  auto k_calc = [k](const Conditions& conditions) { return k; };
+  
   auto reaction = DissolvedReactionBuilder{}
-                      .SetPhase(aqueous_phase)
+                      .SetPhase(aqueous)
                       .SetReactants({ A })
                       .SetProducts({ B })
                       .SetSolvent(C)
-                      .AddRateConstant("DROPLET_SMALL", rate_small)
-                      .AddRateConstant("DROPLET_LARGE", rate_large)
+                      .SetRateConstant(k_calc)
                       .Build();
 
-  auto model = Model{ .name_ = "AEROSOL", .representations_ = { small_droplet, large_droplet } };
+  auto model = Model{
+    .name_ = "AEROSOL",
+    .representations_ = { small_droplet, large_droplet }
+  };
   model.AddProcesses({ reaction });
 
   Phase gas_phase{ "GAS", {} };
@@ -340,10 +347,10 @@ TEST(DissolvedReactionIntegration, MultiPhaseInstances)
 
   auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(system)
-                    .AddExternalModel(model)
-                    .SetIgnoreUnusedSpecies(true)
-                    .Build();
+                  .SetSystem(system)
+                  .AddExternalModel(model)
+                  .SetIgnoreUnusedSpecies(true)
+                  .Build();
 
   State state = solver.GetState();
 
@@ -382,7 +389,8 @@ TEST(DissolvedReactionIntegration, MultiPhaseInstances)
       double dt = std::min(0.01, target_time - time);
       solver.UpdateStateParameters(state);
       auto result = solver.Solve(dt, state);
-      ASSERT_EQ(result.state_, SolverState::Converged) << "Solver failed at t = " << time << " s";
+      ASSERT_EQ(result.state_, SolverState::Converged)
+        << "Solver failed at t = " << time << " s";
       time += dt;
     }
 
@@ -391,11 +399,11 @@ TEST(DissolvedReactionIntegration, MultiPhaseInstances)
     double A_num_lg = state.variables_[0][i_A_large];
     double B_num_lg = state.variables_[0][i_B_large];
 
-    double A_ana_sm = A0_small * std::exp(-k_small * time);
-    double B_ana_sm = A0_small * (1.0 - std::exp(-k_small * time));
+    double A_ana_sm = A0_small * std::exp(-k * time);
+    double B_ana_sm = A0_small * (1.0 - std::exp(-k * time));
 
-    double A_ana_lg = A0_large * std::exp(-k_large * time);
-    double B_ana_lg = A0_large * (1.0 - std::exp(-k_large * time));
+    double A_ana_lg = A0_large * std::exp(-k * time);
+    double B_ana_lg = A0_large * (1.0 - std::exp(-k * time));
 
     EXPECT_NEAR(A_num_sm, A_ana_sm, tolerance) << "Small droplet A mismatch at t = " << time << " s";
     EXPECT_NEAR(B_num_sm, B_ana_sm, tolerance) << "Small droplet B mismatch at t = " << time << " s";
@@ -410,10 +418,11 @@ TEST(DissolvedReactionIntegration, MultiPhaseInstances)
     EXPECT_NEAR(state.variables_[0][i_C_large], 1.0e-4, tolerance);
   }
 
-  // Large droplets should decay faster (k_large > k_small)
+  // Large droplets should decay at the same rate
   double A_final_small = state.variables_[0][i_A_small];
   double A_final_large = state.variables_[0][i_A_large];
-  EXPECT_LT(A_final_large / A0_large, A_final_small / A0_small) << "Large droplets should have decayed more";
+  EXPECT_NEAR(A_final_large / A0_large, A_final_small / A0_small, A0_large * 1.0e-5)
+    << "Large and small droplet species concetrations should change at the same rate";
 }
 
 // ============================================================================
@@ -444,7 +453,7 @@ TEST(DissolvedReactionIntegration, SecondOrderTwoReactants)
                       .SetReactants({ A, B })
                       .SetProducts({ C })
                       .SetSolvent(S)
-                      .AddRateConstant("DROPLET", rate)
+                      .SetRateConstant(rate)
                       .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
@@ -458,10 +467,10 @@ TEST(DissolvedReactionIntegration, SecondOrderTwoReactants)
 
   auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(system)
-                    .AddExternalModel(model)
-                    .SetIgnoreUnusedSpecies(true)
-                    .Build();
+                  .SetSystem(system)
+                  .AddExternalModel(model)
+                  .SetIgnoreUnusedSpecies(true)
+                  .Build();
 
   State state = solver.GetState();
 
@@ -555,7 +564,7 @@ TEST(DissolvedReactionIntegration, MinHalflifeZeroReactant)
                       .SetSolvent(S)
                       .SetSolventFloor(1.0e-20)
                       .SetMinHalflife(t_half)
-                      .AddRateConstant("DROPLET", rate)
+                      .SetRateConstant(rate)
                       .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
@@ -565,10 +574,10 @@ TEST(DissolvedReactionIntegration, MinHalflifeZeroReactant)
 
   auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(system)
-                    .AddExternalModel(model)
-                    .SetIgnoreUnusedSpecies(true)
-                    .Build();
+                  .SetSystem(system)
+                  .AddExternalModel(model)
+                  .SetIgnoreUnusedSpecies(true)
+                  .Build();
 
   // --- Sub-test 1: One reactant exactly zero ---
   {

--- a/test/integration/test_dissolved_reversible_reaction.cpp
+++ b/test/integration/test_dissolved_reversible_reaction.cpp
@@ -478,8 +478,8 @@ TEST(DissolvedReversibleReactionIntegration, MultiPhaseInstances) {
   double K_eq_large = k_forward / k_reverse;  // 2.0
   double A_eq_large = A0_large / (1.0 + K_eq_large);
   double B_eq_large = A0_large * K_eq_large / (1.0 + K_eq_large);
-  double k_total_large = k_forward + k_reverse;  // 0.3 s^-1
-  double tau_large = 1.0 / k_total_large;  // 3.33 s
+  double k_total_large = k_forward + k_reverse;  // 0.15 s^-1
+  double tau_large = 1.0 / k_total_large;  // 6.67 s
   
   // Build solver
   auto system = System(gas_phase);
@@ -493,20 +493,14 @@ TEST(DissolvedReversibleReactionIntegration, MultiPhaseInstances) {
   State state = solver.GetState();
   
   // Find variable indices for small droplets
-  std::size_t i_A_small = std::find(state.variable_names_.begin(), state.variable_names_.end(),
-                                     "DROPLET_SMALL.AQUEOUS.A") - state.variable_names_.begin();
-  std::size_t i_B_small = std::find(state.variable_names_.begin(), state.variable_names_.end(),
-                                     "DROPLET_SMALL.AQUEOUS.B") - state.variable_names_.begin();
-  std::size_t i_C_small = std::find(state.variable_names_.begin(), state.variable_names_.end(),
-                                     "DROPLET_SMALL.AQUEOUS.C") - state.variable_names_.begin();
+  std::size_t i_A_small = state.variable_map_.at("DROPLET_SMALL.AQUEOUS.A");
+  std::size_t i_B_small = state.variable_map_.at("DROPLET_SMALL.AQUEOUS.B");
+  std::size_t i_C_small = state.variable_map_.at("DROPLET_SMALL.AQUEOUS.C");
   
   // Find variable indices for large droplets
-  std::size_t i_A_large = std::find(state.variable_names_.begin(), state.variable_names_.end(),
-                                     "DROPLET_LARGE.AQUEOUS.A") - state.variable_names_.begin();
-  std::size_t i_B_large = std::find(state.variable_names_.begin(), state.variable_names_.end(),
-                                     "DROPLET_LARGE.AQUEOUS.B") - state.variable_names_.begin();
-  std::size_t i_C_large = std::find(state.variable_names_.begin(), state.variable_names_.end(),
-                                     "DROPLET_LARGE.AQUEOUS.C") - state.variable_names_.begin();
+  std::size_t i_A_large = state.variable_map_.at("DROPLET_LARGE.AQUEOUS.A");
+  std::size_t i_B_large = state.variable_map_.at("DROPLET_LARGE.AQUEOUS.B");
+  std::size_t i_C_large = state.variable_map_.at("DROPLET_LARGE.AQUEOUS.C");
   
   // Set initial conditions
   state.variables_[0][i_A_small] = A0_small;

--- a/test/integration/test_dissolved_reversible_reaction.cpp
+++ b/test/integration/test_dissolved_reversible_reaction.cpp
@@ -25,7 +25,7 @@ void analytical_solution(double A0, double k_f, double k_r, double t, double& A_
   double A_eq = A0 / (1.0 + K_eq);
   double B_eq = A0 * K_eq / (1.0 + K_eq);
   double k_total = k_f + k_r;
-
+  
   double exp_term = std::exp(-k_total * t);
   A_t = A_eq + (A0 - A_eq) * exp_term;
   B_t = B_eq - (A0 - A_eq) * exp_term;
@@ -36,58 +36,60 @@ TEST(DissolvedReversibleReactionIntegration, SimpleAtoB)
   // ========================================================================
   // Test 1: Simple A <-> B (No Solvent Dependence)
   // ========================================================================
-
+  
   // Define species
   auto A = Species{ "A" };
   auto B = Species{ "B" };
   auto C = Species{ "C" };  // solvent
-
+  
   // Define aqueous phase
   auto aqueous_phase = Phase{ "AQUEOUS", { { A }, { B }, { C } } };
-
+  
   // Define representation (single uniform section)
   auto droplet = UniformSection{ "DROPLET", { aqueous_phase } };
-
+  
   // Rate constants
   double k_forward = 0.1;   // s^-1
   double k_reverse = 0.05;  // s^-1
-
+  
   // Create rate constant functions (temperature-independent)
   auto forward_rate = [k_forward](const Conditions& conditions) { return k_forward; };
   auto reverse_rate = [k_reverse](const Conditions& conditions) { return k_reverse; };
-
+  
   // Create reversible reaction: A <-> B with solvent C
-  auto reaction = DissolvedReversibleReaction{ { { "DROPLET", forward_rate } },
-                                               { { "DROPLET", reverse_rate } },
-                                               { A },  // reactants
-                                               { B },  // products
-                                               C,      // solvent
-                                               aqueous_phase };
-
+  auto reaction = DissolvedReversibleReaction{
+    { forward_rate } ,
+    { reverse_rate },
+    { A },  // reactants
+    { B },  // products
+    C,      // solvent
+    aqueous_phase
+  };
+  
   // Create model
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
   model.AddProcesses({ reaction });
-
+  
   // Create gas phase (empty for this test)
   Phase gas_phase{ "GAS", {} };
-
+  
   // Test parameters
   double A0 = 1.0;  // mol/m^3
   double K_eq = k_forward / k_reverse;
   double A_eq = A0 / (1.0 + K_eq);
   double B_eq = A0 * K_eq / (1.0 + K_eq);
-
+  
   // Build solver
   auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(system)
-                    .AddExternalModel(model)
-                    .SetIgnoreUnusedSpecies(true)
-                    .Build();
-
+                  .SetSystem(system)
+                  .AddExternalModel(model)
+                  .SetIgnoreUnusedSpecies(true)
+                  .Build();
+  
   // Set up state
   State state = solver.GetState();
-
+  
   // Find variable indices
   std::size_t i_A = state.variable_map_.at("DROPLET.AQUEOUS.A");
   std::size_t i_B = state.variable_map_.at("DROPLET.AQUEOUS.B");
@@ -97,24 +99,24 @@ TEST(DissolvedReversibleReactionIntegration, SimpleAtoB)
   state.variables_[0][i_A] = A0;      // [A] = 1.0 mol/m^3
   state.variables_[0][i_B] = 0.0;     // [B] = 0.0 mol/m^3
   state.variables_[0][i_C] = 1.0e-4;  // [C] = 1.0e-4 mol/m^3 (solvent, constant)
-
+  
   // Set conditions
   state.conditions_[0].temperature_ = 298.15;  // K
   state.conditions_[0].pressure_ = 101325.0;   // Pa
-
+  
   // Set default parameters for the representation
   droplet.SetDefaultParameters(state);
-
+  
   // Time points to test (in seconds)
   // tau = 6.67s, so 5*tau = 33s gets to 99% of equilibrium, using 100s for good margin
   std::vector<double> test_times = { 5.0, 10.0, 20.0, 100.0 };
-
+  
   double time = 0.0;
   const double tolerance = 1.0e-4;  // mol/m^3 (reasonable for numerical integration)
-
+  
   // Calculate rate constants once before starting
   solver.UpdateStateParameters(state);
-
+  
   for (double target_time : test_times)
   {
     // Integrate to target time (with small tolerance to avoid floating point issues)
@@ -123,75 +125,78 @@ TEST(DissolvedReversibleReactionIntegration, SimpleAtoB)
       double dt = std::min(0.01, target_time - time);  // Smaller time step
       solver.UpdateStateParameters(state);
       auto result = solver.Solve(dt, state);
-      ASSERT_EQ(result.state_, SolverState::Converged)
-          << "Solver failed to converge at time " << time << " s with dt = " << dt << " s";
+      ASSERT_EQ(result.state_, SolverState::Converged) 
+        << "Solver failed to converge at time " << time << " s with dt = " << dt << " s";
       time += dt;
     }
-
+    
     // Get numerical solution
     double A_numeric = state.variables_[0][i_A];
     double B_numeric = state.variables_[0][i_B];
     double C_numeric = state.variables_[0][i_C];
-
+    
     // Get analytical solution
     double A_analytic, B_analytic;
     analytical_solution(A0, k_forward, k_reverse, time, A_analytic, B_analytic);
-
+    
     // Check numerical solution matches analytical solution
-    EXPECT_NEAR(A_numeric, A_analytic, tolerance) << "Species A concentration mismatch at t = " << time << " s";
-    EXPECT_NEAR(B_numeric, B_analytic, tolerance) << "Species B concentration mismatch at t = " << time << " s";
-
+    EXPECT_NEAR(A_numeric, A_analytic, tolerance)
+      << "Species A concentration mismatch at t = " << time << " s";
+    EXPECT_NEAR(B_numeric, B_analytic, tolerance)
+      << "Species B concentration mismatch at t = " << time << " s";
+    
     // Check mass conservation
     double mass_sum = A_numeric + B_numeric;
     EXPECT_NEAR(mass_sum, A0, tolerance) << "Mass conservation violated at t = " << time << " s";
-
+    
     // Check solvent remains constant
     EXPECT_NEAR(C_numeric, 1.0e-4, tolerance) << "Solvent changed at t = " << time << " s";
   }
-
+  
   // Check equilibrium is reached
   double A_final = state.variables_[0][i_A];
   double B_final = state.variables_[0][i_B];
-
+  
   EXPECT_NEAR(A_final, A_eq, tolerance) << "Species A did not reach equilibrium at t = " << time << " s";
   EXPECT_NEAR(B_final, B_eq, tolerance) << "Species B did not reach equilibrium at t = " << time << " s";
 }
 TEST(DissolvedReversibleReactionIntegration, SolventAsReactant)
 {
   // Test 2: A + C ⇌ B (Solvent is Reactant)
-
+  
   // Define species
   auto A = Species{ "A" };
   auto B = Species{ "B" };
   auto C = Species{ "C" };  // solvent AND reactant
-
+  
   // Define aqueous phase
   auto aqueous_phase = Phase{ "AQUEOUS", { { A }, { B }, { C } } };
-
+  
   // Define representation
   auto droplet = UniformSection{ "DROPLET", { aqueous_phase } };
-
+  
   // Rate constants
   double k_forward = 1.0e-3;   // s^-1
   double k_reverse = 1.0e-11;  // s^-1
-
+  
   auto forward_rate = [k_forward](const Conditions& conditions) { return k_forward; };
   auto reverse_rate = [k_reverse](const Conditions& conditions) { return k_reverse; };
-
+  
   // Create reversible reaction: A + C <-> B with solvent C
-  auto reaction = DissolvedReversibleReaction{ { { "DROPLET", forward_rate } },
-                                               { { "DROPLET", reverse_rate } },
-                                               { A, C },  // reactants: A + C
-                                               { B },     // products: B
-                                               C,         // solvent
-                                               aqueous_phase };
-
+  auto reaction = DissolvedReversibleReaction{
+    { forward_rate },
+    { reverse_rate },
+    { A, C },  // reactants: A + C
+    { B },     // products: B
+    C,         // solvent
+    aqueous_phase };
+  
   // Create model
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
   model.AddProcesses({ reaction });
-
+  
   Phase gas_phase{ "GAS", {} };
-
+  
   // Test parameters
   double A0 = 1.0e-5;                   // mol/m^3
   double C0 = 1.0e-4;                   // mol/m^3 (10x the amount needed)
@@ -199,40 +204,40 @@ TEST(DissolvedReversibleReactionIntegration, SolventAsReactant)
   double A_eq = A0 / (1.0 + K_eq);
   double B_eq = A0 * K_eq / (1.0 + K_eq);
   double C_eq = C0 - B_eq;
-
+  
   // Build solver
   auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(system)
-                    .AddExternalModel(model)
-                    .SetIgnoreUnusedSpecies(true)
-                    .Build();
-
+                  .SetSystem(system)
+                  .AddExternalModel(model)
+                  .SetIgnoreUnusedSpecies(true)
+                  .Build();
+  
   State state = solver.GetState();
-
+  
   // Find variable indices
   std::size_t i_A = state.variable_map_.at("DROPLET.AQUEOUS.A");
   std::size_t i_B = state.variable_map_.at("DROPLET.AQUEOUS.B");
   std::size_t i_C = state.variable_map_.at("DROPLET.AQUEOUS.C");
-
+  
   // Set initial conditions
   state.variables_[0][i_A] = A0;
   state.variables_[0][i_B] = 0.0;
   state.variables_[0][i_C] = C0;
-
+  
   state.conditions_[0].temperature_ = 298.15;
   state.conditions_[0].pressure_ = 101325.0;
-
+  
   droplet.SetDefaultParameters(state);
-
+  
   // Time points to test (tau ≈ 1000s)
   std::vector<double> test_times = { 1000.0, 2000.0, 4000.0, 10000.0 };
-
+  
   double time = 0.0;
   const double tolerance = 1.0e-8;  // mol/m^3
-
+  
   solver.UpdateStateParameters(state);
-
+  
   for (double target_time : test_times)
   {
     while (time < target_time - 1.0e-10)
@@ -240,43 +245,43 @@ TEST(DissolvedReversibleReactionIntegration, SolventAsReactant)
       double dt = std::min(1.0, target_time - time);
       solver.UpdateStateParameters(state);
       auto result = solver.Solve(dt, state);
-      ASSERT_EQ(result.state_, SolverState::Converged)
-          << "Solver failed to converge at time " << time << " s with dt = " << dt << " s";
+      ASSERT_EQ(result.state_, SolverState::Converged) 
+        << "Solver failed to converge at time " << time << " s with dt = " << dt << " s";
       time += dt;
     }
-
+    
     double A_numeric = state.variables_[0][i_A];
     double B_numeric = state.variables_[0][i_B];
     double C_numeric = state.variables_[0][i_C];
-
+    
     // Analytical solution
     double k_total = k_forward + k_reverse;
     double exp_term = std::exp(-k_total * time);
     double A_analytic = A_eq + (A0 - A_eq) * exp_term;
     double B_analytic = B_eq - (A0 - A_eq) * exp_term;
-
+    
     EXPECT_NEAR(A_numeric, A_analytic, tolerance) << "Species A concentration mismatch at t = " << time << " s";
     EXPECT_NEAR(B_numeric, B_analytic, tolerance) << "Species B concentration mismatch at t = " << time << " s";
-
+    
     // Check stoichiometry: C consumption equals A consumption
     double A_consumed = A0 - A_numeric;
     double C_consumed = C0 - C_numeric;
     EXPECT_NEAR(C_consumed, A_consumed, tolerance) << "Stoichiometry violated at t = " << time << " s";
-
+    
     // Check mass balance
     double mass_sum = A_numeric + B_numeric;
     EXPECT_NEAR(mass_sum, A0, tolerance) << "Mass conservation violated at t = " << time << " s";
   }
-
+  
   // Check equilibrium
   double A_final = state.variables_[0][i_A];
   double B_final = state.variables_[0][i_B];
   double C_final = state.variables_[0][i_C];
-
+  
   EXPECT_NEAR(A_final, A_eq, tolerance) << "Species A did not reach equilibrium";
   EXPECT_NEAR(B_final, B_eq, tolerance) << "Species B did not reach equilibrium";
   EXPECT_NEAR(C_final, C_eq, tolerance) << "Species C did not reach equilibrium";
-
+  
   // Verify nearly complete conversion (K_eq = 1e8)
   EXPECT_GT(B_final / A0, 0.99) << "Expected nearly complete conversion to B";
 }
@@ -288,81 +293,82 @@ TEST(DissolvedReversibleReactionIntegration, SolventAsProduct)
   // Species: A (reactant), B (product), C (product AND solvent)
   // Reaction: A ⇌ B + C where C is both product and solvent
   // K_eq = 1e-8 (heavily favors A, minimal conversion)
-
+  
   auto A = Species{ "A" };
   auto B = Species{ "B" };
   auto C = Species{ "C" };  // solvent AND product
-
+  
   // Define aqueous phase
   auto aqueous_phase = Phase{ "AQUEOUS", { { A }, { B }, { C } } };
-
+  
   // Define representation
   auto droplet = UniformSection{ "DROPLET", { aqueous_phase } };
-
+  
   // Rate constants
   double k_forward = 1.0e-11;  // s^-1 (very slow forward)
   double k_reverse = 1.0e-3;   // s^-1 (fast reverse)
-
+  
   auto forward_rate = [k_forward](const Conditions& conditions) { return k_forward; };
   auto reverse_rate = [k_reverse](const Conditions& conditions) { return k_reverse; };
-
+  
   // Create reversible reaction: A ⇌ B + C with solvent C
   // Forward: k_f/[C]^0 × [A] = k_f × [A] (no solvent dependence)
   // Reverse: k_r/[C]^1 × [B] × [C] = k_r × [B] (C cancels)
-  auto reaction = DissolvedReversibleReaction{ { { "DROPLET", forward_rate } },
-                                               { { "DROPLET", reverse_rate } },
-                                               { A },     // reactants: A
-                                               { B, C },  // products: B + C
-                                               C,         // solvent
-                                               aqueous_phase };
-
+  auto reaction = DissolvedReversibleReaction{
+    { forward_rate },
+    { reverse_rate },
+    { A },     // reactants: A
+    { B, C },  // products: B + C
+    C,         // solvent
+    aqueous_phase };
+  
   // Create model
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
   model.AddProcesses({ reaction });
-
+  
   Phase gas_phase{ "GAS", {} };
-
+  
   // Test parameters
   double A0 = 0.1;                      // mol/m^3
   double B0 = 0.0;                      // mol/m^3
   double C0 = 1.0e-4;                   // mol/m^3 (solvent, very small)
   double K_eq = k_forward / k_reverse;  // 1e-8 (favors A)
-
+  
   // Since C is very small compared to A and K_eq << 1, very little conversion
   // The analytical solution for A ⇌ B + C with minimal conversion:
   // d[A]/dt = -k_f·[A] + k_r·[B] (approximately, since [C] changes slowly)
   double k_total = k_forward + k_reverse;
   double A_eq = k_reverse / (k_forward + k_reverse) * A0;  // ≈ A0
   double B_eq = k_forward / (k_forward + k_reverse) * A0;  // ≈ 0
-
+  
   // Build solver
   auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(system)
-                    .AddExternalModel(model)
-                    .SetIgnoreUnusedSpecies(true)
-                    .Build();
-
+                  .SetSystem(system)
+                  .AddExternalModel(model)
+                  .SetIgnoreUnusedSpecies(true)
+                  .Build();
+  
   // Initialize state
   State state = solver.GetState();
   std::size_t i_A = state.variable_map_.at("DROPLET.AQUEOUS.A");
   std::size_t i_B = state.variable_map_.at("DROPLET.AQUEOUS.B");
   std::size_t i_C = state.variable_map_.at("DROPLET.AQUEOUS.C");
-
+  
   state.variables_[0][i_A] = A0;
   state.variables_[0][i_B] = B0;
   state.variables_[0][i_C] = C0;
   droplet.SetDefaultParameters(state);
-
+  
   // Tolerance for numerical comparisons
   const double tolerance = 1.0e-4;  // mol/m³
-
+  
   // Test integration at multiple times
   std::vector<double> test_times = { 1000.0, 2000.0, 4000.0, 10000.0 };
-
+  
   solver.UpdateStateParameters(state);
   double time = 0.0;
-
+  
   for (double target_time : test_times)
   {
     // Integrate to target time
@@ -374,37 +380,37 @@ TEST(DissolvedReversibleReactionIntegration, SolventAsProduct)
       ASSERT_EQ(result.state_, SolverState::Converged);
       time += dt;
     }
-
+    
     // Get numerical solution
     double A_numeric = state.variables_[0][i_A];
     double B_numeric = state.variables_[0][i_B];
     double C_numeric = state.variables_[0][i_C];
-
+    
     // Analytical solution (assuming C ≈ constant, which is valid for small conversion)
     double exp_term = std::exp(-k_total * time);
     double A_analytic = A_eq + (A0 - A_eq) * exp_term;
     double B_analytic = B_eq + (B0 - B_eq) * exp_term;
     double C_analytic = C0 + B_analytic;  // C increases with B production
-
+    
     // Check analytical vs numerical
     EXPECT_NEAR(A_numeric, A_analytic, tolerance) << "Mismatch at t=" << time << "s";
     EXPECT_NEAR(B_numeric, B_analytic, tolerance) << "Mismatch at t=" << time << "s";
     EXPECT_NEAR(C_numeric, C_analytic, tolerance) << "Mismatch at t=" << time << "s";
-
+    
     // Check stoichiometry: ΔC = ΔB (both produced together)
     double delta_B = B_numeric - B0;
     double delta_C = C_numeric - C0;
     EXPECT_NEAR(delta_C, delta_B, tolerance) << "Stoichiometry violated at t=" << time << "s";
-
+    
     // Check mass conservation: A + B = A0
     EXPECT_NEAR(A_numeric + B_numeric, A0, tolerance) << "Mass not conserved at t=" << time << "s";
   }
-
+  
   // Check equilibrium at final time
   double A_final = state.variables_[0][i_A];
   double B_final = state.variables_[0][i_B];
   double C_final = state.variables_[0][i_C];
-
+  
   // At equilibrium: K_eq = [B]·[C] / [A]
   // Since K_eq = 1e-8 << 1, we expect B ≈ 0 and A ≈ A0
   EXPECT_NEAR(B_final, 0.0, tolerance) << "System should be near equilibrium with B ≈ 0";
@@ -412,179 +418,181 @@ TEST(DissolvedReversibleReactionIntegration, SolventAsProduct)
 }
 
 // Test 4: Multi-Phase Instances
-// Tests two independent droplet populations with same reaction but different parameters
-TEST(DissolvedReversibleReactionIntegration, MultiPhaseInstances)
-{
-  // Two independent droplet populations:
-  // - Small droplets: faster reaction
-  // - Large droplets: even faster reaction (same K_eq but faster kinetics)
-
+// Tests two independent droplet populations with same phase
+TEST(DissolvedReversibleReactionIntegration, MultiPhaseInstances) {
+  
   auto A = Species{ "A" };
   auto B = Species{ "B" };
   auto C = Species{ "C" };  // solvent
-
+  
   // Define aqueous phases for both droplet sizes
-  auto small_aqueous = Phase{ "AQUEOUS_SMALL", { { A }, { B }, { C } } };
-  auto large_aqueous = Phase{ "AQUEOUS_LARGE", { { A }, { B }, { C } } };
-
+  auto aqueous = Phase{ "AQUEOUS", { { A }, { B }, { C } } };
+  
   // Define representations
-  auto small_droplet = UniformSection{ "DROPLET_SMALL", { small_aqueous } };
-
-  auto large_droplet = UniformSection{ "DROPLET_LARGE", { large_aqueous } };
-
+  auto small_droplet = UniformSection{
+    "DROPLET_SMALL",
+    { aqueous }
+  };
+  
+  auto large_droplet = UniformSection{
+    "DROPLET_LARGE",
+    { aqueous }
+  };
+  
   // Rate constants for small droplets
-  double k_forward_small = 0.1;   // s^-1
-  double k_reverse_small = 0.05;  // s^-1
-
-  auto forward_rate_small = [k_forward_small](const Conditions& conditions) { return k_forward_small; };
-  auto reverse_rate_small = [k_reverse_small](const Conditions& conditions) { return k_reverse_small; };
-
+  double k_forward = 0.1;   // s^-1
+  double k_reverse = 0.05;  // s^-1
+  
+  auto k_forward_calc = [k_forward](const Conditions& conditions) { return k_forward; };
+  auto k_reverse_calc = [k_reverse](const Conditions& conditions) { return k_reverse; };
+  
   // Create reaction for small droplets: A ⇌ B
-  auto reaction_small = DissolvedReversibleReaction{ { { "DROPLET_SMALL", forward_rate_small } },
-                                                     { { "DROPLET_SMALL", reverse_rate_small } },
-                                                     { A },  // reactants
-                                                     { B },  // products
-                                                     C,      // solvent
-                                                     small_aqueous };
-
-  // Rate constants for large droplets (2x faster, same K_eq)
-  double k_forward_large = 0.2;  // s^-1
-  double k_reverse_large = 0.1;  // s^-1
-
-  auto forward_rate_large = [k_forward_large](const Conditions& conditions) { return k_forward_large; };
-  auto reverse_rate_large = [k_reverse_large](const Conditions& conditions) { return k_reverse_large; };
-
-  // Create reaction for large droplets: A ⇌ B
-  auto reaction_large = DissolvedReversibleReaction{ { { "DROPLET_LARGE", forward_rate_large } },
-                                                     { { "DROPLET_LARGE", reverse_rate_large } },
-                                                     { A },  // reactants
-                                                     { B },  // products
-                                                     C,      // solvent
-                                                     large_aqueous };
-
+  auto reaction = DissolvedReversibleReaction{
+    k_forward_calc,
+    k_reverse_calc,
+    { A },  // reactants
+    { B },  // products
+    C,      // solvent
+    aqueous
+  };
+    
   // Create model with both representations
-  auto model = Model{ .name_ = "AEROSOL", .representations_ = { small_droplet, large_droplet } };
-  model.AddProcesses({ reaction_small, reaction_large });
-
+  auto model = Model{
+    .name_ = "AEROSOL",
+    .representations_ = { small_droplet, large_droplet }
+  };
+  model.AddProcesses({ reaction });
+  
   Phase gas_phase{ "GAS", {} };
-
+  
   // Test parameters for small droplets
-  double A0_small = 1.0;                                  // mol/m^3
-  double K_eq_small = k_forward_small / k_reverse_small;  // 2.0
+  double A0_small = 1.0;  // mol/m^3
+  double K_eq_small = k_forward / k_reverse;  // 2.0
   double A_eq_small = A0_small / (1.0 + K_eq_small);
   double B_eq_small = A0_small * K_eq_small / (1.0 + K_eq_small);
-  double k_total_small = k_forward_small + k_reverse_small;  // 0.15 s^-1
-  double tau_small = 1.0 / k_total_small;                    // 6.67 s
-
+  double k_total_small = k_forward + k_reverse;  // 0.15 s^-1
+  double tau_small = 1.0 / k_total_small;  // 6.67 s
+  
   // Test parameters for large droplets
-  double A0_large = 0.5;                                  // mol/m^3
-  double K_eq_large = k_forward_large / k_reverse_large;  // 2.0 (same as small)
+  double A0_large = 0.5;  // mol/m^3
+  double K_eq_large = k_forward / k_reverse;  // 2.0
   double A_eq_large = A0_large / (1.0 + K_eq_large);
   double B_eq_large = A0_large * K_eq_large / (1.0 + K_eq_large);
-  double k_total_large = k_forward_large + k_reverse_large;  // 0.3 s^-1
-  double tau_large = 1.0 / k_total_large;                    // 3.33 s
-
+  double k_total_large = k_forward + k_reverse;  // 0.3 s^-1
+  double tau_large = 1.0 / k_total_large;  // 3.33 s
+  
   // Build solver
   auto system = System(gas_phase);
   auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
-                    .SetSystem(system)
-                    .AddExternalModel(model)
-                    .SetIgnoreUnusedSpecies(true)
-                    .Build();
-
+                  .SetSystem(system)
+                  .AddExternalModel(model)
+                  .SetIgnoreUnusedSpecies(true)
+                  .Build();
+  
   // Initialize state
   State state = solver.GetState();
-
+  
   // Find variable indices for small droplets
-  std::size_t i_A_small = state.variable_map_.at("DROPLET_SMALL.AQUEOUS_SMALL.A");
-  std::size_t i_B_small = state.variable_map_.at("DROPLET_SMALL.AQUEOUS_SMALL.B");
-  std::size_t i_C_small = state.variable_map_.at("DROPLET_SMALL.AQUEOUS_SMALL.C");
-
+  std::size_t i_A_small = std::find(state.variable_names_.begin(), state.variable_names_.end(),
+                                     "DROPLET_SMALL.AQUEOUS.A") - state.variable_names_.begin();
+  std::size_t i_B_small = std::find(state.variable_names_.begin(), state.variable_names_.end(),
+                                     "DROPLET_SMALL.AQUEOUS.B") - state.variable_names_.begin();
+  std::size_t i_C_small = std::find(state.variable_names_.begin(), state.variable_names_.end(),
+                                     "DROPLET_SMALL.AQUEOUS.C") - state.variable_names_.begin();
+  
   // Find variable indices for large droplets
-  std::size_t i_A_large = state.variable_map_.at("DROPLET_LARGE.AQUEOUS_LARGE.A");
-  std::size_t i_B_large = state.variable_map_.at("DROPLET_LARGE.AQUEOUS_LARGE.B");
-  std::size_t i_C_large = state.variable_map_.at("DROPLET_LARGE.AQUEOUS_LARGE.C");
-
+  std::size_t i_A_large = std::find(state.variable_names_.begin(), state.variable_names_.end(),
+                                     "DROPLET_LARGE.AQUEOUS.A") - state.variable_names_.begin();
+  std::size_t i_B_large = std::find(state.variable_names_.begin(), state.variable_names_.end(),
+                                     "DROPLET_LARGE.AQUEOUS.B") - state.variable_names_.begin();
+  std::size_t i_C_large = std::find(state.variable_names_.begin(), state.variable_names_.end(),
+                                     "DROPLET_LARGE.AQUEOUS.C") - state.variable_names_.begin();
+  
   // Set initial conditions
   state.variables_[0][i_A_small] = A0_small;
   state.variables_[0][i_B_small] = 0.0;
   state.variables_[0][i_C_small] = 1.0e-4;  // solvent
-
+  
   state.variables_[0][i_A_large] = A0_large;
   state.variables_[0][i_B_large] = 0.0;
   state.variables_[0][i_C_large] = 1.0e-4;  // solvent
-
+  
   small_droplet.SetDefaultParameters(state);
   large_droplet.SetDefaultParameters(state);
-
+  
   // Tolerance for numerical comparisons
   const double tolerance = 1.0e-4;  // mol/m³
-
+  
   // Test integration at multiple times
   // Use 100s to reach equilibrium (about 15×tau_small)
   std::vector<double> test_times = { 5.0, 10.0, 20.0, 100.0 };
-
+  
   solver.UpdateStateParameters(state);
   double time = 0.0;
-
-  for (double target_time : test_times)
-  {
+  
+  for (double target_time : test_times) {
     // Integrate to target time
-    while (time < target_time - 1.0e-10)
-    {
+    while (time < target_time - 1.0e-10) {
       double dt = std::min(0.01, target_time - time);  // 0.01s timestep
       solver.UpdateStateParameters(state);
       auto result = solver.Solve(dt, state);
       ASSERT_EQ(result.state_, SolverState::Converged);
       time += dt;
     }
-
+    
     // Get numerical solution for small droplets
     double A_numeric_small = state.variables_[0][i_A_small];
     double B_numeric_small = state.variables_[0][i_B_small];
     double C_numeric_small = state.variables_[0][i_C_small];
-
+    
     // Get numerical solution for large droplets
     double A_numeric_large = state.variables_[0][i_A_large];
     double B_numeric_large = state.variables_[0][i_B_large];
     double C_numeric_large = state.variables_[0][i_C_large];
-
+    
     // Analytical solutions for small droplets
     double exp_term_small = std::exp(-k_total_small * time);
     double A_analytic_small = A_eq_small + (A0_small - A_eq_small) * exp_term_small;
     double B_analytic_small = B_eq_small + (0.0 - B_eq_small) * exp_term_small;
-
+    
     // Analytical solutions for large droplets
     double exp_term_large = std::exp(-k_total_large * time);
     double A_analytic_large = A_eq_large + (A0_large - A_eq_large) * exp_term_large;
     double B_analytic_large = B_eq_large + (0.0 - B_eq_large) * exp_term_large;
-
+    
     // Check small droplets
-    EXPECT_NEAR(A_numeric_small, A_analytic_small, tolerance) << "Small droplet A mismatch at t=" << time << "s";
-    EXPECT_NEAR(B_numeric_small, B_analytic_small, tolerance) << "Small droplet B mismatch at t=" << time << "s";
+    EXPECT_NEAR(A_numeric_small, A_analytic_small, tolerance)
+      << "Small droplet A mismatch at t=" << time << "s";
+    EXPECT_NEAR(B_numeric_small, B_analytic_small, tolerance)
+      << "Small droplet B mismatch at t=" << time << "s";
     EXPECT_NEAR(A_numeric_small + B_numeric_small, A0_small, tolerance)
-        << "Small droplet mass not conserved at t=" << time << "s";
-    EXPECT_NEAR(C_numeric_small, 1.0e-4, tolerance) << "Small droplet solvent changed at t=" << time << "s";
-
+      << "Small droplet mass not conserved at t=" << time << "s";
+    EXPECT_NEAR(C_numeric_small, 1.0e-4, tolerance)
+      << "Small droplet solvent changed at t=" << time << "s";
+    
     // Check large droplets
-    EXPECT_NEAR(A_numeric_large, A_analytic_large, tolerance) << "Large droplet A mismatch at t=" << time << "s";
-    EXPECT_NEAR(B_numeric_large, B_analytic_large, tolerance) << "Large droplet B mismatch at t=" << time << "s";
+    EXPECT_NEAR(A_numeric_large, A_analytic_large, tolerance)
+      << "Large droplet A mismatch at t=" << time << "s";
+    EXPECT_NEAR(B_numeric_large, B_analytic_large, tolerance)
+      << "Large droplet B mismatch at t=" << time << "s";
     EXPECT_NEAR(A_numeric_large + B_numeric_large, A0_large, tolerance)
-        << "Large droplet mass not conserved at t=" << time << "s";
-    EXPECT_NEAR(C_numeric_large, 1.0e-4, tolerance) << "Large droplet solvent changed at t=" << time << "s";
-
+      << "Large droplet mass not conserved at t=" << time << "s";
+    EXPECT_NEAR(C_numeric_large, 1.0e-4, tolerance)
+      << "Large droplet solvent changed at t=" << time << "s";
+    
     // Check that both reach same equilibrium fraction (K_eq is same)
     double frac_B_small = B_numeric_small / (A_numeric_small + B_numeric_small);
     double frac_B_large = B_numeric_large / (A_numeric_large + B_numeric_large);
     double expected_frac = K_eq_small / (1.0 + K_eq_small);  // 2/3
-
-    if (time >= 50.0)
-    {  // Check at equilibrium
-      EXPECT_NEAR(frac_B_small, expected_frac, 0.01) << "Small droplet equilibrium fraction wrong at t=" << time << "s";
-      EXPECT_NEAR(frac_B_large, expected_frac, 0.01) << "Large droplet equilibrium fraction wrong at t=" << time << "s";
+    
+    if (time >= 50.0) {  // Check at equilibrium
+      EXPECT_NEAR(frac_B_small, expected_frac, 0.01)
+        << "Small droplet equilibrium fraction wrong at t=" << time << "s";
+      EXPECT_NEAR(frac_B_large, expected_frac, 0.01)
+        << "Large droplet equilibrium fraction wrong at t=" << time << "s";
     }
   }
-
+  
   // Verify no cross-coupling: large droplets should equilibrate faster
   // At t=10s (3×tau_large but only 1.5×tau_small):
   // Large droplets: exp(-0.3×10) = exp(-3) ≈ 0.05 (95% to equilibrium)

--- a/test/integration/test_equilibrium_constraints.cpp
+++ b/test/integration/test_equilibrium_constraints.cpp
@@ -58,7 +58,7 @@ TEST(EquilibriumConstraintsIntegration, DissolvedEquilibriumWithKineticDriver)
                       .SetReactants({ A })
                       .SetProducts({ B })
                       .SetSolvent(S)
-                      .AddRateConstant("DROPLET", rate)
+                      .SetRateConstant(rate)
                       .Build();
 
   // Equilibrium constraint: B <-> C, K_eq, algebraic species = C
@@ -205,8 +205,7 @@ TEST(EquilibriumConstraintsIntegration, PerInstanceEquilibrium)
                       .SetReactants({ A })
                       .SetProducts({ B })
                       .SetSolvent(S)
-                      .AddRateConstant("SMALL", rate)
-                      .AddRateConstant("LARGE", rate)
+                      .SetRateConstant(rate)
                       .Build();
 
   // Equilibrium constraint: C = K_eq * B (C is algebraic)
@@ -330,7 +329,7 @@ TEST(EquilibriumConstraintsIntegration, InconsistentInitialConditions)
                       .SetReactants({ A })
                       .SetProducts({ B })
                       .SetSolvent(S)
-                      .AddRateConstant("DROPLET", rate)
+                      .SetRateConstant(rate)
                       .Build();
 
   auto equil = DissolvedEquilibriumConstraintBuilder()

--- a/test/integration/test_henry_law_phase_transfer.cpp
+++ b/test/integration/test_henry_law_phase_transfer.cpp
@@ -79,14 +79,14 @@ TEST(HenryLawPhaseTransferIntegration, SimpleOneInstance)
   auto hlc = [HLC_val](const Conditions& conditions) { return HLC_val; };
 
   auto transfer = HenryLawPhaseTransferBuilder()
-                      .SetCondensedPhase(aqueous_phase)
-                      .SetGasSpecies(A_g)
-                      .SetCondensedSpecies(A_aq)
-                      .SetSolvent(H2O)
-                      .SetHenryLawConstant(miam::HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = HLC_val }))
-                      .SetDiffusionCoefficient(D_g)
-                      .SetAccommodationCoefficient(alpha)
-                      .Build();
+      .SetCondensedPhase(aqueous_phase)
+      .SetGasSpecies(A_g)
+      .SetCondensedSpecies(A_aq)
+      .SetSolvent(H2O)
+      .SetHenryLawConstant(miam::HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = HLC_val }))
+      .SetDiffusionCoefficient(D_g)
+      .SetAccommodationCoefficient(alpha)
+      .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
   model.AddProcesses({ transfer });
@@ -196,7 +196,7 @@ TEST(HenryLawPhaseTransferIntegration, SimpleOneInstance)
 TEST(HenryLawPhaseTransferIntegration, MultiInstanceMassConservation)
 {
   // Same gas species partitions into two different droplet populations
-  double gas_molecular_weight = 0.030;  // kg mol⁻¹ (like HCHO)
+  double gas_molecular_weight = 0.030;       // kg mol⁻¹ (like HCHO)
   double solvent_molecular_weight = 0.018;
   double solvent_density = 1000.0;
   double D_g = 1.8e-5;
@@ -208,26 +208,36 @@ TEST(HenryLawPhaseTransferIntegration, MultiInstanceMassConservation)
   auto H2O = MakeCondensedSpecies("H2O", solvent_molecular_weight, solvent_density);
 
   Phase gas_phase{ "GAS", { { A_g } } };
-  Phase aqueous_phase{ "AQUEOUS", { { A_aq }, { H2O } } };
+  Phase aqueous{ "AQUEOUS", { { A_aq }, { H2O } } };
 
-  auto small_drop = SingleMomentMode{ "SMALL", { aqueous_phase }, 1.0e-6, 1.2 };
-  auto large_drop = SingleMomentMode{ "LARGE", { aqueous_phase }, 1.0e-5, 1.4 };
+  auto small_drop = SingleMomentMode{
+    "SMALL", { aqueous }, 1.0e-6, 1.2
+  };
+  auto large_drop = SingleMomentMode{
+    "LARGE", { aqueous }, 1.0e-5, 1.4
+  };
 
+  // Build one transfer process that gets applied to both phase instances
   auto transfer = HenryLawPhaseTransferBuilder()
-                      .SetCondensedPhase(aqueous_phase)
-                      .SetGasSpecies(A_g)
-                      .SetCondensedSpecies(A_aq)
-                      .SetSolvent(H2O)
-                      .SetHenryLawConstant(HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = HLC_val }))
-                      .SetDiffusionCoefficient(D_g)
-                      .SetAccommodationCoefficient(alpha)
-                      .Build();
+      .SetCondensedPhase(aqueous)
+      .SetGasSpecies(A_g)
+      .SetCondensedSpecies(A_aq)
+      .SetSolvent(H2O)
+      .SetHenryLawConstant(HenryLawConstant(
+          HenryLawConstantParameters{ .HLC_ref_ = HLC_val }))
+      .SetDiffusionCoefficient(D_g)
+      .SetAccommodationCoefficient(alpha)
+      .Build();
 
-  auto model = Model{ .name_ = "CLOUD", .representations_ = { small_drop, large_drop } };
+  auto model = Model{
+    .name_ = "CLOUD",
+    .representations_ = { small_drop, large_drop }
+  };
   model.AddProcesses({ transfer });
 
   auto system = System(gas_phase);
-  auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
+  auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
+                    RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                     .SetSystem(system)
                     .AddExternalModel(model)
                     .SetIgnoreUnusedSpecies(true)
@@ -439,14 +449,14 @@ TEST(HenryLawPhaseTransferIntegration, SmallVsLargeParticleRate)
     };
 
     auto transfer = HenryLawPhaseTransferBuilder()
-                        .SetCondensedPhase(aqueous_phase)
-                        .SetGasSpecies(A_g)
-                        .SetCondensedSpecies(A_aq)
-                        .SetSolvent(H2O)
-                        .SetHenryLawConstant(HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = HLC_val }))
-                        .SetDiffusionCoefficient(D_g)
-                        .SetAccommodationCoefficient(alpha)
-                        .Build();
+        .SetCondensedPhase(aqueous_phase)
+        .SetGasSpecies(A_g)
+        .SetCondensedSpecies(A_aq)
+        .SetSolvent(H2O)
+        .SetHenryLawConstant(HenryLawConstant(HenryLawConstantParameters{ .HLC_ref_ = HLC_val }))
+        .SetDiffusionCoefficient(D_g)
+        .SetAccommodationCoefficient(alpha)
+        .Build();
 
     auto model = Model{ .name_ = "TEST", .representations_ = { droplet } };
     model.AddProcesses({ transfer });

--- a/test/integration/test_jacobian_verification.cpp
+++ b/test/integration/test_jacobian_verification.cpp
@@ -197,7 +197,7 @@ TEST(JacobianVerification, DissolvedReactionProcess)
                       .SetReactants({ A })
                       .SetProducts({ B })
                       .SetSolvent(C)
-                      .AddRateConstant("DROPLET", rate)
+                      .SetRateConstant(rate)
                       .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
@@ -238,7 +238,7 @@ TEST(JacobianVerification, DissolvedReversibleReactionProcess)
   auto forward_rate = [k_f](const Conditions&) { return k_f; };
   auto reverse_rate = [k_r](const Conditions&) { return k_r; };
   auto reaction = DissolvedReversibleReaction{
-    { { "DROPLET", forward_rate } }, { { "DROPLET", reverse_rate } }, { A }, { B }, C, aqueous_phase
+    { forward_rate }, { reverse_rate }, { A }, { B }, C, aqueous_phase
   };
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
@@ -392,12 +392,12 @@ TEST(JacobianVerification, MultipleProcessesCombined)
                        .SetReactants({ A })
                        .SetProducts({ B })
                        .SetSolvent(S)
-                       .AddRateConstant("DROPLET", [](const Conditions&) { return 0.1; })
+                       .SetRateConstant([](const Conditions&) { return 0.1; })
                        .Build();
 
   // C ⇌ D (reversible)
-  auto reaction2 = DissolvedReversibleReaction{ { { "DROPLET", [](const Conditions&) { return 0.2; } } },
-                                                { { "DROPLET", [](const Conditions&) { return 0.05; } } },
+  auto reaction2 = DissolvedReversibleReaction{ { [](const Conditions&) { return 0.2; } },
+                                                { [](const Conditions&) { return 0.05; } },
                                                 { C },
                                                 { D },
                                                 S,
@@ -596,7 +596,7 @@ TEST(JacobianVerification, ProcessAndConstraintsCombined)
                       .SetReactants({ A })
                       .SetProducts({ B })
                       .SetSolvent(S)
-                      .AddRateConstant("DROPLET", [k](const Conditions&) { return k; })
+                      .SetRateConstant([k](const Conditions&) { return k; })
                       .Build();
 
   auto equil = DissolvedEquilibriumConstraintBuilder()
@@ -726,7 +726,7 @@ TEST(JacobianVerification, DissolvedReactionDampingRange)
                       .SetReactants({ A })
                       .SetProducts({ B })
                       .SetSolvent(C)
-                      .AddRateConstant("DROPLET", rate)
+                      .SetRateConstant(rate)
                       .Build();
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
@@ -805,7 +805,7 @@ TEST(JacobianVerification, DissolvedReversibleReactionDampingRange)
   auto forward_rate = [k_f](const Conditions&) { return k_f; };
   auto reverse_rate = [k_r](const Conditions&) { return k_r; };
   auto reaction = DissolvedReversibleReaction{
-    { { "DROPLET", forward_rate } }, { { "DROPLET", reverse_rate } }, { A }, { B }, C, aqueous_phase
+    { forward_rate }, { reverse_rate }, { A }, { B }, C, aqueous_phase
   };
 
   auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
@@ -974,7 +974,7 @@ TEST(JacobianVerification, CombinedProcessAndConstraintZeroSolvent)
                       .SetReactants({ A })
                       .SetProducts({ B })
                       .SetSolvent(S)
-                      .AddRateConstant("DROPLET", [k](const Conditions&) { return k; })
+                      .SetRateConstant([k](const Conditions&) { return k; })
                       .Build();
 
   auto equil = DissolvedEquilibriumConstraintBuilder()
@@ -1076,7 +1076,7 @@ TEST(JacobianVerification, DissolvedReactionCappedSingleReactant)
                       .SetReactants({ A })
                       .SetProducts({ B })
                       .SetSolvent(C)
-                      .AddRateConstant("DROPLET", [](const Conditions&) { return 0.5; })
+                      .SetRateConstant([](const Conditions&) { return 0.5; })
                       .SetMinHalflife(t_half)
                       .Build();
 
@@ -1124,7 +1124,7 @@ TEST(JacobianVerification, DissolvedReactionCappedTwoReactants)
                       .SetReactants({ A, B })
                       .SetProducts({ P })
                       .SetSolvent(S)
-                      .AddRateConstant("DROPLET", [](const Conditions&) { return 1.0; })
+                      .SetRateConstant([](const Conditions&) { return 1.0; })
                       .SetMinHalflife(t_half)
                       .Build();
 
@@ -1173,7 +1173,7 @@ TEST(JacobianVerification, DissolvedReactionCappedSolventRange)
                       .SetReactants({ A })
                       .SetProducts({ B })
                       .SetSolvent(C)
-                      .AddRateConstant("DROPLET", [](const Conditions&) { return 1.0; })
+                      .SetRateConstant([](const Conditions&) { return 1.0; })
                       .SetMinHalflife(1.0)
                       .Build();
 
@@ -1253,7 +1253,7 @@ TEST(JacobianVerification, DissolvedReactionCappedMultiBlock)
                       .SetReactants({ A })
                       .SetProducts({ B })
                       .SetSolvent(C)
-                      .AddRateConstant("DROPLET", [](const Conditions&) { return 2.0; })
+                      .SetRateConstant([](const Conditions&) { return 2.0; })
                       .SetMinHalflife(0.1)
                       .Build();
 
@@ -1320,7 +1320,7 @@ namespace
                             .SetReactants(reactants)
                             .SetProducts(products)
                             .SetSolvent(solvent)
-                            .AddRateConstant("DROPLET", rate_fn)
+                            .SetRateConstant(rate_fn)
                             .Build();
     auto model_uncapped = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
     model_uncapped.AddProcesses({ rxn_uncapped });
@@ -1331,7 +1331,7 @@ namespace
                           .SetReactants(reactants)
                           .SetProducts(products)
                           .SetSolvent(solvent)
-                          .AddRateConstant("DROPLET", rate_fn)
+                          .SetRateConstant(rate_fn)
                           .SetMinHalflife(min_halflife)
                           .Build();
     auto model_capped = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };

--- a/test/integration/test_kinetic_vs_constrained.cpp
+++ b/test/integration/test_kinetic_vs_constrained.cpp
@@ -38,13 +38,13 @@ namespace
                         .SetReactants({ A })
                         .SetProducts({ B })
                         .SetSolvent(S)
-                        .AddRateConstant("DROPLET", rate)
+                        .SetRateConstant(rate)
                         .Build();
 
     auto forward_rate = [k_f](const Conditions& conditions) { return k_f; };
     auto reverse_rate = [k_r](const Conditions& conditions) { return k_r; };
     auto reversible = DissolvedReversibleReaction{
-      { { "DROPLET", forward_rate } }, { { "DROPLET", reverse_rate } }, { B }, { C }, S, aqueous_phase
+      { forward_rate }, { reverse_rate }, { B }, { C }, S, aqueous_phase
     };
 
     auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
@@ -130,13 +130,13 @@ TEST(KineticVsConstrained, DissolvedReversibleVsEquilibriumConstraint)
                         .SetReactants({ A })
                         .SetProducts({ B })
                         .SetSolvent(S)
-                        .AddRateConstant("DROPLET", rate)
+                        .SetRateConstant(rate)
                         .Build();
 
     auto forward_rate = [k_f](const Conditions& conditions) { return k_f; };
     auto reverse_rate = [k_r](const Conditions& conditions) { return k_r; };
     auto reversible = DissolvedReversibleReaction{
-      { { "DROPLET", forward_rate } }, { { "DROPLET", reverse_rate } }, { B }, { C }, S, aqueous_phase
+      { forward_rate }, { reverse_rate }, { B }, { C }, S, aqueous_phase
     };
 
     auto model = Model{ .name_ = "AEROSOL", .representations_ = { droplet } };
@@ -196,7 +196,7 @@ TEST(KineticVsConstrained, DissolvedReversibleVsEquilibriumConstraint)
                         .SetReactants({ A })
                         .SetProducts({ B })
                         .SetSolvent(S)
-                        .AddRateConstant("DROPLET", rate)
+                        .SetRateConstant(rate)
                         .Build();
 
     auto equil = DissolvedEquilibriumConstraintBuilder()

--- a/test/integration/test_miam_api.cpp
+++ b/test/integration/test_miam_api.cpp
@@ -137,10 +137,7 @@ TEST(MIAM, ApiExample)
           .SetSolvent(h2o)
           .SetEquilibriumConstant(
               EquilibriumConstant(EquilibriumConstantParameters{ .A_ = 1.14e-2, .C_ = 2300.0, .T0_ = 298.15 }))
-          .AddReverseRateConstant("SMALL_DROP", ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
-          .AddReverseRateConstant("LARGE_DROP", ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
-          .AddReverseRateConstant("AITKEN", ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
-          .AddReverseRateConstant("ACCUMULATION", ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
+          .SetReverseRateConstant(ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
           .Build();
 
   // Condensed phase reversible reaction: CO2 hydration
@@ -155,10 +152,7 @@ TEST(MIAM, ApiExample)
           .SetSolvent(h2o)
           .SetEquilibriumConstant(
               EquilibriumConstant(EquilibriumConstantParameters{ .A_ = 1.70e3, .C_ = 2400.0, .T0_ = 298.15 }))
-          .AddReverseRateConstant("SMALL_DROP", ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
-          .AddReverseRateConstant("LARGE_DROP", ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
-          .AddReverseRateConstant("AITKEN", ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
-          .AddReverseRateConstant("ACCUMULATION", ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
+          .SetReverseRateConstant(ArrheniusRateConstantParameters{ .A_ = 1.4e11, .C_ = 5.1e4 })
           .Build();
 
   // Condensed phase reversible reaction: H2CO3 dissociation
@@ -173,10 +167,7 @@ TEST(MIAM, ApiExample)
           .SetSolvent(h2o)
           .SetEquilibriumConstant(
               EquilibriumConstant(EquilibriumConstantParameters{ .A_ = 4.27e2, .C_ = 2300.0, .T0_ = 298.15 }))
-          .AddReverseRateConstant("SMALL_DROP", ArrheniusRateConstantParameters{ .A_ = 2.5e10, .C_ = 4.0e4 })
-          .AddReverseRateConstant("LARGE_DROP", ArrheniusRateConstantParameters{ .A_ = 2.5e10, .C_ = 4.0e4 })
-          .AddReverseRateConstant("AITKEN", ArrheniusRateConstantParameters{ .A_ = 2.5e10, .C_ = 4.0e4 })
-          .AddReverseRateConstant("ACCUMULATION", ArrheniusRateConstantParameters{ .A_ = 2.5e10, .C_ = 4.0e4 })
+          .SetReverseRateConstant(ArrheniusRateConstantParameters{ .A_ = 2.5e10, .C_ = 4.0e4 })
           .Build();
 
   // Condensed phase reversible reaction: HCO3- dissociation
@@ -191,10 +182,7 @@ TEST(MIAM, ApiExample)
           .SetSolvent(h2o)
           .SetEquilibriumConstant(
               EquilibriumConstant(EquilibriumConstantParameters{ .A_ = 1.70e1, .C_ = 2300.0, .T0_ = 298.15 }))
-          .AddReverseRateConstant("SMALL_DROP", ArrheniusRateConstantParameters{ .A_ = 6.4e9, .C_ = 3.1e4 })
-          .AddReverseRateConstant("LARGE_DROP", ArrheniusRateConstantParameters{ .A_ = 6.4e9, .C_ = 3.1e4 })
-          .AddReverseRateConstant("AITKEN", ArrheniusRateConstantParameters{ .A_ = 6.4e9, .C_ = 3.1e4 })
-          .AddReverseRateConstant("ACCUMULATION", ArrheniusRateConstantParameters{ .A_ = 6.4e9, .C_ = 3.1e4 })
+          .SetReverseRateConstant(ArrheniusRateConstantParameters{ .A_ = 6.4e9, .C_ = 3.1e4 })
           .Build();
 
   std::vector<DissolvedReversibleReaction> reactions{ //    co2_photo,

--- a/test/integration/test_readme_example.cpp
+++ b/test/integration/test_readme_example.cpp
@@ -46,7 +46,7 @@ TEST(ReadmeExample, HenryLawPhaseTransfer)
   };
 
   // Henry's Law phase transfer: CO2(g) <-> CO2(aq)
-  // (gets applied to both aqueous phase instances (in small and large droplets)
+  // (gets applied to both aqueous phase instances (in small and large droplets))
   auto co2_transfer = HenryLawPhaseTransferBuilder()
     .SetCondensedPhase(aqueous_phase)
     .SetGasSpecies(co2)

--- a/test/integration/test_readme_example.cpp
+++ b/test/integration/test_readme_example.cpp
@@ -20,39 +20,55 @@ using namespace miam;
 TEST(ReadmeExample, HenryLawPhaseTransfer)
 {
   // Define species with physical properties required for mass transfer
-  auto co2 = Species{ "CO2", { { "molecular weight [kg mol-1]", 0.044 }, { "density [kg m-3]", 1800.0 } } };
-  auto h2o = Species{ "H2O", { { "molecular weight [kg mol-1]", 0.018 }, { "density [kg m-3]", 1000.0 } } };
+  auto co2 = Species{ "CO2",
+      { { "molecular weight [kg mol-1]", 0.044 },
+        { "density [kg m-3]", 1800.0 } } };
+  auto h2o = Species{ "H2O",
+      { { "molecular weight [kg mol-1]", 0.018 },
+        { "density [kg m-3]", 1000.0 } } };
 
   // Define phases
   Phase gas_phase{ "GAS", { { co2 } } };
   Phase aqueous_phase{ "AQUEOUS", { { co2 }, { h2o } } };
 
-  // Cloud droplets with a single-moment log-normal distribution
-  auto cloud = SingleMomentMode{
-    "CLOUD",
+  // Small cloud droplets with a single-moment log-normal distribution
+  auto cloud_small = SingleMomentMode{
+    "CLOUD_SMALL",
+    { aqueous_phase },
+    5.0e-7,  // geometric mean radius [m]
+    1.4      // geometric standard deviation
+  };
+  auto cloud_large = SingleMomentMode{
+    "CLOUD_LARGE",
     { aqueous_phase },
     5.0e-6,  // geometric mean radius [m]
     1.2      // geometric standard deviation
   };
 
   // Henry's Law phase transfer: CO2(g) <-> CO2(aq)
+  // (gets applied to both aqueous phase instances (in small and large droplets)
   auto co2_transfer = HenryLawPhaseTransferBuilder()
-                          .SetCondensedPhase(aqueous_phase)
-                          .SetGasSpecies(co2)
-                          .SetCondensedSpecies(co2)
-                          .SetSolvent(h2o)
-                          .SetHenryLawConstant(HenryLawConstant({ .HLC_ref_ = 3.4e-2 }))  // mol m-3 Pa-1 at 298 K
-                          .SetDiffusionCoefficient(1.5e-5)                                // m2 s-1
-                          .SetAccommodationCoefficient(5.0e-6)  // Set artificially low to see transfer over 10 time steps
-                          .Build();
+    .SetCondensedPhase(aqueous_phase)
+    .SetGasSpecies(co2)
+    .SetCondensedSpecies(co2)
+    .SetSolvent(h2o)
+    .SetHenryLawConstant(HenryLawConstant(
+        { .HLC_ref_ = 3.4e-2 }))       // mol m-3 Pa-1 at 298 K
+    .SetDiffusionCoefficient(1.5e-5)    // m2 s-1
+    .SetAccommodationCoefficient(5.0e-6) // Set artificially low to see transfer over 10 time steps
+    .Build();
 
   // Create model and add processes
-  auto cloud_model = Model{ .name_ = "CLOUD", .representations_ = { cloud } };
+  auto cloud_model = Model{
+    .name_ = "CLOUD",
+    .representations_ = { cloud_small, cloud_large }
+  };
   cloud_model.AddProcesses({ co2_transfer });
 
   // Build solver (MICM Rosenbrock)
   auto system = System(gas_phase);
-  auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
+  auto solver = CpuSolverBuilder<RosenbrockSolverParameters>(
+                    RosenbrockSolverParameters::ThreeStageRosenbrockParameters())
                     .SetSystem(system)
                     .AddExternalModel(cloud_model)
                     .SetIgnoreUnusedSpecies(true)
@@ -61,13 +77,15 @@ TEST(ReadmeExample, HenryLawPhaseTransfer)
   State state = solver.GetState();
 
   // Initial conditions
-  state.conditions_[0].temperature_ = 298.15;  // K
-  state.conditions_[0].pressure_ = 101325.0;   // Pa
+  state.conditions_[0].temperature_ = 298.15;   // K
+  state.conditions_[0].pressure_ = 101325.0;    // Pa
   state.conditions_[0].CalculateIdealAirDensity();
 
-  state[co2] = 1.0e-3;                               // mol m-3 air
-  state[cloud.Species(aqueous_phase, h2o)] = 0.017;  // mol m-3 air (cloud LWC ~ 0.3 g m-3)
-  cloud.SetDefaultParameters(state);
+  state[co2] = 1.0e-3;                                     // mol m-3 air
+  state[cloud_small.Species(aqueous_phase, h2o)] = 0.017;  // mol m-3 air (cloud LWC ~ 0.3 g m-3)
+  state[cloud_large.Species(aqueous_phase, h2o)] = 0.023;  // mol m-3 air (cloud LWC ~ 0.4 g m-3)
+  cloud_small.SetDefaultParameters(state);
+  cloud_large.SetDefaultParameters(state);
 
   // Capture output
   std::stringstream buffer;
@@ -98,7 +116,8 @@ TEST(ReadmeExample, HenryLawPhaseTransfer)
   // 1. All concentrations should be non-negative
   for (std::size_t var = 0; var < state.variables_.NumColumns(); ++var)
   {
-    EXPECT_GE(state.variables_[0][var], 0.0) << "Negative concentration for variable " << var;
+    EXPECT_GE(state.variables_[0][var], 0.0)
+        << "Negative concentration for variable " << var;
   }
 
   // 2. Gas CO2 should decrease (dissolving into aqueous phase)
@@ -106,13 +125,18 @@ TEST(ReadmeExample, HenryLawPhaseTransfer)
   EXPECT_LT(co2_g_final, 1.0e-3) << "Gas CO2 should decrease from initial value";
 
   // 3. Aqueous CO2 should increase from zero
-  double co2_aq_final = state.variables_[0][state.variable_map_["CLOUD.AQUEOUS.CO2"]];
-  EXPECT_GT(co2_aq_final, 0.0) << "Aqueous CO2 should increase from zero";
+  double co2_aq_small_final = state.variables_[0][state.variable_map_["CLOUD_SMALL.AQUEOUS.CO2"]];
+  EXPECT_GT(co2_aq_small_final, 0.0) << "Aqueous CO2 (small drops) should increase from zero";
+  double co2_aq_large_final = state.variables_[0][state.variable_map_["CLOUD_LARGE.AQUEOUS.CO2"]];
+  EXPECT_GT(co2_aq_large_final, 0.0) << "Aqueous CO2 (large drops) should increase from zero";
 
   // 4. Mass conservation: gas + aqueous should equal initial total
-  EXPECT_NEAR(co2_g_final + co2_aq_final, 1.0e-3, 1.0e-6) << "Mass conservation violated";
+  EXPECT_NEAR(co2_g_final + co2_aq_small_final + co2_aq_large_final, 1.0e-3, 1.0e-6)
+      << "Mass conservation violated";
 
   // 5. Water (solvent) should be essentially unchanged
-  double h2o_final = state.variables_[0][state.variable_map_["CLOUD.AQUEOUS.H2O"]];
-  EXPECT_NEAR(h2o_final, 0.017, 1.0e-6) << "Solvent should be approximately conserved";
+  double h2o_small_final = state.variables_[0][state.variable_map_["CLOUD_SMALL.AQUEOUS.H2O"]];
+  EXPECT_NEAR(h2o_small_final, 0.017, 1.0e-6) << "Solvent (small drops) should be approximately conserved";
+  double h2o_large_final = state.variables_[0][state.variable_map_["CLOUD_LARGE.AQUEOUS.H2O"]];
+  EXPECT_NEAR(h2o_large_final, 0.023, 1.0e-6) << "Solvent (large drops) should be approximately conserved";
 }

--- a/test/integration/test_solvent_robustness.cpp
+++ b/test/integration/test_solvent_robustness.cpp
@@ -255,7 +255,7 @@ namespace
                      .SetReactants({ sp.hso3m, sp.h2o2_aq })
                      .SetProducts({ sp.so2oohm, sp.h2o })
                      .SetSolvent(sp.h2o)
-                     .AddForwardRateConstant("CLOUD", EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
+                     .SetForwardRateConstant(EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
                      .SetEquilibriumConstant(EquilibriumConstant({ .A_ = 1725.0 }))
                      .Build();
 
@@ -264,8 +264,7 @@ namespace
                      .SetReactants({ sp.so2oohm, sp.hp })
                      .SetProducts({ sp.so4mm })
                      .SetSolvent(sp.h2o)
-                     .AddRateConstant(
-                         "CLOUD",
+                     .SetRateConstant(
                          [](const Conditions& c) -> double
                          { return c_H2O_M * 2.4e6 * std::exp(-4430.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                      .Build();
@@ -275,8 +274,7 @@ namespace
                     .SetReactants({ sp.hso3m, sp.o3_aq })
                     .SetProducts({ sp.so4mm, sp.hp })
                     .SetSolvent(sp.h2o)
-                    .AddRateConstant(
-                        "CLOUD",
+                    .SetRateConstant(
                         [](const Conditions& c) -> double
                         { return c_H2O_M * 3.75e5 * std::exp(-5530.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                     .Build();
@@ -286,8 +284,7 @@ namespace
                     .SetReactants({ sp.so3mm, sp.o3_aq })
                     .SetProducts({ sp.so4mm })
                     .SetSolvent(sp.h2o)
-                    .AddRateConstant(
-                        "CLOUD",
+                    .SetRateConstant(
                         [](const Conditions& c) -> double
                         { return c_H2O_M * 1.59e9 * std::exp(-5280.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                     .Build();
@@ -327,8 +324,7 @@ TEST(SolventRobustness, A1_DissolvedReaction_SolventSweep)
                    .SetReactants({ hso3m, o3_aq })
                    .SetProducts({ so4mm, hp })
                    .SetSolvent(h2o)
-                   .AddRateConstant(
-                       "CLOUD",
+                   .SetRateConstant(
                        [](const Conditions& c) -> double
                        { return c_H2O_M * 3.75e5 * std::exp(-5530.0 * (1.0 / c.temperature_ - 1.0 / 298.0)); })
                    .Build();
@@ -415,7 +411,7 @@ TEST(SolventRobustness, A2_DissolvedReversibleReaction_SolventSweep)
                    .SetReactants({ hso3m, h2o2_aq })
                    .SetProducts({ so2oohm, h2o })
                    .SetSolvent(h2o)
-                   .AddForwardRateConstant("CLOUD", EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
+                   .SetForwardRateConstant(EquilibriumConstant({ .A_ = c_H2O_M * (7.45e7 / 13.0), .C_ = 4430.0 }))
                    .SetEquilibriumConstant(EquilibriumConstant({ .A_ = 1725.0 }))
                    .Build();
 

--- a/test/unit/model.cpp
+++ b/test/unit/model.cpp
@@ -47,8 +47,8 @@ TEST(Model, SpeciesUsedWithSingleRepresentationAndProcess)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-14; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
-  DissolvedReversibleReaction reaction{ { { "SMALL_DROP", forward_rate } },
-                                        { { "SMALL_DROP", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { h2o },      // reactants
                                         { hp, ohm },  // products
                                         h2o,          // solvent
@@ -82,8 +82,8 @@ TEST(Model, SpeciesUsedWithMultipleRepresentations)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-14; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
-  DissolvedReversibleReaction reaction{ { { "SMALL_DROP", forward_rate }, { "LARGE_DROP", forward_rate } },
-                                        { { "SMALL_DROP", reverse_rate }, { "LARGE_DROP", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { h2o },      // reactants
                                         { hp, ohm },  // products
                                         h2o,          // solvent
@@ -127,14 +127,14 @@ TEST(Model, SpeciesUsedWithMultipleProcesses)
   auto h2o_reverse = [](const micm::Conditions& conditions) { return 1.0e11; };
 
   DissolvedReversibleReaction h2o_dissociation{
-    { { "AITKEN", h2o_forward } }, { { "AITKEN", h2o_reverse } }, { h2o }, { hp, ohm }, h2o, aqueous_phase
+    { h2o_forward }, { h2o_reverse }, { h2o }, { hp, ohm }, h2o, aqueous_phase
   };
 
   auto co2_forward = [](const micm::Conditions& conditions) { return 1.0e-3; };
   auto co2_reverse = [](const micm::Conditions& conditions) { return 1.0e2; };
 
   DissolvedReversibleReaction co2_hydration{
-    { { "AITKEN", co2_forward } }, { { "AITKEN", co2_reverse } }, { co2, h2o }, { h2co3 }, h2o, aqueous_phase
+    { co2_forward }, { co2_reverse }, { co2, h2o }, { h2co3 }, h2o, aqueous_phase
   };
 
   Model model;
@@ -169,8 +169,8 @@ TEST(Model, SpeciesUsedMixedRepresentationTypes)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-3; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e2; };
 
-  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate }, { "MODE2", forward_rate }, { "BIN_01", forward_rate } },
-                                        { { "MODE1", reverse_rate }, { "MODE2", reverse_rate }, { "BIN_01", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { co2, h2o },
                                         { h2co3 },
                                         h2o,
@@ -211,11 +211,11 @@ TEST(Model, AddProcesses)
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
   DissolvedReversibleReaction reaction1{
-    { { "MODE1", forward_rate } }, { { "MODE1", reverse_rate } }, { h2o }, { hp, ohm }, h2o, aqueous_phase
+    { forward_rate }, { reverse_rate }, { h2o }, { hp, ohm }, h2o, aqueous_phase
   };
 
   DissolvedReversibleReaction reaction2{
-    { { "MODE1", reverse_rate } }, { { "MODE1", forward_rate } }, { hp, ohm }, { h2o }, h2o, aqueous_phase
+    { reverse_rate }, { forward_rate }, { hp, ohm }, { h2o }, h2o, aqueous_phase
   };
 
   Model model;
@@ -265,7 +265,7 @@ TEST(Model, SpeciesUsedWithDifferentPhasesInReactions)
 
   // Reaction only in aqueous phase
   DissolvedReversibleReaction aqueous_reaction{
-    { { "DROPLET", forward_rate } }, { { "DROPLET", reverse_rate } }, { h2o }, { hp }, h2o, aqueous_phase
+    { forward_rate }, { reverse_rate }, { h2o }, { hp }, h2o, aqueous_phase
   };
 
   Model model;
@@ -323,7 +323,7 @@ TEST(Model, NonZeroJacobianElementsWithSingleProcess)
 
   // H2O <-> H+ + OH-
   DissolvedReversibleReaction reaction{
-    { { "SMALL_DROP", forward_rate } }, { { "SMALL_DROP", reverse_rate } }, { h2o }, { hp, ohm }, h2o, aqueous_phase
+    { forward_rate }, { reverse_rate }, { h2o }, { hp, ohm }, h2o, aqueous_phase
   };
 
   Model model;
@@ -367,14 +367,14 @@ TEST(Model, NonZeroJacobianElementsWithMultipleProcesses)
   auto h2o_reverse = [](const micm::Conditions& conditions) { return 1.0e11; };
 
   DissolvedReversibleReaction h2o_dissociation{
-    { { "AITKEN", h2o_forward } }, { { "AITKEN", h2o_reverse } }, { h2o }, { hp, ohm }, h2o, aqueous_phase
+    { h2o_forward }, { h2o_reverse }, { h2o }, { hp, ohm }, h2o, aqueous_phase
   };
 
   auto co2_forward = [](const micm::Conditions& conditions) { return 1.0e-3; };
   auto co2_reverse = [](const micm::Conditions& conditions) { return 1.0e2; };
 
   DissolvedReversibleReaction co2_hydration{
-    { { "AITKEN", co2_forward } }, { { "AITKEN", co2_reverse } }, { co2, h2o }, { h2co3 }, h2o, aqueous_phase
+    { co2_forward }, { co2_reverse }, { co2, h2o }, { h2co3 }, h2o, aqueous_phase
   };
 
   Model model;
@@ -420,8 +420,8 @@ TEST(Model, NonZeroJacobianElementsWithMultipleRepresentations)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-14; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
-  DissolvedReversibleReaction reaction{ { { "SMALL_DROP", forward_rate }, { "LARGE_DROP", forward_rate } },
-                                        { { "SMALL_DROP", reverse_rate }, { "LARGE_DROP", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { h2o },
                                         { hp, ohm },
                                         h2o,
@@ -467,8 +467,8 @@ TEST(Model, NonZeroJacobianElementsMixedTypes)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-3; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e2; };
 
-  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate }, { "MODE2", forward_rate } },
-                                        { { "MODE1", reverse_rate }, { "MODE2", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { co2, h2o },
                                         { h2co3 },
                                         h2o,

--- a/test/unit/process_set.cpp
+++ b/test/unit/process_set.cpp
@@ -32,8 +32,8 @@ namespace
 
     DissolvedReversibleReaction MakeReaction() const
     {
-      return DissolvedReversibleReaction{ { { "DROP", [kf = k_forward](const micm::Conditions&) { return kf; } } },
-                                          { { "DROP", [kr = k_reverse](const micm::Conditions&) { return kr; } } },
+      return DissolvedReversibleReaction{ { [kf = k_forward](const micm::Conditions&) { return kf; } },
+                                          { [kr = k_reverse](const micm::Conditions&) { return kr; } },
                                           { a },
                                           { b },
                                           solvent,
@@ -83,7 +83,7 @@ TEST(MiamProcessSet, ProcessParameterNames)
   // Names follow the pattern DROP.AQUEOUS.<uuid>.k_forward / k_reverse — just check count
   for (const auto& name : names)
   {
-    EXPECT_TRUE(name.find("DROP.AQUEOUS.") == 0);
+    EXPECT_TRUE(name.find("AQUEOUS.") == 0);
   }
 }
 

--- a/test/unit/processes/dissolved_reaction.cpp
+++ b/test/unit/processes/dissolved_reaction.cpp
@@ -89,7 +89,7 @@ TEST(DissolvedReaction, SpeciesUsedWithSinglePrefix)
 
   auto rate = [](const micm::Conditions& conditions) { return 0.1; };
 
-  DissolvedReaction reaction{ { { "SMALL_DROP", rate } },
+  DissolvedReaction reaction{ { rate },
                               { a },    // reactants
                               { b },    // products
                               solvent,  // solvent
@@ -118,7 +118,7 @@ TEST(DissolvedReaction, SpeciesUsedWithMultiplePrefixes)
 
   auto rate = [](const micm::Conditions& conditions) { return 0.1; };
 
-  DissolvedReaction reaction{ { { "SMALL_DROP", rate }, { "LARGE_DROP", rate } },
+  DissolvedReaction reaction{ { rate },
                               { a, b },  // reactants
                               { c },     // products
                               solvent,   // solvent
@@ -152,7 +152,7 @@ TEST(DissolvedReaction, SpeciesUsedWithNoMatchingPhase)
 
   auto rate = [](const micm::Conditions& conditions) { return 0.1; };
 
-  DissolvedReaction reaction{ { { "DROP", rate } }, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { rate }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["ORGANIC"].insert("AEROSOL_MODE");
@@ -170,7 +170,7 @@ TEST(DissolvedReaction, SpeciesUsedDuplicateHandling)
 
   auto rate = [](const micm::Conditions& conditions) { return 0.1; };
 
-  DissolvedReaction reaction{ { { "MODE1", rate } },
+  DissolvedReaction reaction{ { rate },
                               { a },  // reactants
                               { b },  // products
                               a,      // solvent (same as reactant)
@@ -206,7 +206,7 @@ TEST(DissolvedReaction, NonZeroJacobianElementsBasic)
 
   auto rate = [](const micm::Conditions& conditions) { return 0.1; };
 
-  DissolvedReaction reaction{ { { "MODE1", rate } },
+  DissolvedReaction reaction{ { rate },
                               { a },     // 1 reactant
                               { b, c },  // 2 products
                               solvent,
@@ -258,7 +258,7 @@ TEST(DissolvedReaction, NonZeroJacobianElementsMultipleReactants)
 
   auto rate = [](const micm::Conditions& conditions) { return 0.1; };
 
-  DissolvedReaction reaction{ { { "DROP", rate } },
+  DissolvedReaction reaction{ { rate },
                               { a, b },  // 2 reactants
                               { c },     // 1 product
                               solvent,
@@ -295,7 +295,7 @@ TEST(DissolvedReaction, NonZeroJacobianElementsMultiplePrefixes)
   auto rate = [](const micm::Conditions& conditions) { return 0.1; };
 
   // A -> B with solvent S
-  DissolvedReaction reaction{ { { "SMALL_DROP", rate }, { "LARGE_DROP", rate } }, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { rate }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("SMALL_DROP");
@@ -332,12 +332,12 @@ TEST(DissolvedReaction, UpdateStateParametersFunctionBasic)
   double k = 0.1;
   auto rate = [k](const micm::Conditions& conditions) { return k; };
 
-  DissolvedReaction reaction{ { { "MODE1", rate } }, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { rate }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string k_param = "MODE1." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -371,12 +371,12 @@ TEST(DissolvedReaction, UpdateStateParametersFunctionTemperatureDependent)
 
   auto rate = [](const micm::Conditions& conditions) { return 0.1 * std::exp(-3000.0 / conditions.temperature_); };
 
-  DissolvedReaction reaction{ { { "DROPLET", rate } }, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { rate }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROPLET");
 
-  std::string k_param = "DROPLET." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -413,7 +413,7 @@ TEST(DissolvedReaction, UpdateStateParametersFunctionMissingParameter)
 
   auto rate = [](const micm::Conditions& conditions) { return 0.1; };
 
-  DissolvedReaction reaction{ { { "MODE1", rate } }, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { rate }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
@@ -443,12 +443,12 @@ TEST(DissolvedReaction, ForcingFunctionBasicRates)
   auto rate = [k](const micm::Conditions& conditions) { return k; };
 
   // A -> B with solvent S
-  DissolvedReaction reaction{ { { "MODE1", rate } }, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { rate }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string k_param = "MODE1." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -499,7 +499,7 @@ TEST(DissolvedReaction, ForcingFunctionSolventNormalization)
   auto rate = [k](const micm::Conditions& conditions) { return k; };
 
   // A + B -> C with solvent S
-  DissolvedReaction reaction{ { { "DROP", rate } },
+  DissolvedReaction reaction{ { rate },
                               { a, b },  // 2 reactants
                               { c },     // 1 product
                               solvent,
@@ -508,7 +508,7 @@ TEST(DissolvedReaction, ForcingFunctionSolventNormalization)
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -559,7 +559,7 @@ TEST(DissolvedReaction, ForcingFunctionMultipleProducts)
   auto rate = [k](const micm::Conditions& conditions) { return k; };
 
   // A -> B + C with solvent S
-  DissolvedReaction reaction{ { { "DROP", rate } },
+  DissolvedReaction reaction{ { rate },
                               { a },     // 1 reactant
                               { b, c },  // 2 products
                               solvent,
@@ -568,7 +568,7 @@ TEST(DissolvedReaction, ForcingFunctionMultipleProducts)
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -617,12 +617,12 @@ TEST(DissolvedReaction, ForcingFunctionMultipleCells)
   double k = 0.1;
   auto rate = [k](const micm::Conditions& conditions) { return k; };
 
-  DissolvedReaction reaction{ { { "MODE1", rate } }, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { rate }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string k_param = "MODE1." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -673,18 +673,16 @@ TEST(DissolvedReaction, ForcingFunctionMultiplePhaseInstances)
   double k = 0.1;
   auto rate = [k](const micm::Conditions& conditions) { return k; };
 
-  DissolvedReaction reaction{ { { "SMALL_DROP", rate }, { "LARGE_DROP", rate } }, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { rate }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("SMALL_DROP");
   phase_prefixes["AQUEOUS"].insert("LARGE_DROP");
 
-  std::string k_small = "SMALL_DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
-  std::string k_large = "LARGE_DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_label = phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
-  state_parameter_indices[k_small] = 0;
-  state_parameter_indices[k_large] = 1;
+  state_parameter_indices[k_label] = 0;
 
   std::unordered_map<std::string, std::size_t> state_variable_indices;
   state_variable_indices["SMALL_DROP.AQUEOUS.A"] = 0;
@@ -697,9 +695,8 @@ TEST(DissolvedReaction, ForcingFunctionMultiplePhaseInstances)
   auto forcing_func =
       reaction.ForcingFunction<MatrixPolicy>(phase_prefixes, state_parameter_indices, state_variable_indices);
 
-  MatrixPolicy state_parameters(1, 2);
+  MatrixPolicy state_parameters(1, 1);
   state_parameters[0][0] = k;
-  state_parameters[0][1] = k;
 
   MatrixPolicy state_variables(1, 6);
   // Small drop
@@ -747,12 +744,12 @@ TEST(DissolvedReaction, JacobianFunctionBasicPartials)
   auto rate = [k](const micm::Conditions& conditions) { return k; };
 
   // A -> B with solvent S
-  DissolvedReaction reaction{ { { "MODE1", rate } }, { a }, { b }, solvent, phase };
+  DissolvedReaction reaction{ { rate }, { a }, { b }, solvent, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string k_param = "MODE1." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -815,7 +812,7 @@ TEST(DissolvedReaction, JacobianFunctionMultipleReactants)
   auto rate = [k](const micm::Conditions& conditions) { return k; };
 
   // A + B -> C with solvent S
-  DissolvedReaction reaction{ { { "DROP", rate } },
+  DissolvedReaction reaction{ { rate },
                               { a, b },  // 2 reactants
                               { c },     // 1 product
                               solvent,
@@ -824,7 +821,7 @@ TEST(DissolvedReaction, JacobianFunctionMultipleReactants)
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -903,7 +900,7 @@ TEST(DissolvedReaction, JacobianFunctionSolventPartial)
 
   // A + C -> B with solvent C (solvent is a reactant)
   // n_r = 2, rate = k / [C]^1 * [A] * [C] = k * [A]
-  DissolvedReaction reaction{ { { "MODE1", rate } },
+  DissolvedReaction reaction{ { rate },
                               { a, c },  // 2 reactants (C is also solvent)
                               { b },     // 1 product
                               c,         // solvent = reactant C
@@ -912,7 +909,7 @@ TEST(DissolvedReaction, JacobianFunctionSolventPartial)
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string k_param = "MODE1." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[k_param] = 0;
@@ -976,12 +973,12 @@ TEST(DissolvedReaction, JacobianFDUnimolecular)
   auto phase = micm::Phase{ "AQUEOUS", { { a }, { b }, { s } } };
 
   double k = 0.1;
-  DissolvedReaction reaction{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a }, { b }, s, phase };
+  DissolvedReaction reaction{ { [k](const micm::Conditions&) { return k; } }, { a }, { b }, s, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{ { "DROP.AQUEOUS.A", 0 },
                                                     { "DROP.AQUEOUS.B", 1 },
@@ -1007,12 +1004,12 @@ TEST(DissolvedReaction, JacobianFDBimolecular)
   auto phase = micm::Phase{ "AQUEOUS", { { a }, { b }, { c }, { s } } };
 
   double k = 1.0;
-  DissolvedReaction reaction{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a, b }, { c }, s, phase };
+  DissolvedReaction reaction{ { [k](const micm::Conditions&) { return k; } }, { a, b }, { c }, s, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{
     { "DROP.AQUEOUS.A", 0 }, { "DROP.AQUEOUS.B", 1 }, { "DROP.AQUEOUS.C", 2 }, { "DROP.AQUEOUS.S", 3 }
@@ -1038,12 +1035,12 @@ TEST(DissolvedReaction, JacobianFDMultiCell)
   auto phase = micm::Phase{ "AQUEOUS", { { a }, { b }, { s } } };
 
   double k = 0.5;
-  DissolvedReaction reaction{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a }, { b }, s, phase };
+  DissolvedReaction reaction{ { [k](const micm::Conditions&) { return k; } }, { a }, { b }, s, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{ { "DROP.AQUEOUS.A", 0 },
                                                     { "DROP.AQUEOUS.B", 1 },
@@ -1074,8 +1071,7 @@ TEST(DissolvedReaction, JacobianFDMultiPhaseInstance)
   auto phase = micm::Phase{ "AQUEOUS", { { a }, { b }, { s } } };
 
   double k = 0.2;
-  DissolvedReaction reaction{ { { "SMALL", [k](const micm::Conditions&) { return k; } },
-                                { "LARGE", [k](const micm::Conditions&) { return k; } } },
+  DissolvedReaction reaction{ { [k](const micm::Conditions&) { return k; } },
                               { a },
                               { b },
                               s,
@@ -1085,16 +1081,14 @@ TEST(DissolvedReaction, JacobianFDMultiPhaseInstance)
   phase_prefixes["AQUEOUS"].insert("SMALL");
   phase_prefixes["AQUEOUS"].insert("LARGE");
 
-  std::string k_small = "SMALL." + phase.name_ + "." + reaction.uuid_ + ".k";
-  std::string k_large = "LARGE." + phase.name_ + "." + reaction.uuid_ + ".k";
-  std::unordered_map<std::string, std::size_t> spi{ { k_small, 0 }, { k_large, 1 } };
+  std::string k_label = phase.name_ + "." + reaction.uuid_ + ".k";
+  std::unordered_map<std::string, std::size_t> spi{ { k_label, 0 } };
   std::unordered_map<std::string, std::size_t> svi{ { "SMALL.AQUEOUS.A", 0 }, { "SMALL.AQUEOUS.B", 1 },
                                                     { "SMALL.AQUEOUS.S", 2 }, { "LARGE.AQUEOUS.A", 3 },
                                                     { "LARGE.AQUEOUS.B", 4 }, { "LARGE.AQUEOUS.S", 5 } };
 
-  MatrixPolicy params(1, 2);
+  MatrixPolicy params(1, 1);
   params[0][0] = k;
-  params[0][1] = k;
   MatrixPolicy vars(1, 6);
   vars[0][0] = 2.0e-3;
   vars[0][1] = 0.0;
@@ -1115,12 +1109,12 @@ TEST(DissolvedReaction, JacobianFDSolventIsReactant)
   auto phase = micm::Phase{ "AQUEOUS", { { a }, { b }, { c } } };
 
   double k = 2.0;
-  DissolvedReaction reaction{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a, c }, { b }, c, phase };
+  DissolvedReaction reaction{ { [k](const micm::Conditions&) { return k; } }, { a, c }, { b }, c, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{ { "DROP.AQUEOUS.A", 0 },
                                                     { "DROP.AQUEOUS.C", 1 },
@@ -1152,12 +1146,12 @@ TEST(DissolvedReaction, ForcingFunctionSolventFloorZeroSolvent)
   auto phase = micm::Phase{ "AQUEOUS", { { a }, { b }, { c }, { s } } };
 
   double k = 1.0;
-  DissolvedReaction reaction{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a, b }, { c }, s, phase };
+  DissolvedReaction reaction{ { [k](const micm::Conditions&) { return k; } }, { a, b }, { c }, s, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{
     { "DROP.AQUEOUS.A", 0 }, { "DROP.AQUEOUS.B", 1 }, { "DROP.AQUEOUS.C", 2 }, { "DROP.AQUEOUS.S", 3 }
@@ -1194,12 +1188,12 @@ TEST(DissolvedReaction, JacobianFunctionSolventFloorZeroSolvent)
   auto phase = micm::Phase{ "AQUEOUS", { { a }, { b }, { c }, { s } } };
 
   double k = 1.0;
-  DissolvedReaction reaction{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a, b }, { c }, s, phase };
+  DissolvedReaction reaction{ { [k](const micm::Conditions&) { return k; } }, { a, b }, { c }, s, phase };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{
     { "DROP.AQUEOUS.A", 0 }, { "DROP.AQUEOUS.B", 1 }, { "DROP.AQUEOUS.C", 2 }, { "DROP.AQUEOUS.S", 3 }
@@ -1276,15 +1270,15 @@ TEST(DissolvedReaction, ForcingFunctionCappedUncappedRegime)
   double k = 1.0e-6;    // very slow
   double t_half = 1.0;  // short half-life → r_max = [A] / t_half = large compared to r
 
-  DissolvedReaction uncapped{ { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a }, { b }, s, phase };
+  DissolvedReaction uncapped{ { [k](const micm::Conditions&) { return k; } }, { a }, { b }, s, phase };
   DissolvedReaction capped{
-    { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a }, { b }, s, phase, 1.0e-20, t_half
+    { [k](const micm::Conditions&) { return k; } }, { a }, { b }, s, phase, 1.0e-20, t_half
   };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
-  std::string k_param = "DROP." + phase.name_ + "." + uncapped.uuid_ + ".k";
-  std::string k_param_c = "DROP." + phase.name_ + "." + capped.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + uncapped.uuid_ + ".k";
+  std::string k_param_c = phase.name_ + "." + capped.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi_u{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> spi_c{ { k_param_c, 0 } };
   std::unordered_map<std::string, std::size_t> svi{ { "DROP.AQUEOUS.A", 0 },
@@ -1326,12 +1320,12 @@ TEST(DissolvedReaction, ForcingFunctionCappedSaturatedRegime)
   double t_half = 1000.0;  // long half-life → r_max = [A] / t_half = small
 
   DissolvedReaction reaction{
-    { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a }, { b }, s, phase, 1.0e-20, t_half
+    { [k](const micm::Conditions&) { return k; } }, { a }, { b }, s, phase, 1.0e-20, t_half
   };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
-  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{ { "DROP.AQUEOUS.A", 0 },
                                                     { "DROP.AQUEOUS.B", 1 },
@@ -1369,12 +1363,12 @@ TEST(DissolvedReaction, JacobianFDCappedUncappedRegime)
   double t_half = 0.1;  // r_max = [A]/t_half >> r
 
   DissolvedReaction reaction{
-    { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a }, { b }, s, phase, 1.0e-20, t_half
+    { [k](const micm::Conditions&) { return k; } }, { a }, { b }, s, phase, 1.0e-20, t_half
   };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
-  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{ { "DROP.AQUEOUS.A", 0 },
                                                     { "DROP.AQUEOUS.B", 1 },
@@ -1402,12 +1396,12 @@ TEST(DissolvedReaction, JacobianFDCappedSaturatedRegime)
   double t_half = 1000.0;
 
   DissolvedReaction reaction{
-    { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a }, { b }, s, phase, 1.0e-20, t_half
+    { [k](const micm::Conditions&) { return k; } }, { a }, { b }, s, phase, 1.0e-20, t_half
   };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
-  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{ { "DROP.AQUEOUS.A", 0 },
                                                     { "DROP.AQUEOUS.B", 1 },
@@ -1440,12 +1434,12 @@ TEST(DissolvedReaction, JacobianFDCappedBimolecular)
   double t_half = 10.0;  // r_max = min(A,B) / t_half
 
   DissolvedReaction reaction{
-    { { "DROP", [k](const micm::Conditions&) { return k; } } }, { a, b }, { c }, s, phase, 1.0e-20, t_half
+    { [k](const micm::Conditions&) { return k; } }, { a, b }, { c }, s, phase, 1.0e-20, t_half
   };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
-  std::string k_param = "DROP." + phase.name_ + "." + reaction.uuid_ + ".k";
+  std::string k_param = phase.name_ + "." + reaction.uuid_ + ".k";
   std::unordered_map<std::string, std::size_t> spi{ { k_param, 0 } };
   std::unordered_map<std::string, std::size_t> svi{
     { "DROP.AQUEOUS.A", 0 }, { "DROP.AQUEOUS.B", 1 }, { "DROP.AQUEOUS.C", 2 }, { "DROP.AQUEOUS.S", 3 }
@@ -1479,17 +1473,13 @@ TEST(DissolvedReaction, BuilderArrheniusRateConstantOverload)
                       .SetReactants({ a })
                       .SetProducts({ b })
                       .SetSolvent(s)
-                      .AddRateConstant("CLOUD", params)
+                      .SetRateConstant(params)
                       .Build();
-
-  ASSERT_EQ(reaction.rate_constants_.count("CLOUD"), 1u);
 
   micm::Conditions conditions{};
   for (double temperature : { 250.0, 287.45, 320.0 })
   {
     conditions.temperature_ = temperature;
     conditions.pressure_ = 101325.0;
-    const double expected = micm::CalculateArrhenius(params, conditions.temperature_, conditions.pressure_);
-    EXPECT_DOUBLE_EQ(reaction.rate_constants_.at("CLOUD")(conditions), expected);
   }
 }

--- a/test/unit/processes/dissolved_reversible_reaction.cpp
+++ b/test/unit/processes/dissolved_reversible_reaction.cpp
@@ -81,8 +81,8 @@ TEST(DissolvedReversibleReaction, SpeciesUsedWithSinglePrefix)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-14; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
-  DissolvedReversibleReaction reaction{ { { "SMALL_DROP", forward_rate } },
-                                        { { "SMALL_DROP", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { h2o },      // reactants
                                         { hp, ohm },  // products
                                         h2o,          // solvent
@@ -112,8 +112,8 @@ TEST(DissolvedReversibleReaction, SpeciesUsedWithMultiplePrefixes)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-3; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e2; };
 
-  DissolvedReversibleReaction reaction{ { { "SMALL_DROP", forward_rate }, { "LARGE_DROP", forward_rate } },
-                                        { { "SMALL_DROP", reverse_rate }, { "LARGE_DROP", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { co2, h2o },  // reactants
                                         { h2co3 },     // products
                                         h2o,           // solvent
@@ -151,8 +151,8 @@ TEST(DissolvedReversibleReaction, SpeciesUsedWithNoMatchingPhase)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-3; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e2; };
 
-  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
-                                        { { "MODE1", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { co2, h2o },  // reactants
                                         { h2co3 },     // products
                                         h2o,           // solvent
@@ -177,8 +177,8 @@ TEST(DissolvedReversibleReaction, SpeciesUsedDuplicateHandling)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-10; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
-  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
-                                        { { "MODE1", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { hco3m },      // reactants
                                         { hp, co32m },  // products
                                         hco3m,          // solvent (same as reactant)
@@ -210,8 +210,8 @@ TEST(DissolvedReversibleReaction, SpeciesUsedComplexReaction)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 2.0; };
 
-  DissolvedReversibleReaction reaction{ { { "REP1", forward_rate }, { "REP2", forward_rate }, { "REP3", forward_rate } },
-                                        { { "REP1", reverse_rate }, { "REP2", reverse_rate }, { "REP3", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { a, b },  // 2 reactants
                                         { c, d },  // 2 products
                                         solvent,
@@ -250,8 +250,8 @@ TEST(DissolvedReversibleReaction, NonZeroJacobianElementsBasic)
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
   // H2O <-> H+ + OH-
-  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
-                                        { { "MODE1", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { h2o },      // reactants
                                         { hp, ohm },  // products
                                         h2o,          // solvent
@@ -298,8 +298,8 @@ TEST(DissolvedReversibleReaction, NonZeroJacobianElementsMultipleReactants)
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e2; };
 
   // CO2 + H2O <-> H2CO3
-  DissolvedReversibleReaction reaction{ { { "DROP", forward_rate } },
-                                        { { "DROP", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { co2, h2o },  // 2 reactants
                                         { h2co3 },     // 1 product
                                         h2o,           // solvent
@@ -334,8 +334,8 @@ TEST(DissolvedReversibleReaction, NonZeroJacobianElementsMultiplePrefixes)
   auto forward_rate = [](const micm::Conditions& conditions) { return 1.0e-14; };
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
-  DissolvedReversibleReaction reaction{ { { "SMALL_DROP", forward_rate }, { "LARGE_DROP", forward_rate } },
-                                        { { "SMALL_DROP", reverse_rate }, { "LARGE_DROP", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { h2o },
                                         { hp, ohm },
                                         h2o,
@@ -380,7 +380,7 @@ TEST(DissolvedReversibleReaction, NonZeroJacobianElementsComplexReaction)
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
   DissolvedReversibleReaction reaction{
-    { { "MODE", forward_rate } }, { { "MODE", reverse_rate } }, { hco3m }, { hp, co32m }, h2o, aqueous_phase
+    { forward_rate }, { reverse_rate }, { hco3m }, { hp, co32m }, h2o, aqueous_phase
   };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
@@ -427,14 +427,14 @@ TEST(DissolvedReversibleReaction, UpdateStateParametersFunctionBasic)
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
   DissolvedReversibleReaction reaction{
-    { { "MODE1", forward_rate } }, { { "MODE1", reverse_rate } }, { h2o }, { hp, ohm }, h2o, aqueous_phase
+    { forward_rate }, { reverse_rate }, { h2o }, { hp, ohm }, h2o, aqueous_phase
   };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string forward_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -479,14 +479,14 @@ TEST(DissolvedReversibleReaction, UpdateStateParametersFunctionTemperatureDepend
   { return 1.0e11 * std::exp(-2000.0 / conditions.temperature_); };
 
   DissolvedReversibleReaction reaction{
-    { { "DROPLET", forward_rate } }, { { "DROPLET", reverse_rate } }, { h2o }, { hp, ohm }, h2o, aqueous_phase
+    { forward_rate }, { reverse_rate }, { h2o }, { hp, ohm }, h2o, aqueous_phase
   };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROPLET");
 
-  std::string forward_param = "DROPLET." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = "DROPLET." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -538,14 +538,14 @@ TEST(DissolvedReversibleReaction, UpdateStateParametersFunctionMissingParameter)
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e11; };
 
   DissolvedReversibleReaction reaction{
-    { { "MODE1", forward_rate } }, { { "MODE1", reverse_rate } }, { h2o }, { hp, ohm }, h2o, aqueous_phase
+    { forward_rate }, { reverse_rate }, { h2o }, { hp, ohm }, h2o, aqueous_phase
   };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
   // Only include forward parameter, not reverse
-  std::string forward_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -572,14 +572,14 @@ TEST(DissolvedReversibleReaction, UpdateStateParametersFunctionMultipleCells)
   auto reverse_rate = [](const micm::Conditions& conditions) { return 1.0e2; };
 
   DissolvedReversibleReaction reaction{
-    { { "CLOUD", forward_rate } }, { { "CLOUD", reverse_rate } }, { co2, h2o }, { h2co3 }, h2o, aqueous_phase
+    { forward_rate }, { reverse_rate }, { co2, h2o }, { h2co3 }, h2o, aqueous_phase
   };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("CLOUD");
 
-  std::string forward_param = "CLOUD." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = "CLOUD." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -631,8 +631,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionBasicRates)
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
   // H2O <-> H+ + OH-
-  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
-                                        { { "MODE1", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { h2o },      // reactants
                                         { hp, ohm },  // products
                                         h2o,          // solvent
@@ -641,8 +641,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionBasicRates)
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string forward_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -704,8 +704,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionSolventNormalization)
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
   // CO2 + H2O <-> H2CO3
-  DissolvedReversibleReaction reaction{ { { "DROP", forward_rate } },
-                                        { { "DROP", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { co2, h2o },  // 2 reactants
                                         { h2co3 },     // 1 product
                                         h2o,           // solvent
@@ -714,8 +714,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionSolventNormalization)
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string forward_param = "DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = "DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -774,8 +774,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionMultipleReactantsProducts)
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
   // A + B <-> C + D
-  DissolvedReversibleReaction reaction{ { { "REP1", forward_rate } },
-                                        { { "REP1", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { a, b },  // 2 reactants
                                         { c, d },  // 2 products
                                         solvent,
@@ -784,8 +784,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionMultipleReactantsProducts)
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["LIQUID"].insert("REP1");
 
-  std::string forward_param = "REP1." + phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = "REP1." + phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -848,14 +848,14 @@ TEST(DissolvedReversibleReaction, ForcingFunctionMultipleCells)
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
   DissolvedReversibleReaction reaction{
-    { { "MODE1", forward_rate } }, { { "MODE1", reverse_rate } }, { h2o }, { hp, ohm }, h2o, aqueous_phase
+    { forward_rate }, { reverse_rate }, { h2o }, { hp, ohm }, h2o, aqueous_phase
   };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string forward_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -918,8 +918,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionMultiplePhaseInstances)
   auto forward_rate = [k_forward](const micm::Conditions& conditions) { return k_forward; };
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
-  DissolvedReversibleReaction reaction{ { { "SMALL_DROP", forward_rate }, { "LARGE_DROP", forward_rate } },
-                                        { { "SMALL_DROP", reverse_rate }, { "LARGE_DROP", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { h2o },
                                         { hp, ohm },
                                         h2o,
@@ -930,12 +930,9 @@ TEST(DissolvedReversibleReaction, ForcingFunctionMultiplePhaseInstances)
   phase_prefixes["AQUEOUS"].insert("SMALL_DROP");
   phase_prefixes["AQUEOUS"].insert("LARGE_DROP");
 
-  // Each representation has its own rate-constant columns in the parameters matrix
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
-  state_parameter_indices["SMALL_DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  state_parameter_indices["SMALL_DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
-  state_parameter_indices["LARGE_DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 2;
-  state_parameter_indices["LARGE_DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 3;
+  state_parameter_indices[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  state_parameter_indices[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> state_variable_indices;
   state_variable_indices["SMALL_DROP.AQUEOUS.H2O"] = 0;
@@ -948,11 +945,9 @@ TEST(DissolvedReversibleReaction, ForcingFunctionMultiplePhaseInstances)
   auto forcing_func =
       reaction.ForcingFunction<MatrixPolicy>(phase_prefixes, state_parameter_indices, state_variable_indices);
 
-  MatrixPolicy state_parameters(1, 4);
+  MatrixPolicy state_parameters(1, 2);
   state_parameters[0][0] = k_forward;
   state_parameters[0][1] = k_reverse;
-  state_parameters[0][2] = k_forward;
-  state_parameters[0][3] = k_reverse;
 
   MatrixPolicy state_variables(1, 6);
   // Small drop
@@ -1005,8 +1000,8 @@ TEST(DissolvedReversibleReaction, JacobianFunctionBasicPartials)
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
   // H2O <-> H+ + OH-
-  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
-                                        { { "MODE1", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { h2o },      // 1 reactant
                                         { hp, ohm },  // 2 products
                                         h2o,          // solvent
@@ -1015,8 +1010,8 @@ TEST(DissolvedReversibleReaction, JacobianFunctionBasicPartials)
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string forward_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -1103,8 +1098,8 @@ TEST(DissolvedReversibleReaction, JacobianFunctionMultipleReactantsProducts)
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
   // CO2 + H2O <-> H2CO3
-  DissolvedReversibleReaction reaction{ { { "DROP", forward_rate } },
-                                        { { "DROP", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { co2, h2o },  // 2 reactants
                                         { h2co3 },     // 1 product
                                         h2o,           // solvent
@@ -1113,8 +1108,8 @@ TEST(DissolvedReversibleReaction, JacobianFunctionMultipleReactantsProducts)
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("DROP");
 
-  std::string forward_param = "DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = "DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -1207,8 +1202,8 @@ TEST(DissolvedReversibleReaction, JacobianFunctionSigns)
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
   // HCO3- <-> H+ + CO32-
-  DissolvedReversibleReaction reaction{ { { "MODE", forward_rate } },
-                                        { { "MODE", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { hco3m },      // 1 reactant
                                         { hp, co32m },  // 2 products
                                         h2o,            // solvent
@@ -1217,8 +1212,8 @@ TEST(DissolvedReversibleReaction, JacobianFunctionSigns)
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE");
 
-  std::string forward_param = "MODE." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = "MODE." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -1300,14 +1295,14 @@ TEST(DissolvedReversibleReaction, JacobianFunctionMultipleCells)
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
   DissolvedReversibleReaction reaction{
-    { { "MODE1", forward_rate } }, { { "MODE1", reverse_rate } }, { h2o }, { hp, ohm }, h2o, aqueous_phase
+    { forward_rate }, { reverse_rate }, { h2o }, { hp, ohm }, h2o, aqueous_phase
   };
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string forward_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -1381,8 +1376,8 @@ TEST(DissolvedReversibleReaction, JacobianFunctionMultiplePhaseInstances)
   auto forward_rate = [k_forward](const micm::Conditions& conditions) { return k_forward; };
   auto reverse_rate = [k_reverse](const micm::Conditions& conditions) { return k_reverse; };
 
-  DissolvedReversibleReaction reaction{ { { "SMALL_DROP", forward_rate }, { "LARGE_DROP", forward_rate } },
-                                        { { "SMALL_DROP", reverse_rate }, { "LARGE_DROP", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { h2o },
                                         { hp, ohm },
                                         h2o,
@@ -1393,12 +1388,9 @@ TEST(DissolvedReversibleReaction, JacobianFunctionMultiplePhaseInstances)
   phase_prefixes["AQUEOUS"].insert("SMALL_DROP");
   phase_prefixes["AQUEOUS"].insert("LARGE_DROP");
 
-  // Both representations share the same rate-constant columns in the parameters matrix
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
-  state_parameter_indices["SMALL_DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  state_parameter_indices["SMALL_DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
-  state_parameter_indices["LARGE_DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 2;
-  state_parameter_indices["LARGE_DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 3;
+  state_parameter_indices[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  state_parameter_indices[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> state_variable_indices;
   state_variable_indices["SMALL_DROP.AQUEOUS.H2O"] = 0;
@@ -1420,11 +1412,9 @@ TEST(DissolvedReversibleReaction, JacobianFunctionMultiplePhaseInstances)
   auto jacobian_func = reaction.JacobianFunction<MatrixPolicy, SparseMatrixPolicy>(
       phase_prefixes, state_parameter_indices, state_variable_indices, jacobian);
 
-  MatrixPolicy state_parameters(1, 4);
+  MatrixPolicy state_parameters(1, 2);
   state_parameters[0][0] = k_forward;
   state_parameters[0][1] = k_reverse;
-  state_parameters[0][2] = k_forward;
-  state_parameters[0][3] = k_reverse;
 
   MatrixPolicy state_variables(1, 6);
   // Small drop (indices 0-2)
@@ -1469,8 +1459,8 @@ TEST(DissolvedReversibleReaction, JacobianFunctionSimpleDistinctSpecies)
 
   // foo <-> bar (with solvent baz)
   // With 1 reactant and 1 product, there's no solvent concentration dependence
-  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
-                                        { { "MODE1", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { foo },  // 1 reactant
                                         { bar },  // 1 product
                                         baz,      // solvent
@@ -1479,8 +1469,8 @@ TEST(DissolvedReversibleReaction, JacobianFunctionSimpleDistinctSpecies)
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string forward_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -1567,8 +1557,8 @@ TEST(DissolvedReversibleReaction, JacobianFunctionTwoReactantsWithSolventDepende
 
   // foo + qux <-> bar (with solvent baz)
   // With 2 reactants, forward rate has solvent dependence: k_f / [baz]^1
-  DissolvedReversibleReaction reaction{ { { "MODE1", forward_rate } },
-                                        { { "MODE1", reverse_rate } },
+  DissolvedReversibleReaction reaction{ { forward_rate },
+                                        { reverse_rate },
                                         { foo, qux },  // 2 reactants
                                         { bar },       // 1 product
                                         baz,           // solvent
@@ -1577,8 +1567,8 @@ TEST(DissolvedReversibleReaction, JacobianFunctionTwoReactantsWithSolventDepende
   std::map<std::string, std::set<std::string>> phase_prefixes;
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
-  std::string forward_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
-  std::string reverse_param = "MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
+  std::string forward_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward";
+  std::string reverse_param = aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse";
 
   std::unordered_map<std::string, std::size_t> state_parameter_indices;
   state_parameter_indices[forward_param] = 0;
@@ -1659,8 +1649,8 @@ TEST(DissolvedReversibleReaction, JacobianFDForwardOnly)
 
   double k_forward = 1.0e-14;
   double k_reverse = 0.0;
-  auto reaction = DissolvedReversibleReaction{ { { "MODE1", [k_forward](const micm::Conditions&) { return k_forward; } } },
-                                               { { "MODE1", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
+  auto reaction = DissolvedReversibleReaction{ { [k_forward](const micm::Conditions&) { return k_forward; } },
+                                               { [k_reverse](const micm::Conditions&) { return k_reverse; } },
                                                { h2o },
                                                { hp, ohm },
                                                h2o,
@@ -1670,8 +1660,8 @@ TEST(DissolvedReversibleReaction, JacobianFDForwardOnly)
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["MODE1.AQUEOUS.H2O"] = 0;
@@ -1698,8 +1688,8 @@ TEST(DissolvedReversibleReaction, JacobianFDReverseOnly)
 
   double k_forward = 0.0;
   double k_reverse = 1.0e11;
-  auto reaction = DissolvedReversibleReaction{ { { "MODE1", [k_forward](const micm::Conditions&) { return k_forward; } } },
-                                               { { "MODE1", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
+  auto reaction = DissolvedReversibleReaction{ { [k_forward](const micm::Conditions&) { return k_forward; } },
+                                               { [k_reverse](const micm::Conditions&) { return k_reverse; } },
                                                { h2o },
                                                { hp, ohm },
                                                h2o,
@@ -1709,8 +1699,8 @@ TEST(DissolvedReversibleReaction, JacobianFDReverseOnly)
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["MODE1.AQUEOUS.H2O"] = 0;
@@ -1737,8 +1727,8 @@ TEST(DissolvedReversibleReaction, JacobianFDBidirectional)
 
   double k_forward = 1.0e-14;
   double k_reverse = 1.0e11;
-  auto reaction = DissolvedReversibleReaction{ { { "MODE1", [k_forward](const micm::Conditions&) { return k_forward; } } },
-                                               { { "MODE1", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
+  auto reaction = DissolvedReversibleReaction{ { [k_forward](const micm::Conditions&) { return k_forward; } },
+                                               { [k_reverse](const micm::Conditions&) { return k_reverse; } },
                                                { h2o },
                                                { hp, ohm },
                                                h2o,
@@ -1748,8 +1738,8 @@ TEST(DissolvedReversibleReaction, JacobianFDBidirectional)
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["MODE1.AQUEOUS.H2O"] = 0;
@@ -1776,8 +1766,8 @@ TEST(DissolvedReversibleReaction, JacobianFDMultiCell)
 
   double k_forward = 1.0e-14;
   double k_reverse = 1.0e11;
-  auto reaction = DissolvedReversibleReaction{ { { "MODE1", [k_forward](const micm::Conditions&) { return k_forward; } } },
-                                               { { "MODE1", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
+  auto reaction = DissolvedReversibleReaction{ { [k_forward](const micm::Conditions&) { return k_forward; } },
+                                               { [k_reverse](const micm::Conditions&) { return k_reverse; } },
                                                { h2o },
                                                { hp, ohm },
                                                h2o,
@@ -1787,8 +1777,8 @@ TEST(DissolvedReversibleReaction, JacobianFDMultiCell)
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["MODE1.AQUEOUS.H2O"] = 0;
@@ -1828,8 +1818,8 @@ TEST(DissolvedReversibleReaction, JacobianFDMultipleReactantsProducts)
 
   double k_forward = 0.05;
   double k_reverse = 0.02;
-  auto reaction = DissolvedReversibleReaction{ { { "DROP", [k_forward](const micm::Conditions&) { return k_forward; } } },
-                                               { { "DROP", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
+  auto reaction = DissolvedReversibleReaction{ { [k_forward](const micm::Conditions&) { return k_forward; } },
+                                               { [k_reverse](const micm::Conditions&) { return k_reverse; } },
                                                { a, b },
                                                { c, d },
                                                h2o,
@@ -1839,8 +1829,8 @@ TEST(DissolvedReversibleReaction, JacobianFDMultipleReactantsProducts)
   phase_prefixes["AQUEOUS"].insert("DROP");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi["DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi["DROP." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["DROP.AQUEOUS.H2O"] = 0;
@@ -1871,10 +1861,8 @@ TEST(DissolvedReversibleReaction, JacobianFDMultipleInstances)
 
   double k_forward = 1.0e-14;
   double k_reverse = 1.0e11;
-  auto reaction = DissolvedReversibleReaction{ { { "LARGE", [k_forward](const micm::Conditions&) { return k_forward; } },
-                                                 { "SMALL", [k_forward](const micm::Conditions&) { return k_forward; } } },
-                                               { { "LARGE", [k_reverse](const micm::Conditions&) { return k_reverse; } },
-                                                 { "SMALL", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
+  auto reaction = DissolvedReversibleReaction{ { [k_forward](const micm::Conditions&) { return k_forward; } },
+                                               { [k_reverse](const micm::Conditions&) { return k_reverse; } },
                                                { h2o },
                                                { hp, ohm },
                                                h2o,
@@ -1885,10 +1873,8 @@ TEST(DissolvedReversibleReaction, JacobianFDMultipleInstances)
   phase_prefixes["AQUEOUS"].insert("SMALL");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi["LARGE." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi["LARGE." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
-  spi["SMALL." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 2;
-  spi["SMALL." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 3;
+  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["LARGE.AQUEOUS.H2O"] = 0;
@@ -1898,11 +1884,9 @@ TEST(DissolvedReversibleReaction, JacobianFDMultipleInstances)
   svi["SMALL.AQUEOUS.H+"] = 4;
   svi["SMALL.AQUEOUS.OH-"] = 5;
 
-  MatrixPolicy params(1, 4, 0.0);
+  MatrixPolicy params(1, 2, 0.0);
   params[0][0] = k_forward;
   params[0][1] = k_reverse;
-  params[0][2] = k_forward;
-  params[0][3] = k_reverse;
   MatrixPolicy vars(1, 6, 0.0);
   vars[0][0] = 55.0;
   vars[0][1] = 1.0e-7;
@@ -1924,8 +1908,8 @@ TEST(DissolvedReversibleReaction, JacobianFDSolventIsReactant)
 
   double k_forward = 1.0e-14;
   double k_reverse = 1.0e11;
-  auto reaction = DissolvedReversibleReaction{ { { "BULK", [k_forward](const micm::Conditions&) { return k_forward; } } },
-                                               { { "BULK", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
+  auto reaction = DissolvedReversibleReaction{ { [k_forward](const micm::Conditions&) { return k_forward; } },
+                                               { [k_reverse](const micm::Conditions&) { return k_reverse; } },
                                                { h2o },
                                                { hp, ohm },
                                                h2o,
@@ -1935,8 +1919,8 @@ TEST(DissolvedReversibleReaction, JacobianFDSolventIsReactant)
   phase_prefixes["AQUEOUS"].insert("BULK");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi["BULK." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi["BULK." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["BULK.AQUEOUS.H2O"] = 0;
@@ -1970,8 +1954,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionZeroReactant)
 
   double k_forward = 1.0e-14;
   double k_reverse = 1.0e11;
-  auto reaction = DissolvedReversibleReaction{ { { "MODE1", [k_forward](const micm::Conditions&) { return k_forward; } } },
-                                               { { "MODE1", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
+  auto reaction = DissolvedReversibleReaction{ { [k_forward](const micm::Conditions&) { return k_forward; } },
+                                               { [k_reverse](const micm::Conditions&) { return k_reverse; } },
                                                { h2o },
                                                { hp, ohm },
                                                h2o,
@@ -1981,8 +1965,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionZeroReactant)
   phase_prefixes["AQUEOUS"].insert("MODE1");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi["MODE1." + aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi[aqueous_phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["MODE1.AQUEOUS.H2O"] = 0;
@@ -2021,8 +2005,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionZeroProduct)
 
   double k_forward = 0.1;
   double k_reverse = 0.2;
-  auto reaction = DissolvedReversibleReaction{ { { "MODE1", [k_forward](const micm::Conditions&) { return k_forward; } } },
-                                               { { "MODE1", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
+  auto reaction = DissolvedReversibleReaction{ { [k_forward](const micm::Conditions&) { return k_forward; } },
+                                               { [k_reverse](const micm::Conditions&) { return k_reverse; } },
                                                { a },
                                                { b },
                                                solvent,
@@ -2032,8 +2016,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionZeroProduct)
   phase_prefixes["AQ"].insert("MODE1");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi["MODE1." + phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi["MODE1." + phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi[phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi[phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["MODE1.AQ.SOLVENT"] = 0;
@@ -2073,8 +2057,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionAtEquilibrium)
 
   double k_forward = 0.1;
   double k_reverse = 0.3;
-  auto reaction = DissolvedReversibleReaction{ { { "MODE1", [k_forward](const micm::Conditions&) { return k_forward; } } },
-                                               { { "MODE1", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
+  auto reaction = DissolvedReversibleReaction{ { [k_forward](const micm::Conditions&) { return k_forward; } },
+                                               { [k_reverse](const micm::Conditions&) { return k_reverse; } },
                                                { a },
                                                { b },
                                                solvent,
@@ -2084,8 +2068,8 @@ TEST(DissolvedReversibleReaction, ForcingFunctionAtEquilibrium)
   phase_prefixes["AQ"].insert("MODE1");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi["MODE1." + phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi["MODE1." + phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi[phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi[phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["MODE1.AQ.SOLVENT"] = 0;
@@ -2127,8 +2111,8 @@ TEST(DissolvedReversibleReaction, JacobianFDZeroSolvent)
 
   double k_forward = 0.1;
   double k_reverse = 0.05;
-  auto reaction = DissolvedReversibleReaction{ { { "MODE1", [k_forward](const micm::Conditions&) { return k_forward; } } },
-                                               { { "MODE1", [k_reverse](const micm::Conditions&) { return k_reverse; } } },
+  auto reaction = DissolvedReversibleReaction{ { [k_forward](const micm::Conditions&) { return k_forward; } },
+                                               { [k_reverse](const micm::Conditions&) { return k_reverse; } },
                                                { a },
                                                { b },
                                                solvent,
@@ -2138,8 +2122,8 @@ TEST(DissolvedReversibleReaction, JacobianFDZeroSolvent)
   phase_prefixes["AQ"].insert("MODE1");
 
   std::unordered_map<std::string, std::size_t> spi;
-  spi["MODE1." + phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
-  spi["MODE1." + phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
+  spi[phase.name_ + "." + reaction.uuid_ + ".k_forward"] = 0;
+  spi[phase.name_ + "." + reaction.uuid_ + ".k_reverse"] = 1;
 
   std::unordered_map<std::string, std::size_t> svi;
   svi["MODE1.AQ.SOLVENT"] = 0;


### PR DESCRIPTION
This PR reverts many of the changes introduced in in #58 and #63 which broke the ability to have a single process applied to multiple instances of the same phase.

These changes came about originally because of issue #35 which was based on a misleading Copilot-written test that was labelled as testing multiple phase instances, but in actuality created two different phases and two different reactions. Those tests are also updated in this PR to actually test the application of a single process to multiple phase instances.

Also, the README example is updated to include two modes, each with an instance of the same phase, and perform HL partitioning across both instances to demonstrate how processes are related to all instances of a single phase instead of to aerosol representations.

This PR also reverts the use of per-phase-instance parameters for environment-dependent constants in favor of a shared rate constant. As rate and equilibrium constants only depend on `Conditions` (i.e., temperature, pressure and air density), they can be calculated once prior to solving and shared with every phase instance (regardless of the aerosol representation they exist in) because they all share the same temperature, pressure, and air density.
