### PR TITLE
Updates for new MICM API

### DIFF
--- a/.github/design/henrys_law_phase_transfer.md
+++ b/.github/design/henrys_law_phase_transfer.md
@@ -551,6 +551,8 @@ struct MiamProcessSet
 {
   using PhaseMap = std::map<std::string, std::set<std::string>>;
   using IndexMap = std::unordered_map<std::string, std::size_t>;
+  template<class U>
+  using Vector = typename DenseMatrixPolicy::template VectorType<U>;
   using ProviderMap = std::map<std::string,
       std::vector<AerosolPropertyProvider<DenseMatrixPolicy>>>;
 
@@ -564,7 +566,7 @@ struct MiamProcessSet
       const PhaseMap&, const IndexMap&, const ProviderMap&)>
       non_zero_jacobian_elements_;
   std::function<std::function<void(
-      const std::vector<micm::Conditions>&, DenseMatrixPolicy&)>(
+      const Vector<micm::Conditions>&, DenseMatrixPolicy&)>(
       const PhaseMap&, const IndexMap&)>
       update_state_parameters_function_;
   std::function<std::function<void(
@@ -1323,7 +1325,7 @@ auto UpdateStateParametersFunction(
     }
 
     DenseMatrixPolicy dummy{ 1, state_parameter_indices.size(), 0.0 };
-    std::vector<micm::Conditions> dummy_conditions;
+    typename DenseMatrixPolicy::template VectorType<micm::Conditions> dummy_conditions;
 
     return DenseMatrixPolicy::Function(
         [this, hlc_indices, temp_indices](auto&& conditions, auto&& params)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -33,7 +33,7 @@ endif()
 
 FetchContent_Declare(micm
     GIT_REPOSITORY https://github.com/NCAR/micm.git
-    GIT_TAG b4ad795c7f9b3bb1f1e4f3e5023df3c8066db439
+    GIT_TAG f94aeddd622bba69cffe955449c0c60c2691ba7c
     GIT_PROGRESS NOT ${FETCHCONTENT_QUIET}
     FIND_PACKAGE_ARGS NAMES micm
 )

--- a/docs/source/developer_guide/adding_a_process.rst
+++ b/docs/source/developer_guide/adding_a_process.rst
@@ -72,7 +72,7 @@ Required Methods
    .. code-block:: c++
 
       template<typename DenseMatrixPolicy>
-      std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)>
+      std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)>
       UpdateStateParametersFunction(
           const std::map<std::string, std::set<std::string>>& phase_prefixes,
           const std::unordered_map<std::string, std::size_t>& param_indices) const;

--- a/include/miam/constraints/dissolved_equilibrium_constraint.hpp
+++ b/include/miam/constraints/dissolved_equilibrium_constraint.hpp
@@ -184,7 +184,7 @@ namespace miam
 
     /// @brief Returns a function that writes \f$ K_{eq}(T) \f$ per grid cell into the state parameter matrix.
     template<typename DenseMatrixPolicy>
-    std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)> UpdateConstraintParametersFunction(
+    std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)> UpdateConstraintParametersFunction(
         const std::map<std::string, std::set<std::string>>& phase_prefixes,
         const std::unordered_map<std::string, std::size_t>& state_parameter_indices) const
     {
@@ -198,7 +198,7 @@ namespace miam
       auto eq_const_fn = equilibrium_constant_;
 
       DenseMatrixPolicy state_parameters{ 1, state_parameter_indices.size(), 0.0 };
-      std::vector<micm::Conditions> conditions_vector;
+      typename DenseMatrixPolicy::template VectorType<micm::Conditions> conditions_vector;
 
       return DenseMatrixPolicy::Function(
           [k_eq_indices, eq_const_fn](auto&& conditions, auto&& params)

--- a/include/miam/constraints/henrys_law_equilibrium_constraint.hpp
+++ b/include/miam/constraints/henrys_law_equilibrium_constraint.hpp
@@ -170,7 +170,7 @@ namespace miam
     /// @brief Returns a function that writes \f$ \text{HLC}(T) \cdot R \cdot T \f$ per grid cell
     ///        into the state parameter matrix.
     template<typename DenseMatrixPolicy>
-    std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)> UpdateConstraintParametersFunction(
+    std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)> UpdateConstraintParametersFunction(
         const std::map<std::string, std::set<std::string>>& phase_prefixes,
         const std::unordered_map<std::string, std::size_t>& state_parameter_indices) const
     {
@@ -185,7 +185,7 @@ namespace miam
       auto hlc_fn = henrys_law_constant_;
 
       DenseMatrixPolicy state_parameters{ 1, state_parameter_indices.size(), 0.0 };
-      std::vector<micm::Conditions> conditions_vector;
+      typename DenseMatrixPolicy::template VectorType<micm::Conditions> conditions_vector;
 
       return DenseMatrixPolicy::Function(
           [hlc_rt_indices, hlc_fn](auto&& conditions, auto&& params)

--- a/include/miam/constraints/linear_constraint.hpp
+++ b/include/miam/constraints/linear_constraint.hpp
@@ -192,11 +192,11 @@ namespace miam
 
     /// @brief Returns a no-op constraint parameter update function (linear constraints have no parameters)
     template<typename DenseMatrixPolicy>
-    std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)> UpdateConstraintParametersFunction(
+    std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)> UpdateConstraintParametersFunction(
         const std::map<std::string, std::set<std::string>>& /*phase_prefixes*/,
         const std::unordered_map<std::string, std::size_t>& /*state_parameter_indices*/) const
     {
-      return [](const std::vector<micm::Conditions>&, DenseMatrixPolicy&) {};
+      return [](const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&) {};
     }
 
     /// @brief Returns state parameter names for constraints that update via conditions

--- a/include/miam/model/model.hpp
+++ b/include/miam/model/model.hpp
@@ -214,12 +214,12 @@ namespace miam
 
     /// @brief Returns a function that updates state parameters
     template<typename DenseMatrixPolicy>
-    std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)> UpdateStateParametersFunction(
+    std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)> UpdateStateParametersFunction(
         const std::unordered_map<std::string, std::size_t>& state_parameter_indices) const
     {
       // Collect parameter update functions from all processes and return a combined function
       auto phase_prefixes = CollectPhaseStatePrefixes();
-      std::vector<std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)>> update_functions;
+      std::vector<std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)>> update_functions;
       ForEachProcess(
           [&](const auto& process)
           {
@@ -227,7 +227,7 @@ namespace miam
                 process.template UpdateStateParametersFunction<DenseMatrixPolicy>(phase_prefixes, state_parameter_indices);
             update_functions.push_back(update_fn);
           });
-      return [update_functions](const std::vector<micm::Conditions>& conditions, DenseMatrixPolicy& state_parameters)
+      return [update_functions](const typename DenseMatrixPolicy::template VectorType<micm::Conditions>& conditions, DenseMatrixPolicy& state_parameters)
       {
         for (const auto& fn : update_functions)
         {
@@ -365,18 +365,18 @@ namespace miam
 
     /// @brief Returns a function that updates constraint parameters based on conditions
     template<typename DenseMatrixPolicy>
-    std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)> ConstraintUpdateStateParametersFunction(
+    std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)> ConstraintUpdateStateParametersFunction(
         const std::unordered_map<std::string, std::size_t>& state_parameter_indices) const
     {
       auto phase_prefixes = CollectPhaseStatePrefixes();
-      std::vector<std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)>> update_fns;
+      std::vector<std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)>> update_fns;
       ForEachConstraint(
           [&](const auto& c)
           {
             update_fns.push_back(
                 c.template UpdateConstraintParametersFunction<DenseMatrixPolicy>(phase_prefixes, state_parameter_indices));
           });
-      return [update_fns](const std::vector<micm::Conditions>& conditions, DenseMatrixPolicy& state_parameters) mutable
+      return [update_fns](const typename DenseMatrixPolicy::template VectorType<micm::Conditions>& conditions, DenseMatrixPolicy& state_parameters) mutable
       {
         for (auto& fn : update_fns)
           fn(conditions, state_parameters);

--- a/include/miam/processes/dissolved_reaction.hpp
+++ b/include/miam/processes/dissolved_reaction.hpp
@@ -230,11 +230,12 @@ namespace miam
     /// vector
     /// @return Function that updates state parameters for this process
     template<typename DenseMatrixPolicy>
-    std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)> UpdateStateParametersFunction(
+    std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)> UpdateStateParametersFunction(
         const std::map<std::string, std::set<std::string>>& phase_prefixes,
         const auto& state_parameter_indices  // acts like std::unordered_map<std::string, std::size_t>
     ) const
     {
+      using ConstVectorView = typename DenseMatrixPolicy::template VectorType<micm::Conditions>::ConstViewType;
       std::string k_param = phase_.name_ + "." + uuid_ + ".k";
       if (state_parameter_indices.find(k_param) == state_parameter_indices.end())
       {
@@ -248,7 +249,7 @@ namespace miam
 
       // Set up dummy arguments to build the function
       DenseMatrixPolicy state_parameters{ 1, state_parameter_indices.size(), 0.0 };
-      std::vector<micm::Conditions> conditions_vector;
+      typename DenseMatrixPolicy::template VectorType<micm::Conditions> conditions_vector;
 
       // return a function that updates the rate constant parameter based on the current conditions
       return DenseMatrixPolicy::Function(

--- a/include/miam/processes/dissolved_reversible_reaction.hpp
+++ b/include/miam/processes/dissolved_reversible_reaction.hpp
@@ -234,7 +234,7 @@ namespace miam
     /// vector
     /// @return Function that updates state parameters for this process
     template<typename DenseMatrixPolicy>
-    std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)> UpdateStateParametersFunction(
+    std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)> UpdateStateParametersFunction(
         const std::map<std::string, std::set<std::string>>& phase_prefixes,
         const auto& state_parameter_indices  // acts like std::unordered_map<std::string, std::size_t>
     ) const
@@ -263,7 +263,7 @@ namespace miam
 
       // Set up dummy arguments to build the function
       DenseMatrixPolicy state_parameters{ 1, state_parameter_indices.size(), 0.0 };
-      std::vector<micm::Conditions> conditions_vector;
+      typename DenseMatrixPolicy::template VectorType<micm::Conditions> conditions_vector;
 
       // return a function that updates the forward and reverse rate constant parameters based on the current conditions
       return DenseMatrixPolicy::Function(

--- a/include/miam/processes/henrys_law_phase_transfer.hpp
+++ b/include/miam/processes/henrys_law_phase_transfer.hpp
@@ -229,7 +229,7 @@ namespace miam
 
     /// @brief Returns a function that updates state parameters (HLC and temperature)
     template<typename DenseMatrixPolicy>
-    std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)> UpdateStateParametersFunction(
+    std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)> UpdateStateParametersFunction(
         const std::map<std::string, std::set<std::string>>& phase_prefixes,
         const auto& state_parameter_indices) const
     {
@@ -258,7 +258,7 @@ namespace miam
       }
 
       DenseMatrixPolicy dummy{ 1, state_parameter_indices.size(), 0.0 };
-      std::vector<micm::Conditions> dummy_conditions;
+      typename DenseMatrixPolicy::template VectorType<micm::Conditions> dummy_conditions;
 
       return DenseMatrixPolicy::Function(
           [this, hlc_indices, temp_indices](auto&& conditions, auto&& params)

--- a/include/miam/processes/process_set.hpp
+++ b/include/miam/processes/process_set.hpp
@@ -37,7 +37,7 @@ namespace miam
     std::function<std::set<std::pair<std::size_t, std::size_t>>(const PhaseMap&, const IndexMap&, const ProviderMap&)>
         non_zero_jacobian_elements_;
     std::function<
-        std::function<void(const std::vector<micm::Conditions>&, DenseMatrixPolicy&)>(const PhaseMap&, const IndexMap&)>
+        std::function<void(const typename DenseMatrixPolicy::template VectorType<micm::Conditions>&, DenseMatrixPolicy&)>(const PhaseMap&, const IndexMap&)>
         update_state_parameters_function_;
     std::function<std::function<void(const DenseMatrixPolicy&, const DenseMatrixPolicy&, DenseMatrixPolicy&)>(
         const PhaseMap&,

--- a/test/integration/test_cam_cloud_chemistry.cpp
+++ b/test/integration/test_cam_cloud_chemistry.cpp
@@ -35,6 +35,8 @@ using namespace miam;
 
 using DenseMatrix = micm::Matrix<double>;
 using SparseMatrixFD = micm::SparseMatrix<double, micm::SparseMatrixStandardOrdering>;
+template<class U>
+using Vector = typename DenseMatrix::template VectorType<U>;
 
 namespace
 {
@@ -134,7 +136,7 @@ namespace
       const IndexMaps& maps,
       const DenseMatrix& variables,
       const DenseMatrix& parameters,
-      const std::vector<Conditions>& conditions,
+      const Vector<Conditions>& conditions,
       double atol = 0,
       double rtol = 0)
   {
@@ -170,7 +172,7 @@ namespace
       const IndexMaps& maps,
       const DenseMatrix& variables,
       const DenseMatrix& parameters,
-      const std::vector<Conditions>& conditions,
+      const Vector<Conditions>& conditions,
       double atol = 0,
       double rtol = 0)
   {
@@ -640,7 +642,7 @@ TEST(CamCloudChemistry, Step2_HLC_Plus_Dissociation)
     variables[0][maps.variable_indices.at("CLOUD.AQUEOUS.OHm")] = oh_ic;
     variables[0][maps.variable_indices.at("CLOUD.AQUEOUS.H2O")] = C_H2O;
     DenseMatrix parameters(1, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-    std::vector<Conditions> conditions(1);
+    Vector<Conditions> conditions(1);
     conditions[0].temperature_ = T;
     conditions[0].pressure_ = 70000.0;
     std::cout << "Checking Step 2 constraint Jacobian..." << std::endl;
@@ -1958,7 +1960,7 @@ TEST(CamCloudChemistry, Step5_JacobianVerification)
   set_var(1, "CLOUD.AQUEOUS.SO2OOHm", 5.0e-7);
 
   DenseMatrix parameters(2, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-  std::vector<Conditions> conditions(2);
+  Vector<Conditions> conditions(2);
   conditions[0].temperature_ = T;
   conditions[0].pressure_ = 70000.0;
   conditions[1].temperature_ = 290.0;

--- a/test/integration/test_jacobian_verification.cpp
+++ b/test/integration/test_jacobian_verification.cpp
@@ -21,6 +21,8 @@ using namespace miam;
 
 using DenseMatrix = micm::Matrix<double>;
 using SparseMatrixFD = micm::SparseMatrix<double, micm::SparseMatrixStandardOrdering>;
+template<class U>
+using Vector = typename DenseMatrix::template VectorType<U>;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Helper: build state index maps from a Model, allocating variable and parameter
@@ -71,7 +73,7 @@ namespace
       const IndexMaps& maps,
       const DenseMatrix& variables,
       const DenseMatrix& parameters,
-      const std::vector<micm::Conditions>& conditions,
+      const Vector<micm::Conditions>& conditions,
       double atol = 0,
       double rtol = 0)
   {
@@ -125,7 +127,7 @@ namespace
       const IndexMaps& maps,
       const DenseMatrix& variables,
       const DenseMatrix& parameters,
-      const std::vector<micm::Conditions>& conditions,
+      const Vector<micm::Conditions>& conditions,
       double atol = 0,
       double rtol = 0)
   {
@@ -215,7 +217,7 @@ TEST(JacobianVerification, DissolvedReactionProcess)
   variables[1][maps.variable_indices.at("DROPLET.AQUEOUS.C")] = 2.0e-4;
 
   DenseMatrix parameters(2, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-  std::vector<Conditions> conditions(2);
+  Vector<Conditions> conditions(2);
   conditions[0].temperature_ = 298.15;
   conditions[0].pressure_ = 101325.0;
   conditions[1].temperature_ = 310.0;
@@ -253,7 +255,7 @@ TEST(JacobianVerification, DissolvedReversibleReactionProcess)
   variables[1][maps.variable_indices.at("DROPLET.AQUEOUS.C")] = 3.0e-4;
 
   DenseMatrix parameters(2, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-  std::vector<Conditions> conditions(2);
+  Vector<Conditions> conditions(2);
   conditions[0].temperature_ = 298.15;
   conditions[0].pressure_ = 101325.0;
   conditions[1].temperature_ = 280.0;
@@ -307,7 +309,7 @@ TEST(JacobianVerification, HenrysLawPhaseTransferProcess)
   variables[1][maps.variable_indices.at("DROPLET.AQUEOUS.H2O")] = 0.017;  // mol/m³ air
 
   DenseMatrix parameters(2, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-  std::vector<Conditions> conditions(2);
+  Vector<Conditions> conditions(2);
   conditions[0].temperature_ = 298.15;
   conditions[0].pressure_ = 101325.0;
   conditions[1].temperature_ = 280.0;
@@ -365,7 +367,7 @@ TEST(JacobianVerification, HenrysLawPhaseTransferTwoMomentMode)
   }
 
   DenseMatrix parameters(1, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-  std::vector<Conditions> conditions(1);
+  Vector<Conditions> conditions(1);
   conditions[0].temperature_ = 298.15;
   conditions[0].pressure_ = 101325.0;
 
@@ -416,7 +418,7 @@ TEST(JacobianVerification, MultipleProcessesCombined)
   variables[1][maps.variable_indices.at("DROPLET.AQUEOUS.S")] = 2.0e-4;
 
   DenseMatrix parameters(2, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-  std::vector<Conditions> conditions(2);
+  Vector<Conditions> conditions(2);
   conditions[0].temperature_ = 298.15;
   conditions[0].pressure_ = 101325.0;
   conditions[1].temperature_ = 273.15;
@@ -466,7 +468,7 @@ TEST(JacobianVerification, DissolvedEquilibriumConstraint)
   variables[1][maps.variable_indices.at("DROPLET.AQUEOUS.S")] = 2.0e-4;
 
   DenseMatrix parameters(2, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-  std::vector<Conditions> conditions(2);
+  Vector<Conditions> conditions(2);
   conditions[0].temperature_ = 298.15;
   conditions[0].pressure_ = 101325.0;
   conditions[1].temperature_ = 310.0;
@@ -508,7 +510,7 @@ TEST(JacobianVerification, LinearConstraint)
   variables[1][maps.variable_indices.at("DROPLET.AQUEOUS.C")] = 0.2;
 
   DenseMatrix parameters(2, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-  std::vector<Conditions> conditions(2);
+  Vector<Conditions> conditions(2);
   conditions[0].temperature_ = 298.15;
   conditions[0].pressure_ = 101325.0;
   conditions[1].temperature_ = 298.15;
@@ -557,7 +559,7 @@ TEST(JacobianVerification, HenrysLawEquilibriumConstraint)
   variables[1][maps.variable_indices.at("DROPLET.AQUEOUS.H2O")] = 0.017;  // mol/m³ air
 
   DenseMatrix parameters(2, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-  std::vector<Conditions> conditions(2);
+  Vector<Conditions> conditions(2);
   conditions[0].temperature_ = 298.15;
   conditions[0].pressure_ = 101325.0;
   conditions[1].temperature_ = 280.0;
@@ -628,7 +630,7 @@ TEST(JacobianVerification, ProcessAndConstraintsCombined)
   variables[1][maps.variable_indices.at("DROPLET.AQUEOUS.S")] = 2.0e-4;
 
   DenseMatrix parameters(2, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-  std::vector<Conditions> conditions(2);
+  Vector<Conditions> conditions(2);
   conditions[0].temperature_ = 298.15;
   conditions[0].pressure_ = 101325.0;
   conditions[1].temperature_ = 310.0;
@@ -691,7 +693,7 @@ TEST(JacobianVerification, HenrysLawEquilibriumWithConservation)
   variables[1][maps.variable_indices.at("DROPLET.AQUEOUS.H2O")] = 0.017;  // mol/m³ air
 
   DenseMatrix parameters(2, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-  std::vector<Conditions> conditions(2);
+  Vector<Conditions> conditions(2);
   conditions[0].temperature_ = 298.15;
   conditions[0].pressure_ = 101325.0;
   conditions[1].temperature_ = 280.0;
@@ -740,7 +742,7 @@ TEST(JacobianVerification, DissolvedReactionDampingRange)
     variables[0][maps.variable_indices.at("DROPLET.AQUEOUS.C")] = sol;
 
     DenseMatrix parameters(1, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-    std::vector<Conditions> conditions(1);
+    Vector<Conditions> conditions(1);
     conditions[0].temperature_ = 298.15;
     conditions[0].pressure_ = 101325.0;
 
@@ -767,7 +769,7 @@ TEST(JacobianVerification, DissolvedReactionDampingRange)
     variables[0][maps.variable_indices.at("DROPLET.AQUEOUS.C")] = sol;
 
     DenseMatrix parameters(1, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-    std::vector<Conditions> conditions(1);
+    Vector<Conditions> conditions(1);
     conditions[0].temperature_ = 298.15;
     conditions[0].pressure_ = 101325.0;
 
@@ -817,7 +819,7 @@ TEST(JacobianVerification, DissolvedReversibleReactionDampingRange)
     variables[0][maps.variable_indices.at("DROPLET.AQUEOUS.C")] = sol;
 
     DenseMatrix parameters(1, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-    std::vector<Conditions> conditions(1);
+    Vector<Conditions> conditions(1);
     conditions[0].temperature_ = 298.15;
     conditions[0].pressure_ = 101325.0;
 
@@ -843,7 +845,7 @@ TEST(JacobianVerification, DissolvedReversibleReactionDampingRange)
     variables[0][maps.variable_indices.at("DROPLET.AQUEOUS.C")] = sol;
 
     DenseMatrix parameters(1, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-    std::vector<Conditions> conditions(1);
+    Vector<Conditions> conditions(1);
     conditions[0].temperature_ = 298.15;
     conditions[0].pressure_ = 101325.0;
 
@@ -900,7 +902,7 @@ TEST(JacobianVerification, DissolvedEquilibriumConstraintDampingRange)
     variables[0][maps.variable_indices.at("DROPLET.AQUEOUS.S")] = sol;
 
     DenseMatrix parameters(1, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-    std::vector<Conditions> conditions(1);
+    Vector<Conditions> conditions(1);
     conditions[0].temperature_ = 298.15;
     conditions[0].pressure_ = 101325.0;
 
@@ -928,7 +930,7 @@ TEST(JacobianVerification, DissolvedEquilibriumConstraintDampingRange)
     variables[0][maps.variable_indices.at("DROPLET.AQUEOUS.S")] = sol;
 
     DenseMatrix parameters(1, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-    std::vector<Conditions> conditions(1);
+    Vector<Conditions> conditions(1);
     conditions[0].temperature_ = 298.15;
     conditions[0].pressure_ = 101325.0;
 
@@ -1001,7 +1003,7 @@ TEST(JacobianVerification, CombinedProcessAndConstraintZeroSolvent)
   variables[0][maps.variable_indices.at("DROPLET.AQUEOUS.S")] = 0.0;
 
   DenseMatrix parameters(1, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-  std::vector<Conditions> conditions(1);
+  Vector<Conditions> conditions(1);
   conditions[0].temperature_ = 298.15;
   conditions[0].pressure_ = 101325.0;
 
@@ -1092,7 +1094,7 @@ TEST(JacobianVerification, DissolvedReactionCappedSingleReactant)
     variables[0][maps.variable_indices.at("DROPLET.AQUEOUS.C")] = 1.0;
 
     DenseMatrix parameters(1, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-    std::vector<Conditions> conditions(1);
+    Vector<Conditions> conditions(1);
     conditions[0].temperature_ = 298.15;
     conditions[0].pressure_ = 101325.0;
 
@@ -1143,7 +1145,7 @@ TEST(JacobianVerification, DissolvedReactionCappedTwoReactants)
     variables[0][maps.variable_indices.at("DROPLET.AQUEOUS.S")] = 1.0;
 
     DenseMatrix parameters(1, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-    std::vector<Conditions> conditions(1);
+    Vector<Conditions> conditions(1);
     conditions[0].temperature_ = 298.15;
     conditions[0].pressure_ = 101325.0;
 
@@ -1186,7 +1188,7 @@ TEST(JacobianVerification, DissolvedReactionCappedSolventRange)
     variables[0][maps.variable_indices.at("DROPLET.AQUEOUS.C")] = sol;
 
     DenseMatrix parameters(1, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-    std::vector<Conditions> conditions(1);
+    Vector<Conditions> conditions(1);
     conditions[0].temperature_ = 298.15;
     conditions[0].pressure_ = 101325.0;
 
@@ -1212,7 +1214,7 @@ TEST(JacobianVerification, DissolvedReactionCappedSolventRange)
     variables[0][maps.variable_indices.at("DROPLET.AQUEOUS.C")] = sol;
 
     DenseMatrix parameters(1, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-    std::vector<Conditions> conditions(1);
+    Vector<Conditions> conditions(1);
     conditions[0].temperature_ = 298.15;
     conditions[0].pressure_ = 101325.0;
 
@@ -1265,7 +1267,7 @@ TEST(JacobianVerification, DissolvedReactionCappedMultiBlock)
   variables[1][maps.variable_indices.at("DROPLET.AQUEOUS.C")] = 1.0;
 
   DenseMatrix parameters(2, std::max(maps.num_parameters, std::size_t(1)), 0.0);
-  std::vector<Conditions> conditions(2);
+  Vector<Conditions> conditions(2);
   conditions[0].temperature_ = 298.15;
   conditions[0].pressure_ = 101325.0;
   conditions[1].temperature_ = 298.15;
@@ -1345,7 +1347,7 @@ namespace
 
     DenseMatrix params_u(1, std::max(maps_u.num_parameters, std::size_t(1)), 0.0);
     DenseMatrix params_c(1, std::max(maps_c.num_parameters, std::size_t(1)), 0.0);
-    std::vector<Conditions> conditions(1);
+    Vector<Conditions> conditions(1);
     conditions[0].temperature_ = 298.15;
     conditions[0].pressure_ = 101325.0;
 

--- a/test/unit/constraints/dissolved_equilibrium_constraint.cpp
+++ b/test/unit/constraints/dissolved_equilibrium_constraint.cpp
@@ -26,9 +26,12 @@
 
 using namespace miam;
 
+using DMP = micm::Matrix<double>;
+template<class U>
+using Vector = typename DMP::template VectorType<U>;
+
 namespace
 {
-  using DMP = micm::Matrix<double>;
 
   auto h2o = micm::Species{ "H2O" };
   auto A = micm::Species{ "A" };
@@ -200,7 +203,7 @@ TEST(DissolvedEquilibriumConstraint, ResidualSimpleAB)
   using DMP = micm::Matrix<double>;
   auto pi = BuildParamIndices(constraint, phase_prefixes);
   DMP state_params{ 1, std::max(pi.size(), std::size_t{ 1 }), 0.0 };
-  std::vector<micm::Conditions> conditions(1);
+  Vector<micm::Conditions> conditions(1);
   auto update_fn = constraint.UpdateConstraintParametersFunction<DMP>(phase_prefixes, pi);
   update_fn(conditions, state_params);
 
@@ -247,7 +250,7 @@ TEST(DissolvedEquilibriumConstraint, ResidualMultiReactant)
   using DMP = micm::Matrix<double>;
   auto pi = BuildParamIndices(constraint, phase_prefixes);
   DMP state_params{ 1, std::max(pi.size(), std::size_t{ 1 }), 0.0 };
-  std::vector<micm::Conditions> conditions(1);
+  Vector<micm::Conditions> conditions(1);
   auto update_fn = constraint.UpdateConstraintParametersFunction<DMP>(phase_prefixes, pi);
   update_fn(conditions, state_params);
 
@@ -298,7 +301,7 @@ TEST(DissolvedEquilibriumConstraint, ResidualMultipleInstances)
   using DMP = micm::Matrix<double>;
   auto pi = BuildParamIndices(constraint, phase_prefixes);
   DMP state_params{ 1, std::max(pi.size(), std::size_t{ 1 }), 0.0 };
-  std::vector<micm::Conditions> conditions(1);
+  Vector<micm::Conditions> conditions(1);
   auto update_fn = constraint.UpdateConstraintParametersFunction<DMP>(phase_prefixes, pi);
   update_fn(conditions, state_params);
 
@@ -347,7 +350,7 @@ TEST(DissolvedEquilibriumConstraint, ResidualMultipleCells)
   using DMP = micm::Matrix<double>;
   auto pi = BuildParamIndices(constraint, phase_prefixes);
   DMP state_params{ 2, std::max(pi.size(), std::size_t{ 1 }), 0.0 };
-  std::vector<micm::Conditions> conditions(2);
+  Vector<micm::Conditions> conditions(2);
   auto update_fn = constraint.UpdateConstraintParametersFunction<DMP>(phase_prefixes, pi);
   update_fn(conditions, state_params);
 
@@ -399,7 +402,7 @@ TEST(DissolvedEquilibriumConstraint, JacobianSimpleAB)
   using SMP = micm::SparseMatrix<double, micm::SparseMatrixStandardOrderingCompressedSparseRow>;
   auto pi = BuildParamIndices(constraint, phase_prefixes);
   DMP state_params{ 1, std::max(pi.size(), std::size_t{ 1 }), 0.0 };
-  std::vector<micm::Conditions> conditions(1);
+  Vector<micm::Conditions> conditions(1);
   auto update_fn = constraint.UpdateConstraintParametersFunction<DMP>(phase_prefixes, pi);
   update_fn(conditions, state_params);
 
@@ -459,7 +462,7 @@ TEST(DissolvedEquilibriumConstraint, JacobianMultiReactant)
   using SMP = micm::SparseMatrix<double, micm::SparseMatrixStandardOrderingCompressedSparseRow>;
   auto pi = BuildParamIndices(constraint, phase_prefixes);
   DMP state_params{ 1, std::max(pi.size(), std::size_t{ 1 }), 0.0 };
-  std::vector<micm::Conditions> conditions(1);
+  Vector<micm::Conditions> conditions(1);
   auto update_fn = constraint.UpdateConstraintParametersFunction<DMP>(phase_prefixes, pi);
   update_fn(conditions, state_params);
 
@@ -520,7 +523,7 @@ TEST(DissolvedEquilibriumConstraint, UpdateConstraintParametersTemperatureDep)
   auto pi = BuildParamIndices(constraint, phase_prefixes);
   ASSERT_EQ(pi.size(), 1u);
 
-  std::vector<micm::Conditions> conditions(3);
+  Vector<micm::Conditions> conditions(3);
   conditions[0].temperature_ = 250.0;
   conditions[1].temperature_ = 300.0;
   conditions[2].temperature_ = 350.0;
@@ -611,7 +614,7 @@ namespace
       const std::unordered_map<std::string, std::size_t>& param_idx,
       std::size_t num_cells)
   {
-    std::vector<micm::Conditions> conditions(num_cells);
+    Vector<micm::Conditions> conditions(num_cells);
     DMP state_params{ num_cells, std::max(param_idx.size(), std::size_t{ 1 }), 0.0 };
     auto fn = constraint.UpdateConstraintParametersFunction<DMP>(phase_prefixes, param_idx);
     fn(conditions, state_params);
@@ -622,7 +625,7 @@ namespace
       const DissolvedEquilibriumConstraint& constraint,
       const std::map<std::string, std::set<std::string>>& phase_prefixes,
       const std::unordered_map<std::string, std::size_t>& param_idx,
-      const std::vector<micm::Conditions>& conditions)
+      const Vector<micm::Conditions>& conditions)
   {
     DMP state_params{ conditions.size(), std::max(param_idx.size(), std::size_t{ 1 }), 0.0 };
     auto fn = constraint.UpdateConstraintParametersFunction<DMP>(phase_prefixes, param_idx);
@@ -1140,7 +1143,7 @@ TEST(DissolvedEquilibriumConstraint, TemperatureDependentKeqFD)
   si["DROP.AQUEOUS.H2O"] = 2;
 
   std::size_t nc = 3;
-  std::vector<micm::Conditions> conditions(nc);
+  Vector<micm::Conditions> conditions(nc);
   conditions[0].temperature_ = 250.0;
   conditions[1].temperature_ = 300.0;
   conditions[2].temperature_ = 350.0;
@@ -1345,7 +1348,7 @@ TEST(DissolvedEquilibriumConstraint, KitchenSinkFD)
   si["M2.AQUEOUS.H2O"] = 9;
 
   std::size_t nc = 3;
-  std::vector<micm::Conditions> conditions(nc);
+  Vector<micm::Conditions> conditions(nc);
   conditions[0].temperature_ = 280.0;
   conditions[1].temperature_ = 300.0;
   conditions[2].temperature_ = 320.0;
@@ -1469,7 +1472,7 @@ namespace
     std::size_t keq_col = pi.begin()->second;
 
     // Update state parameters with distinct per-cell conditions
-    std::vector<micm::Conditions> conditions(num_cells);
+    typename VDM::template VectorType<micm::Conditions> conditions(num_cells);
     for (std::size_t c = 0; c < num_cells; ++c)
       conditions[c].temperature_ = 298.15 + static_cast<double>(c) * 10.0;
 
@@ -1535,11 +1538,11 @@ namespace
         {
           double fd = (rp[c][i] - rm[c][i]) / (2.0 * h);
           double analytical;
-          try
+          if (!jacobian.IsZero(i,j))
           {
             analytical = jacobian[c][i][j];
           }
-          catch (...)
+          else
           {
             if (std::abs(fd) > 1e-10)
               ADD_FAILURE() << "Missing Jacobian cell=" << c << " row=" << i << " col=" << j << " fd=" << fd;

--- a/test/unit/constraints/henrys_law_equilibrium_constraint.cpp
+++ b/test/unit/constraints/henrys_law_equilibrium_constraint.cpp
@@ -26,9 +26,11 @@
 
 using namespace miam;
 
+using DMP = micm::Matrix<double>;
+template<class U>
+using Vector = typename DMP::template VectorType<U>;
 namespace
 {
-  using DMP = micm::Matrix<double>;
 
   constexpr double water_molecular_weight = 0.018;
   constexpr double water_density = 1000.0;
@@ -202,7 +204,7 @@ TEST(HenrysLawEquilibriumConstraint, ResidualSingleInstance)
   using DMP = micm::Matrix<double>;
   auto pi = BuildParamIndices(constraint, phase_prefixes);
   DMP state_params{ 1, std::max(pi.size(), std::size_t{ 1 }), 0.0 };
-  std::vector<micm::Conditions> conditions(1);
+  Vector<micm::Conditions> conditions(1);
   conditions[0].temperature_ = T;
   auto update_fn = constraint.UpdateConstraintParametersFunction<DMP>(phase_prefixes, pi);
   update_fn(conditions, state_params);
@@ -256,7 +258,7 @@ TEST(HenrysLawEquilibriumConstraint, ResidualMultipleInstances)
   using DMP = micm::Matrix<double>;
   auto pi = BuildParamIndices(constraint, phase_prefixes);
   DMP state_params{ 1, std::max(pi.size(), std::size_t{ 1 }), 0.0 };
-  std::vector<micm::Conditions> conditions(1);
+  Vector<micm::Conditions> conditions(1);
   conditions[0].temperature_ = T;
   auto update_fn = constraint.UpdateConstraintParametersFunction<DMP>(phase_prefixes, pi);
   update_fn(conditions, state_params);
@@ -312,7 +314,7 @@ TEST(HenrysLawEquilibriumConstraint, JacobianSingleInstance)
   using SMP = micm::SparseMatrix<double, micm::SparseMatrixStandardOrderingCompressedSparseRow>;
   auto pi = BuildParamIndices(constraint, phase_prefixes);
   DMP state_params{ 1, std::max(pi.size(), std::size_t{ 1 }), 0.0 };
-  std::vector<micm::Conditions> conditions(1);
+  Vector<micm::Conditions> conditions(1);
   conditions[0].temperature_ = T;
   auto update_fn = constraint.UpdateConstraintParametersFunction<DMP>(phase_prefixes, pi);
   update_fn(conditions, state_params);
@@ -375,7 +377,7 @@ TEST(HenrysLawEquilibriumConstraint, UpdateConstraintParametersTemperatureDep)
   auto pi = BuildParamIndices(constraint, phase_prefixes);
   ASSERT_EQ(pi.size(), 1u);
 
-  std::vector<micm::Conditions> conditions(2);
+  Vector<micm::Conditions> conditions(2);
   conditions[0].temperature_ = 250.0;
   conditions[1].temperature_ = 350.0;
 
@@ -454,7 +456,7 @@ namespace
       std::size_t num_cells,
       double T = 298.15)
   {
-    std::vector<micm::Conditions> conditions(num_cells);
+    Vector<micm::Conditions> conditions(num_cells);
     for (auto& c : conditions)
       c.temperature_ = T;
     DMP state_params{ num_cells, std::max(param_idx.size(), std::size_t{ 1 }), 0.0 };
@@ -467,7 +469,7 @@ namespace
       const HenrysLawEquilibriumConstraint& constraint,
       const std::map<std::string, std::set<std::string>>& phase_prefixes,
       const std::unordered_map<std::string, std::size_t>& param_idx,
-      const std::vector<micm::Conditions>& conditions)
+      const Vector<micm::Conditions>& conditions)
   {
     DMP state_params{ conditions.size(), std::max(param_idx.size(), std::size_t{ 1 }), 0.0 };
     auto fn = constraint.UpdateConstraintParametersFunction<DMP>(phase_prefixes, param_idx);
@@ -867,7 +869,7 @@ TEST(HenrysLawEquilibriumConstraint, TemperatureDependentHlcMultiCell)
   si["DROP.AQUEOUS.H2O"] = 2;
 
   std::size_t nc = 3;
-  std::vector<micm::Conditions> conditions(nc);
+  Vector<micm::Conditions> conditions(nc);
   conditions[0].temperature_ = 270.0;
   conditions[1].temperature_ = 298.15;
   conditions[2].temperature_ = 320.0;
@@ -1007,12 +1009,6 @@ TEST(HenrysLawEquilibriumConstraint, JacobianMultipleInstancesAnalytical)
   EXPECT_NEAR(jacobian[0][3][0], -hlc_rt * fv_small, std::abs(hlc_rt * fv_small) * 1e-12);
   EXPECT_NEAR(jacobian[0][3][3], 1.0, 1e-12);
   EXPECT_NEAR(jacobian[0][3][4], -hlc_rt * Mw_rho * 1.0e-5, std::abs(hlc_rt * Mw_rho * 1e-5) * 1e-12);
-
-  // Cross-instance: LARGE row shouldn't have entries for SMALL columns and vice versa
-  EXPECT_THROW(jacobian[0][1][3], std::exception);
-  EXPECT_THROW(jacobian[0][1][4], std::exception);
-  EXPECT_THROW(jacobian[0][3][1], std::exception);
-  EXPECT_THROW(jacobian[0][3][2], std::exception);
 }
 
 // ── Large HLC ──
@@ -1177,7 +1173,7 @@ TEST(HenrysLawEquilibriumConstraint, KitchenSinkFD)
   si["M3.AQUEOUS.H2O"] = 6;
 
   std::size_t nc = 3;
-  std::vector<micm::Conditions> conditions(nc);
+  Vector<micm::Conditions> conditions(nc);
   conditions[0].temperature_ = 275.0;
   conditions[1].temperature_ = 298.15;
   conditions[2].temperature_ = 315.0;
@@ -1253,7 +1249,7 @@ namespace
     std::size_t hlc_rt_col = pi.begin()->second;
 
     // Build conditions with per-cell temperatures
-    std::vector<micm::Conditions> conditions(num_cells);
+    typename VDM::template VectorType<micm::Conditions> conditions(num_cells);
     for (std::size_t c = 0; c < num_cells; ++c)
       conditions[c].temperature_ = T_base + (varying_temperature ? static_cast<double>(c) * 10.0 : 0.0);
 
@@ -1327,11 +1323,11 @@ namespace
         {
           double fd = (rp[c][i] - rm[c][i]) / (2.0 * h);
           double analytical;
-          try
+          if (!jacobian.IsZero(i,j))
           {
             analytical = jacobian[c][i][j];
           }
-          catch (...)
+          else
           {
             if (std::abs(fd) > 1e-10)
               ADD_FAILURE() << "Missing Jacobian cell=" << c << " row=" << i << " col=" << j << " fd=" << fd;

--- a/test/unit/constraints/linear_constraint.cpp
+++ b/test/unit/constraints/linear_constraint.cpp
@@ -23,9 +23,11 @@
 
 using namespace miam;
 
+using DMP = micm::Matrix<double>;
+template<class U>
+using Vector = typename DMP::template VectorType<U>;
 namespace
 {
-  using DMP = micm::Matrix<double>;
   std::unordered_map<std::string, std::size_t> param_indices;
   const DMP no_params{};
 
@@ -317,7 +319,7 @@ TEST(LinearConstraint, UpdateConstraintParametersNoOp)
 
   std::map<std::string, std::set<std::string>> phase_prefixes;
   auto update_fn = constraint.UpdateConstraintParametersFunction<micm::Matrix<double>>(phase_prefixes, param_indices);
-  std::vector<micm::Conditions> conditions(3);
+  Vector<micm::Conditions> conditions(3);
   micm::Matrix<double> state_params{ 3, 1, 0.0 };
   // Should not throw
   update_fn(conditions, state_params);
@@ -699,10 +701,6 @@ TEST(LinearConstraint, JacobianPerInstanceNonUnitCoefficients)
   EXPECT_NEAR(jacobian[0][3][4], 0.5, 1e-12);
   EXPECT_NEAR(jacobian[0][3][5], -3.0, 1e-12);
 
-  // Cross-instance entries should not exist
-  EXPECT_THROW(jacobian[0][0][3], std::exception);
-  EXPECT_THROW(jacobian[0][3][0], std::exception);
-
   // FD check
   CheckConstraintFDJacobian(constraint, phase_prefixes, si, state_variables);
 }
@@ -991,10 +989,6 @@ TEST(LinearConstraint, PerInstanceWithGasTerms)
   // SMALL row (2): dG/d[A_g] = 1, dG/d[SMALL.A_aq] = 1
   EXPECT_NEAR(jacobian[0][2][0], -1.0, 1e-12);
   EXPECT_NEAR(jacobian[0][2][2], -1.0, 1e-12);
-
-  // Cross-instance isolation: LARGE doesn't depend on SMALL
-  EXPECT_THROW(jacobian[0][1][2], std::exception);
-  EXPECT_THROW(jacobian[0][2][1], std::exception);
 
   // FD check multi-cell
   std::size_t nc = 3;

--- a/test/unit/process_set.cpp
+++ b/test/unit/process_set.cpp
@@ -17,6 +17,8 @@ using namespace miam;
 using MatrixPolicy = micm::Matrix<double>;
 using SparseMatrixPolicy = micm::SparseMatrix<double, micm::SparseMatrixStandardOrderingCompressedSparseRow>;
 using ProcessSet = MiamProcessSet<MatrixPolicy, SparseMatrixPolicy>;
+template<class U>
+using Vector = typename MatrixPolicy::template VectorType<U>;
 
 namespace
 {
@@ -156,7 +158,7 @@ TEST(MiamProcessSet, UpdateStateParametersFunction)
 
   // 2 grid cells, 2 parameters
   MatrixPolicy state_parameters(2, param_names.size(), 0.0);
-  std::vector<micm::Conditions> conditions(2);
+  Vector<micm::Conditions> conditions(2);
   conditions[0].temperature_ = 298.15;
   conditions[1].temperature_ = 310.0;
 
@@ -201,7 +203,7 @@ TEST(MiamProcessSet, ForcingFunction)
 
   // Fill parameters using the same wrapped process
   auto update_fn = ps.update_state_parameters_function_(phase_prefixes, param_indices);
-  std::vector<micm::Conditions> conditions(1);
+  Vector<micm::Conditions> conditions(1);
   conditions[0].temperature_ = 298.15;
   update_fn(conditions, state_parameters);
 
@@ -263,7 +265,7 @@ TEST(MiamProcessSet, JacobianFunction)
 
   // Fill parameters using the same wrapped process
   auto update_fn = ps.update_state_parameters_function_(phase_prefixes, param_indices);
-  std::vector<micm::Conditions> conditions(1);
+  Vector<micm::Conditions> conditions(1);
   conditions[0].temperature_ = 298.15;
   update_fn(conditions, state_parameters);
 

--- a/test/unit/processes/dissolved_reaction.cpp
+++ b/test/unit/processes/dissolved_reaction.cpp
@@ -21,10 +21,12 @@
 
 using namespace miam;
 
+using MatrixPolicy = micm::Matrix<double>;
+using SparseMatrixPolicy = micm::SparseMatrix<double, micm::SparseMatrixStandardOrderingCompressedSparseRow>;
+template<class U>
+using Vector = typename MatrixPolicy::template VectorType<U>;
 namespace
 {
-  using MatrixPolicy = micm::Matrix<double>;
-  using SparseMatrixPolicy = micm::SparseMatrix<double, micm::SparseMatrixStandardOrderingCompressedSparseRow>;
 
   /// @brief Compare analytical Jacobian against central finite-difference approximation
   ///        using MICM's FiniteDifferenceJacobian / CompareJacobianToFiniteDifference utilities.
@@ -346,7 +348,7 @@ TEST(DissolvedReaction, UpdateStateParametersFunctionBasic)
 
   MatrixPolicy state_parameters(3, 1, 0.0);
 
-  std::vector<micm::Conditions> conditions(3);
+  typename MatrixPolicy::template VectorType<micm::Conditions> conditions(3);
   conditions[0].temperature_ = 298.15;
   conditions[1].temperature_ = 310.0;
   conditions[2].temperature_ = 285.0;
@@ -385,7 +387,7 @@ TEST(DissolvedReaction, UpdateStateParametersFunctionTemperatureDependent)
 
   MatrixPolicy state_parameters(3, 1, 0.0);
 
-  std::vector<micm::Conditions> conditions(3);
+  typename MatrixPolicy::template VectorType<micm::Conditions> conditions(3);
   conditions[0].temperature_ = 298.15;
   conditions[1].temperature_ = 310.0;
   conditions[2].temperature_ = 273.15;
@@ -1225,7 +1227,7 @@ TEST(DissolvedReaction, JacobianFunctionSolventFloorZeroSolvent)
   for (std::size_t i = 0; i < 4; ++i)
     for (std::size_t j = 0; j < 4; ++j)
     {
-      try
+      if (!jacobian.IsZero(i, j))
       {
         double val = jacobian[0][i][j];
         EXPECT_FALSE(std::isnan(val)) << "NaN at [" << i << "," << j << "]";
@@ -1242,9 +1244,6 @@ TEST(DissolvedReaction, JacobianFunctionSolventFloorZeroSolvent)
           EXPECT_NEAR(val, 0.0, 1e-5) << "Expected near-zero reactant/product-column Jacobian when [S]=0 at [" << i << ","
                                       << j << "]";
         }
-      }
-      catch (...)
-      { /* sparse zero — expected */
       }
     }
 }

--- a/test/unit/processes/dissolved_reversible_reaction.cpp
+++ b/test/unit/processes/dissolved_reversible_reaction.cpp
@@ -16,10 +16,12 @@
 
 using namespace miam;
 
+using MatrixPolicy = micm::Matrix<double>;
+using SparseMatrixPolicy = micm::SparseMatrix<double, micm::SparseMatrixStandardOrderingCompressedSparseRow>;
+template<class U>
+using Vector = typename MatrixPolicy::template VectorType<U>;
 namespace
 {
-  using MatrixPolicy = micm::Matrix<double>;
-  using SparseMatrixPolicy = micm::SparseMatrix<double, micm::SparseMatrixStandardOrderingCompressedSparseRow>;
 
   /// @brief Compare analytical Jacobian against central finite-difference approximation
   ///        using MICM’s FiniteDifferenceJacobian / CompareJacobianToFiniteDifference utilities.
@@ -435,7 +437,7 @@ TEST(DissolvedReversibleReaction, UpdateStateParametersFunctionBasic)
   MatrixPolicy state_parameters(3, 2, 0.0);
 
   // Create conditions for 3 grid cells
-  std::vector<micm::Conditions> conditions(3);
+  typename MatrixPolicy::template VectorType<micm::Conditions> conditions(3);
   conditions[0].temperature_ = 298.15;
   conditions[1].temperature_ = 310.0;
   conditions[2].temperature_ = 285.0;
@@ -485,7 +487,7 @@ TEST(DissolvedReversibleReaction, UpdateStateParametersFunctionTemperatureDepend
   MatrixPolicy state_parameters(3, 2, 0.0);
 
   // Create conditions with different temperatures
-  std::vector<micm::Conditions> conditions(3);
+  typename MatrixPolicy::template VectorType<micm::Conditions> conditions(3);
   conditions[0].temperature_ = 298.15;
   conditions[1].temperature_ = 310.0;
   conditions[2].temperature_ = 273.15;
@@ -574,7 +576,7 @@ TEST(DissolvedReversibleReaction, UpdateStateParametersFunctionMultipleCells)
   MatrixPolicy state_parameters(5, 2, 0.0);
 
   // Create conditions with different pressures
-  std::vector<micm::Conditions> conditions(5);
+  typename MatrixPolicy::template VectorType<micm::Conditions> conditions(5);
   for (std::size_t i = 0; i < 5; ++i)
   {
     conditions[i].temperature_ = 298.15;

--- a/test/unit/processes/henrys_law_phase_transfer.cpp
+++ b/test/unit/processes/henrys_law_phase_transfer.cpp
@@ -20,6 +20,8 @@
 using namespace miam;
 using MatrixPolicy = micm::Matrix<double>;
 using SparseMatrixPolicy = micm::SparseMatrix<double, micm::SparseMatrixStandardOrderingCompressedSparseRow>;
+template<class U>
+using Vector = typename MatrixPolicy::template VectorType<U>;
 
 namespace
 {
@@ -304,7 +306,7 @@ TEST(HenrysLawPhaseTransfer, UpdateStateParametersFunction)
 
   MatrixPolicy state_parameters(1, 2, 0.0);
 
-  std::vector<micm::Conditions> conditions(1);
+  Vector<micm::Conditions> conditions(1);
   conditions[0].temperature_ = 298.15;
 
   update_func(conditions, state_parameters);
@@ -331,7 +333,7 @@ TEST(HenrysLawPhaseTransfer, UpdateStateParametersFunctionMultipleCells)
 
   MatrixPolicy state_parameters(3, 2, 0.0);
 
-  std::vector<micm::Conditions> conditions(3);
+  Vector<micm::Conditions> conditions(3);
   conditions[0].temperature_ = 280.0;
   conditions[1].temperature_ = 298.15;
   conditions[2].temperature_ = 310.0;
@@ -1093,22 +1095,15 @@ TEST(HenrysLawPhaseTransfer, JacobianMultiplePhaseInstances)
   // -J[MODE2.aq, gas] = -phi2*kc2
   EXPECT_NEAR(jacobian[0][3][0], -phi2 * kc2, std::abs(phi2 * kc2) * 1e-10);
 
-  // Cross-mode independence: MODE1 aq row should not depend on MODE2 aq variable
-  EXPECT_THROW(jacobian[0][1][3], std::exception);
-  EXPECT_THROW(jacobian[0][3][1], std::exception);
-
   // Mass conservation: sum of gas row and all aq rows for each column = 0
   for (std::size_t j = 0; j < 5; ++j)
   {
     double sum = 0.0;
     for (std::size_t i : { std::size_t(0), std::size_t(1), std::size_t(3) })
     {
-      try
+      if (!jacobian.IsZero(i,j))
       {
         sum += jacobian[0][i][j];
-      }
-      catch (...)
-      {
       }
     }
     EXPECT_NEAR(sum, 0.0, 1e-15) << "Mass conservation violated for column " << j;
@@ -1554,11 +1549,11 @@ TEST(HenrysLawPhaseTransfer, JacobianFDMultipleTransferProcesses)
     {
       double fd = (fp[0][i] - fm[0][i]) / (2.0 * h);
       double analytical;
-      try
+      if (!jacobian.IsZero(i,j))
       {
         analytical = jacobian[0][i][j];
       }
-      catch (...)
+      else
       {
         continue;
       }


### PR DESCRIPTION
This PR updates MIAM for the latest commit of MICM on main. The changes are just to ensure existing tests pass, but don't add tests using the new Kokkos matrix classes.

The changes were essentially to replace `std::vector<micm::Conditions>` with `micm::Paddedvector<micm::Conditions>` and to modify tests that were relying on exceptions to detect non-zero sparse matrix elements to use the `IsZero()` function instead (the exceptions were replaced with `assert` in MICM).